### PR TITLE
chore: set up Percy CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
     steps:
     - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
     - uses: ./.github/workflows/setup-workspace
+    - name: Cache Storybook Build
+      id: cache-storybook
+      uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+      with:
+        path: storybook-static
+        key: storybook-${{ github.sha }}
     - run: npm run build-storybook
     - name: Deploy to Netlify (preview)
       if: github.ref_name!='main'

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,0 +1,32 @@
+name:  Submit screenshots to Percy for visual regression testing.
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  percy-components:
+    name: Percy - Storybook Components
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - uses: ./.github/workflows/setup-workspace
+    - name: Use cached storybook build
+      id: cache-storybook
+      uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+      with:
+        path: storybook-static
+        key: storybook-${{ github.sha }}
+    - run: npm run storybook-build
+      if: steps.cache-storybook.outputs.cache-hit != 'true'
+    - uses: cypress-io/github-action@2113e5bc19c45979ba123df6e07256d2aaba9a33
+      with:
+        start: npx http-server ./storybook-static -p 3009
+        command-prefix: 'percy exec -- npx'
+        config-file: cypress.storybook.json
+        wait-on: http://localhost:3009
+      env: 
+        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_STORYBOOK }}


### PR DESCRIPTION
- Sets up Percy job to run on manual trigger
- adds cache action to 'storybook' job in ci.yml - this well save a cache so the percy job doesn't need to regenerate it