### PR TITLE
fix: Fix for squashed button text in BannerFeatured

### DIFF
--- a/src/lib-components/BannerFeatured.vue
+++ b/src/lib-components/BannerFeatured.vue
@@ -357,7 +357,6 @@ export default {
         padding-right: clamp(360px, 35%, 600px);
         max-width: $container-l-main + px;
 
-        display: flex;
         flex-direction: column;
         flex-wrap: nowrap;
         justify-content: flex-start;
@@ -431,9 +430,7 @@ export default {
         padding: 0 0 5px 5px;
     }
     .button {
-        width: 180px;
         height: 50px;
-        padding: 0px 0px;
         margin-top: 16px;
     }
 


### PR DESCRIPTION
Before:
<img width="953" alt="Screen Shot 2022-07-29 at 10 27 47 AM" src="https://user-images.githubusercontent.com/73365/181813840-59cc257b-1856-4b82-b9da-d542e3595ea3.png">

After:
<img width="897" alt="Screen Shot 2022-07-29 at 10 28 30 AM" src="https://user-images.githubusercontent.com/73365/181813896-55fb3f76-5a4e-4ffd-8fef-0e3ac8137ab0.png">

