### PR TITLE
fix: APPS-1758 lazy load components

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -31,6 +31,7 @@ const projectRoot = path.resolve(__dirname, "..")
 
 const baseConfig = {
     input: "src/entry.js",
+    inlineDynamicImports: true,
     plugins: {
         preVue: [
             alias({

--- a/src/lib-components/BannerFeatured.vue
+++ b/src/lib-components/BannerFeatured.vue
@@ -89,16 +89,11 @@
 <script>
 import format from "date-fns/format"
 
-// Components
+// SVGs
 import SvgMoleculeHalfFaceted from "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
 import SvgHatchRight from "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
 
-import SvgHeadingVector from "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"
-import SvgIconOnline from "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
-import SvgIconEmail from "ucla-library-design-tokens/assets/svgs/icon-email.svg"
-import SvgIconPhone from "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
-import SvgIconLocation from "ucla-library-design-tokens/assets/svgs/icon-location.svg"
-import SvgIconPerson from "ucla-library-design-tokens/assets/svgs/icon-person.svg"
+// Components
 import SmartLink from "@/lib-components/SmartLink.vue"
 import ButtonLink from "@/lib-components/ButtonLink.vue"
 import RichText from "@/lib-components/RichText.vue"
@@ -116,12 +111,35 @@ export default {
     components: {
         SvgMoleculeHalfFaceted,
         SvgHatchRight,
-        SvgHeadingVector,
-        SvgIconOnline,
-        SvgIconEmail,
-        SvgIconPhone,
-        SvgIconLocation,
-        SvgIconPerson,
+        SvgHeadingVector: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"
+            ).then((d) => d.default),
+        SvgIconOnline: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
+            ).then((d) => d.default),
+
+        SvgIconEmail: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-email.svg"
+            ).then((d) => d.default),
+        SvgIconPhone: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
+            ).then((d) => d.default),
+        SvgIconPhone: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
+            ).then((d) => d.default),
+        SvgIconLocation: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-location.svg"
+            ).then((d) => d.default),
+        SvgIconPerson: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-person.svg"
+            ).then((d) => d.default),
         SmartLink,
         ButtonLink,
         RichText,

--- a/src/lib-components/BannerFeatured.vue
+++ b/src/lib-components/BannerFeatured.vue
@@ -1,4 +1,4 @@
-<!-- <template>
+<template>
     <div :class="classes">
         <div class="slot">
             <slot>
@@ -38,9 +38,7 @@
         <div class="meta">
             <div class="category category-desktop" v-html="category" />
 
-            <h3 id="banner-featured" class="title" v-html="title">
-
-            </h3>
+            <h3 id="banner-featured" class="title" v-html="title"></h3>
 
             <rich-text
                 v-if="description"
@@ -567,4 +565,4 @@ export default {
         }
     }
 }
-</style> -->
+</style>

--- a/src/lib-components/BannerFeatured.vue
+++ b/src/lib-components/BannerFeatured.vue
@@ -1,4 +1,4 @@
-<template>
+<!-- <template>
     <div :class="classes">
         <div class="slot">
             <slot>
@@ -37,12 +37,9 @@
 
         <div class="meta">
             <div class="category category-desktop" v-html="category" />
-            <!-- TODO make the id unique programmaticly -->
+
             <h3 id="banner-featured" class="title" v-html="title">
-                <!--nuxt-link
-                    :to="to"
-                    v-html="title"
-                /-->
+
             </h3>
 
             <rich-text
@@ -570,4 +567,4 @@ export default {
         }
     }
 }
-</style>
+</style> -->

--- a/src/lib-components/BannerFeatured.vue
+++ b/src/lib-components/BannerFeatured.vue
@@ -128,10 +128,6 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
             ).then((d) => d.default),
-        SvgIconPhone: () =>
-            import(
-                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
-            ).then((d) => d.default),
         SvgIconLocation: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-location.svg"

--- a/src/lib-components/BannerFeatured.vue
+++ b/src/lib-components/BannerFeatured.vue
@@ -84,6 +84,13 @@
 <script>
 import format from "date-fns/format"
 
+// Components
+import SvgMoleculeHalfFaceted from "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
+import SvgHatchRight from "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
+import ResponsiveImage from "@/lib-components/ResponsiveImage.vue"
+import ResponsiveVideo from "@/lib-components/ResponsiveVideo.vue"
+import SmartLink from "@/lib-components/SmartLink.vue"
+
 // Utility functions
 import formatEventTimes from "@/mixins/formatEventTimes"
 import formatEventDates from "@/mixins/formatEventDates"
@@ -93,24 +100,11 @@ export default {
     name: "BannerFeatured",
     mixins: [getSectionName, formatEventTimes, formatEventDates],
     components: {
-        SvgMoleculeHalfFaceted: () =>
-            import(
-                "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
-            ).then((d) => d.default),
-        SvgHatchRight: () =>
-            import(
-                "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
-            ).then((d) => d.default),
-        ResponsiveImage: () =>
-            import("@/lib-components/ResponsiveImage.vue").then(
-                (d) => d.default
-            ),
-        ResponsiveVideo: () =>
-            import("@/lib-components/ResponsiveVideo.vue").then(
-                (d) => d.default
-            ),
-        SmartLink: () =>
-            import("@/lib-components/SmartLink.vue").then((d) => d.default),
+        SvgMoleculeHalfFaceted,
+        SvgHatchRight,
+        ResponsiveImage,
+        ResponsiveVideo,
+        SmartLink,
         ButtonLink: () =>
             import("@/lib-components/ButtonLink.vue").then((d) => d.default),
         RichText: () =>

--- a/src/lib-components/BannerFeatured.vue
+++ b/src/lib-components/BannerFeatured.vue
@@ -89,17 +89,6 @@
 <script>
 import format from "date-fns/format"
 
-// SVGs
-import SvgMoleculeHalfFaceted from "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
-import SvgHatchRight from "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
-
-// Components
-import SmartLink from "@/lib-components/SmartLink.vue"
-import ButtonLink from "@/lib-components/ButtonLink.vue"
-import RichText from "@/lib-components/RichText.vue"
-import ResponsiveImage from "@/lib-components/ResponsiveImage.vue"
-import ResponsiveVideo from "@/lib-components/ResponsiveVideo.vue"
-
 // Utility functions
 import formatEventTimes from "@/mixins/formatEventTimes"
 import formatEventDates from "@/mixins/formatEventDates"
@@ -109,8 +98,28 @@ export default {
     name: "BannerFeatured",
     mixins: [getSectionName, formatEventTimes, formatEventDates],
     components: {
-        SvgMoleculeHalfFaceted,
-        SvgHatchRight,
+        SvgMoleculeHalfFaceted: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
+            ).then((d) => d.default),
+        SvgHatchRight: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
+            ).then((d) => d.default),
+        ResponsiveImage: () =>
+            import("@/lib-components/ResponsiveImage.vue").then(
+                (d) => d.default
+            ),
+        ResponsiveVideo: () =>
+            import("@/lib-components/ResponsiveVideo.vue").then(
+                (d) => d.default
+            ),
+        SmartLink: () =>
+            import("@/lib-components/SmartLink.vue").then((d) => d.default),
+        ButtonLink: () =>
+            import("@/lib-components/ButtonLink.vue").then((d) => d.default),
+        RichText: () =>
+            import("@/lib-components/RichText.vue").then((d) => d.default),
         SvgHeadingVector: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"
@@ -136,11 +145,6 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-person.svg"
             ).then((d) => d.default),
-        SmartLink,
-        ButtonLink,
-        RichText,
-        ResponsiveImage,
-        ResponsiveVideo,
     },
     props: {
         image: {

--- a/src/lib-components/BannerHeader.vue
+++ b/src/lib-components/BannerHeader.vue
@@ -118,6 +118,14 @@
 <script>
 import format from "date-fns/format"
 
+// Components
+
+import SvgMoleculeHalfFaceted from "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
+import SvgHatchRight from "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
+import ResponsiveImage from "@/lib-components/ResponsiveImage.vue"
+import ResponsiveVideo from "@/lib-components/ResponsiveVideo.vue"
+import SmartLink from "@/lib-components/SmartLink.vue"
+
 // Utility functions
 import formatEventTimes from "@/mixins/formatEventTimes"
 import formatEventDates from "@/mixins/formatEventDates"
@@ -127,24 +135,11 @@ export default {
     name: "BannerHeader",
     mixins: [getSectionName, formatEventTimes, formatEventDates],
     components: {
-        SvgMoleculeHalfFaceted: () =>
-            import(
-                "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
-            ).then((d) => d.default),
-        SvgHatchRight: () =>
-            import(
-                "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
-            ).then((d) => d.default),
-        ResponsiveImage: () =>
-            import("@/lib-components/ResponsiveImage.vue").then(
-                (d) => d.default
-            ),
-        ResponsiveVideo: () =>
-            import("@/lib-components/ResponsiveVideo.vue").then(
-                (d) => d.default
-            ),
-        SmartLink: () =>
-            import("@/lib-components/SmartLink.vue").then((d) => d.default),
+        SvgMoleculeHalfFaceted,
+        SvgHatchRight,
+        ResponsiveImage,
+        ResponsiveVideo,
+        SmartLink,
         ButtonLink: () =>
             import("@/lib-components/ButtonLink.vue").then((d) => d.default),
         RichText: () =>

--- a/src/lib-components/BannerHeader.vue
+++ b/src/lib-components/BannerHeader.vue
@@ -1,4 +1,4 @@
-<template>
+<!-- <template>
     <div :class="classes">
         <div v-if="category" class="category">
             <svg-heading-vector class="heading-line" />
@@ -174,11 +174,6 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-person.svg"
             ).then((d) => d.default),
-        SmartLink,
-        ButtonLink,
-        RichText,
-        ResponsiveImage,
-        ResponsiveVideo,
     },
     props: {
         image: {
@@ -706,4 +701,4 @@ export default {
         }
     }
 }
-</style>
+</style> -->

--- a/src/lib-components/BannerHeader.vue
+++ b/src/lib-components/BannerHeader.vue
@@ -118,17 +118,6 @@
 <script>
 import format from "date-fns/format"
 
-// SVGs
-import SvgMoleculeHalfFaceted from "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
-import SvgHatchRight from "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
-
-// Components
-import SmartLink from "@/lib-components/SmartLink.vue"
-import ButtonLink from "@/lib-components/ButtonLink.vue"
-import RichText from "@/lib-components/RichText.vue"
-import ResponsiveImage from "@/lib-components/ResponsiveImage.vue"
-import ResponsiveVideo from "@/lib-components/ResponsiveVideo.vue"
-
 // Utility functions
 import formatEventTimes from "@/mixins/formatEventTimes"
 import formatEventDates from "@/mixins/formatEventDates"
@@ -138,8 +127,28 @@ export default {
     name: "BannerHeader",
     mixins: [getSectionName, formatEventTimes, formatEventDates],
     components: {
-        SvgMoleculeHalfFaceted,
-        SvgHatchRight,
+        SvgMoleculeHalfFaceted: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
+            ).then((d) => d.default),
+        SvgHatchRight: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
+            ).then((d) => d.default),
+        ResponsiveImage: () =>
+            import("@/lib-components/ResponsiveImage.vue").then(
+                (d) => d.default
+            ),
+        ResponsiveVideo: () =>
+            import("@/lib-components/ResponsiveVideo.vue").then(
+                (d) => d.default
+            ),
+        SmartLink: () =>
+            import("@/lib-components/SmartLink.vue").then((d) => d.default),
+        ButtonLink: () =>
+            import("@/lib-components/ButtonLink.vue").then((d) => d.default),
+        RichText: () =>
+            import("@/lib-components/RichText.vue").then((d) => d.default),
         SvgHeadingVector: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"

--- a/src/lib-components/BannerHeader.vue
+++ b/src/lib-components/BannerHeader.vue
@@ -1,4 +1,4 @@
-<!-- <template>
+<template>
     <div :class="classes">
         <div v-if="category" class="category">
             <svg-heading-vector class="heading-line" />
@@ -701,4 +701,4 @@ export default {
         }
     }
 }
-</style> -->
+</style>

--- a/src/lib-components/BannerHeader.vue
+++ b/src/lib-components/BannerHeader.vue
@@ -157,10 +157,6 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
             ).then((d) => d.default),
-        SvgIconPhone: () =>
-            import(
-                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
-            ).then((d) => d.default),
         SvgIconLocation: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-location.svg"

--- a/src/lib-components/BannerHeader.vue
+++ b/src/lib-components/BannerHeader.vue
@@ -118,16 +118,11 @@
 <script>
 import format from "date-fns/format"
 
-// Components
+// SVGs
 import SvgMoleculeHalfFaceted from "ucla-library-design-tokens/assets/svgs/molecule-half-overlay.svg"
 import SvgHatchRight from "ucla-library-design-tokens/assets/svgs/graphic-hatch-lines.svg"
 
-import SvgHeadingVector from "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"
-import SvgIconOnline from "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
-import SvgIconEmail from "ucla-library-design-tokens/assets/svgs/icon-email.svg"
-import SvgIconPhone from "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
-import SvgIconLocation from "ucla-library-design-tokens/assets/svgs/icon-location.svg"
-import SvgIconPerson from "ucla-library-design-tokens/assets/svgs/icon-person.svg"
+// Components
 import SmartLink from "@/lib-components/SmartLink.vue"
 import ButtonLink from "@/lib-components/ButtonLink.vue"
 import RichText from "@/lib-components/RichText.vue"
@@ -145,12 +140,35 @@ export default {
     components: {
         SvgMoleculeHalfFaceted,
         SvgHatchRight,
-        SvgHeadingVector,
-        SvgIconOnline,
-        SvgIconEmail,
-        SvgIconPhone,
-        SvgIconLocation,
-        SvgIconPerson,
+        SvgHeadingVector: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"
+            ).then((d) => d.default),
+        SvgIconOnline: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
+            ).then((d) => d.default),
+
+        SvgIconEmail: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-email.svg"
+            ).then((d) => d.default),
+        SvgIconPhone: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
+            ).then((d) => d.default),
+        SvgIconPhone: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
+            ).then((d) => d.default),
+        SvgIconLocation: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-location.svg"
+            ).then((d) => d.default),
+        SvgIconPerson: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-person.svg"
+            ).then((d) => d.default),
         SmartLink,
         ButtonLink,
         RichText,

--- a/src/lib-components/BannerText.vue
+++ b/src/lib-components/BannerText.vue
@@ -1,4 +1,4 @@
-<template>
+<!-- <template>
     <div :class="classes">
         <div class="banner-text-content-container">
             <div v-if="category" class="meta">
@@ -28,7 +28,6 @@
                         class="schedule-item"
                         v-html="parsedTime"
                     />
-                    <!-- TODO this can be multiple locations, on own line with icon -->
                     <div v-if="isOnline" class="schedule-item">Online</div>
                 </div>
                 <div v-if="locations.length" class="location-group">
@@ -522,4 +521,4 @@ export default {
         }
     }
 }
-</style>
+</style> -->

--- a/src/lib-components/BannerText.vue
+++ b/src/lib-components/BannerText.vue
@@ -1,4 +1,4 @@
-<!-- <template>
+<template>
     <div :class="classes">
         <div class="banner-text-content-container">
             <div v-if="category" class="meta">
@@ -521,4 +521,4 @@ export default {
         }
     }
 }
-</style> -->
+</style>

--- a/src/lib-components/BannerText.vue
+++ b/src/lib-components/BannerText.vue
@@ -108,17 +108,14 @@ export default {
             import("@/lib-components/ButtonLink.vue").then((d) => d.default),
         RichText: () =>
             import("@/lib-components/RichText.vue").then((d) => d.default),
-
         SvgHeadingVector: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"
             ).then((d) => d.default),
-
         SvgIconOnline: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
             ).then((d) => d.default),
-
         SvgIconEmail: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-email.svg"

--- a/src/lib-components/BannerText.vue
+++ b/src/lib-components/BannerText.vue
@@ -90,22 +90,11 @@
                 />
             </div>
         </div>
-
-        <!-- <svg-molecule-two-facets class="molecule" /> -->
     </div>
 </template>
 
 <script>
-// import format from "date-fns/format"
-
 // Components
-// import SvgMoleculeTwoFacets from "ucla-library-design-tokens/assets/svgs/molecule-half.svg"
-import SvgHeadingVector from "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"
-import SvgIconOnline from "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
-import SvgIconEmail from "ucla-library-design-tokens/assets/svgs/icon-email.svg"
-import SvgIconPhone from "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
-import SvgIconLocation from "ucla-library-design-tokens/assets/svgs/icon-location.svg"
-import SvgIconPerson from "ucla-library-design-tokens/assets/svgs/icon-person.svg"
 import SmartLink from "@/lib-components/SmartLink.vue"
 import ButtonLink from "@/lib-components/ButtonLink.vue"
 import RichText from "@/lib-components/RichText.vue"
@@ -119,13 +108,37 @@ export default {
     name: "BannerText",
     mixins: [getSectionName, formatEventTimes, formatEventDates],
     components: {
-        // SvgMoleculeTwoFacets,
-        SvgHeadingVector,
-        SvgIconOnline,
-        SvgIconEmail,
-        SvgIconPhone,
-        SvgIconLocation,
-        SvgIconPerson,
+        SvgHeadingVector: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"
+            ).then((d) => d.default),
+
+        SvgIconOnline: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
+            ).then((d) => d.default),
+
+        SvgIconEmail: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-email.svg"
+            ).then((d) => d.default),
+        SvgIconPhone: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
+            ).then((d) => d.default),
+        SvgIconPhone: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
+            ).then((d) => d.default),
+        SvgIconLocation: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-location.svg"
+            ).then((d) => d.default),
+        SvgIconPerson: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-person.svg"
+            ).then((d) => d.default),
+
         SmartLink,
         ButtonLink,
         RichText,

--- a/src/lib-components/BannerText.vue
+++ b/src/lib-components/BannerText.vue
@@ -126,10 +126,6 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
             ).then((d) => d.default),
-        SvgIconPhone: () =>
-            import(
-                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
-            ).then((d) => d.default),
         SvgIconLocation: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-location.svg"

--- a/src/lib-components/BannerText.vue
+++ b/src/lib-components/BannerText.vue
@@ -95,9 +95,6 @@
 
 <script>
 // Components
-import SmartLink from "@/lib-components/SmartLink.vue"
-import ButtonLink from "@/lib-components/ButtonLink.vue"
-import RichText from "@/lib-components/RichText.vue"
 
 // Utility functions
 import formatEventTimes from "@/mixins/formatEventTimes"
@@ -108,6 +105,13 @@ export default {
     name: "BannerText",
     mixins: [getSectionName, formatEventTimes, formatEventDates],
     components: {
+        SmartLink: () =>
+            import("@/lib-components/SmartLink.vue").then((d) => d.default),
+        ButtonLink: () =>
+            import("@/lib-components/ButtonLink.vue").then((d) => d.default),
+        RichText: () =>
+            import("@/lib-components/RichText.vue").then((d) => d.default),
+
         SvgHeadingVector: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/graphic-category-slash.svg"

--- a/src/lib-components/BannerText.vue
+++ b/src/lib-components/BannerText.vue
@@ -94,8 +94,6 @@
 </template>
 
 <script>
-// Components
-
 // Utility functions
 import formatEventTimes from "@/mixins/formatEventTimes"
 import formatEventDates from "@/mixins/formatEventDates"
@@ -138,10 +136,6 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-person.svg"
             ).then((d) => d.default),
-
-        SmartLink,
-        ButtonLink,
-        RichText,
     },
     props: {
         category: {

--- a/src/lib-components/BlockAmenities.vue
+++ b/src/lib-components/BlockAmenities.vue
@@ -18,49 +18,56 @@
 </template>
 
 <script>
-// SVGs
-
-// 24 Hour Study Space - icon-clock
-import IconClock from "ucla-library-design-tokens/assets/svgs/icon-clock.svg"
-
-// ADA Stations - icon-accessible
-import IconAccessible from "ucla-library-design-tokens/assets/svgs/icon-accessible.svg"
-
-// Cafe - icon-chair
-import IconChair from "ucla-library-design-tokens/assets/svgs/icon-chair.svg"
-
-// Computer/Laptop Access - icon-virtual
-import IconVirtual from "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
-
-// Laptop Lending - icon-laptop
-import IconLaptop from "ucla-library-design-tokens/assets/svgs/icon-laptop.svg"
-
-// Lockers - icon-locker
-import IconLocker from "ucla-library-design-tokens/assets/svgs/icon-locker.svg"
-
-// Makerspace - icon-light
-import IconLight from "ucla-library-design-tokens/assets/svgs/icon-light.svg"
-
-// Printing, Scanning, and Copying - icon-share-printer
-// use svg class names to get rid of the circle background
-import IconSharePrinter from "ucla-library-design-tokens/assets/svgs/icon-share-printer.svg"
-
-// Research Help -  icon-book
-import IconBook from "ucla-library-design-tokens/assets/svgs/icon-book.svg"
-
 export default {
     // TO DO import all amenitites svgs
     name: "BlockAmenities",
     components: {
-        IconClock,
-        IconAccessible,
-        IconChair,
-        IconVirtual,
-        IconLaptop,
-        IconLocker,
-        IconLight,
-        IconSharePrinter,
-        IconBook,
+        // 24 Hour Study Space - icon-clock
+        IconClock: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-clock.svg"
+            ).then((d) => d.default),
+
+        // ADA Stations - icon-accessible
+        IconAccessible: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-accessible.svg"
+            ).then((d) => d.default),
+        // Cafe - icon-chair
+        IconChair: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-chair.svg"
+            ).then((d) => d.default),
+        // Computer/Laptop Access - icon-virtual
+        IconVirtual: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
+            ).then((d) => d.default),
+        // Laptop Lending - icon-laptop
+        IconLaptop: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-laptop.svg"
+            ).then((d) => d.default),
+        // Lockers - icon-locker
+        IconLocker: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-locker.svg"
+            ).then((d) => d.default),
+        // Makerspace - icon-light
+        IconLight: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-light.svg"
+            ).then((d) => d.default),
+        // Printing, Scanning, and Copying - icon-share-printer
+        IconSharePrinter: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-share-printer.svg"
+            ).then((d) => d.default),
+        // Research Help -  icon-book
+        IconBook: () =>
+            import("ucla-library-design-tokens/assets/svgs/icon-book.svg").then(
+                (d) => d.default
+            ),
     },
     props: {
         amenities: {

--- a/src/lib-components/BlockCallToAction.vue
+++ b/src/lib-components/BlockCallToAction.vue
@@ -1,4 +1,4 @@
-<template>
+<!-- <template>
     <div :class="classes">
         <component :is="parsedContent.svgName" class="svg" />
         <div class="title" v-html="parsedContent.title" />
@@ -244,4 +244,4 @@ export default {
         }
     }
 }
-</style>
+</style> -->

--- a/src/lib-components/BlockCallToAction.vue
+++ b/src/lib-components/BlockCallToAction.vue
@@ -1,4 +1,4 @@
-<!-- <template>
+<template>
     <div :class="classes">
         <component :is="parsedContent.svgName" class="svg" />
         <div class="title" v-html="parsedContent.title" />
@@ -244,4 +244,4 @@ export default {
         }
     }
 }
-</style> -->
+</style>

--- a/src/lib-components/BlockCallToAction.vue
+++ b/src/lib-components/BlockCallToAction.vue
@@ -12,12 +12,11 @@
 </template>
 
 <script>
-import ButtonLink from "@/lib-components/ButtonLink.vue"
-
 export default {
     name: "BlockCallToAction",
     components: {
-        ButtonLink,
+        ButtonLink: () =>
+            import("@/lib-components/ButtonLink.vue").then((d) => d.default),
         SvgCallToActionMoney: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/call-to-action-money.svg"

--- a/src/lib-components/BlockCallToAction.vue
+++ b/src/lib-components/BlockCallToAction.vue
@@ -13,19 +13,27 @@
 
 <script>
 import ButtonLink from "@/lib-components/ButtonLink.vue"
-import SvgCallToActionMoney from "ucla-library-design-tokens/assets/svgs/call-to-action-money.svg"
-import SvgCallToActionChat from "ucla-library-design-tokens/assets/svgs/call-to-action-chat.svg"
-import SvgCallToActionMail from "ucla-library-design-tokens/assets/svgs/call-to-action-mail.svg"
-import SvgCallToActionFind from "ucla-library-design-tokens/assets/svgs/call-to-action-find.svg"
 
 export default {
     name: "BlockCallToAction",
     components: {
         ButtonLink,
-        SvgCallToActionMoney,
-        SvgCallToActionChat,
-        SvgCallToActionMail,
-        SvgCallToActionFind,
+        SvgCallToActionMoney: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/call-to-action-money.svg"
+            ).then((d) => d.default),
+        SvgCallToActionChat: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/call-to-action-chat.svg"
+            ).then((d) => d.default),
+        SvgCallToActionMail: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/call-to-action-mail.svg"
+            ).then((d) => d.default),
+        SvgCallToActionFind: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/call-to-action-find.svg"
+            ).then((d) => d.default),
     },
     props: {
         svgName: {

--- a/src/lib-components/BlockCallToAction.vue
+++ b/src/lib-components/BlockCallToAction.vue
@@ -12,11 +12,11 @@
 </template>
 
 <script>
+import ButtonLink from "@/lib-components/ButtonLink.vue"
 export default {
     name: "BlockCallToAction",
     components: {
-        ButtonLink: () =>
-            import("@/lib-components/ButtonLink.vue").then((d) => d.default),
+        ButtonLink,
         SvgCallToActionMoney: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/call-to-action-money.svg"

--- a/src/lib-components/BlockCardWithIllustration.vue
+++ b/src/lib-components/BlockCardWithIllustration.vue
@@ -13,9 +13,6 @@
 </template>
 
 <script>
-// Components
-import SmartLink from "@/lib-components/SmartLink.vue"
-
 // Utility Functions
 import getSectionName from "@/mixins/getSectionName"
 
@@ -23,7 +20,8 @@ export default {
     name: "BlockCardWithIllustration",
     mixins: [getSectionName],
     components: {
-        SmartLink,
+        SmartLink: () =>
+            import("@/lib-components/SmartLink.vue").then((d) => d.default),
         IllustrationBookBinding: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/illustration-book-binding.svg"

--- a/src/lib-components/BlockCardWithIllustration.vue
+++ b/src/lib-components/BlockCardWithIllustration.vue
@@ -13,15 +13,10 @@
 </template>
 
 <script>
+// Components
 import SmartLink from "@/lib-components/SmartLink.vue"
-import IllustrationBookBinding from "ucla-library-design-tokens/assets/svgs/illustration-book-binding.svg"
-import IllustrationBorrowingBooks from "ucla-library-design-tokens/assets/svgs/illustration-borrowing-books.svg"
-import IllustrationDatabases from "ucla-library-design-tokens/assets/svgs/illustration-databases.svg"
-import IllustrationDigitizedResources from "ucla-library-design-tokens/assets/svgs/illustration-digitized-resources.svg"
-import IllustrationFindSpace from "ucla-library-design-tokens/assets/svgs/illustration-find-space.svg"
-import IllustrationRemoteAccess from "ucla-library-design-tokens/assets/svgs/illustration-remote-access.svg"
-import IllustrationResearch from "ucla-library-design-tokens/assets/svgs/illustration-research.svg"
-import IllustrationTeaching from "ucla-library-design-tokens/assets/svgs/illustration-teaching.svg"
+
+// Utility Functions
 import getSectionName from "@/mixins/getSectionName"
 
 export default {
@@ -29,14 +24,38 @@ export default {
     mixins: [getSectionName],
     components: {
         SmartLink,
-        IllustrationBookBinding,
-        IllustrationBorrowingBooks,
-        IllustrationDatabases,
-        IllustrationDigitizedResources,
-        IllustrationFindSpace,
-        IllustrationRemoteAccess,
-        IllustrationResearch,
-        IllustrationTeaching,
+        IllustrationBookBinding: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/illustration-book-binding.svg"
+            ).then((d) => d.default),
+        IllustrationBorrowingBooks: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/illustration-borrowing-books.svg"
+            ).then((d) => d.default),
+        IllustrationDatabases: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/illustration-databases.svg"
+            ).then((d) => d.default),
+        IllustrationDigitizedResources: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/illustration-digitized-resources.svg"
+            ).then((d) => d.default),
+        IllustrationFindSpace: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/illustration-find-space.svg"
+            ).then((d) => d.default),
+        IllustrationRemoteAccess: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/illustration-remote-access.svg"
+            ).then((d) => d.default),
+        IllustrationResearch: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/illustration-research.svg"
+            ).then((d) => d.default),
+        IllustrationTeaching: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/illustration-teaching.svg"
+            ).then((d) => d.default),
     },
     props: {
         iconName: {

--- a/src/lib-components/BlockCardWithIllustration.vue
+++ b/src/lib-components/BlockCardWithIllustration.vue
@@ -13,6 +13,9 @@
 </template>
 
 <script>
+// Componenets
+
+import SmartLink from "@/lib-components/SmartLink.vue"
 // Utility Functions
 import getSectionName from "@/mixins/getSectionName"
 
@@ -20,8 +23,7 @@ export default {
     name: "BlockCardWithIllustration",
     mixins: [getSectionName],
     components: {
-        SmartLink: () =>
-            import("@/lib-components/SmartLink.vue").then((d) => d.default),
+        SmartLink,
         IllustrationBookBinding: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/illustration-book-binding.svg"

--- a/src/lib-components/BlockCardWithIllustration.vue
+++ b/src/lib-components/BlockCardWithIllustration.vue
@@ -1,4 +1,4 @@
-<!-- <template>
+<template>
     <div :class="classes">
         <component :is="parsedSvgName" class="svg" />
 
@@ -271,4 +271,4 @@ export default {
         }
     }
 }
-</style> -->
+</style>

--- a/src/lib-components/BlockCardWithIllustration.vue
+++ b/src/lib-components/BlockCardWithIllustration.vue
@@ -1,4 +1,4 @@
-<template>
+<!-- <template>
     <div :class="classes">
         <component :is="parsedSvgName" class="svg" />
 
@@ -271,4 +271,4 @@ export default {
         }
     }
 }
-</style>
+</style> -->

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -54,20 +54,30 @@
 </template>
 
 <script>
+// Utility functions
 import formatTimes from "@/mixins/formatEventTimes"
 import formatDates from "@/mixins/formatEventDates"
 import formatDay from "@/mixins/formatEventDay"
 import formatMonth from "@/mixins/formatEventMonth"
 import getSectionName from "@/mixins/getSectionName"
-import SvgIconLocation from "ucla-library-design-tokens/assets/svgs/icon-location.svg"
-import SvgIconOnline from "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
+
+// Components
 import SmartLink from "@/lib-components/SmartLink"
 import ResponsiveImage from "@/lib-components/ResponsiveImage"
+
 export default {
     name: "BlockHighlight",
     components: {
-        SvgIconLocation,
-        SvgIconOnline,
+        SvgIconLocation: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-location.svg"
+            ).then((d) => d.default),
+        ,
+        SvgIconOnline: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
+            ).then((d) => d.default),
+        ,
         SmartLink,
         ResponsiveImage,
     },

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -54,6 +54,10 @@
 </template>
 
 <script>
+// Components
+import ResponsiveImage from "@/lib-components/ResponsiveImage.vue"
+import SmartLink from "@/lib-components/SmartLink.vue"
+
 // Utility functions
 import formatTimes from "@/mixins/formatEventTimes"
 import formatDates from "@/mixins/formatEventDates"
@@ -72,12 +76,8 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-location.svg"
             ).then((d) => d.default),
-        SmartLink: () =>
-            import("@/lib-components/SmartLink.vue").then((d) => d.default),
-        ResponsiveImage: () =>
-            import("@/lib-components/ResponsiveImage.vue").then(
-                (d) => d.default
-            ),
+        SmartLink,
+        ResponsiveImage,
     },
     mixins: [formatTimes, formatDates, formatDay, formatMonth, getSectionName],
     props: {

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -61,10 +61,6 @@ import formatDay from "@/mixins/formatEventDay"
 import formatMonth from "@/mixins/formatEventMonth"
 import getSectionName from "@/mixins/getSectionName"
 
-// Components
-import SmartLink from "@/lib-components/SmartLink"
-import ResponsiveImage from "@/lib-components/ResponsiveImage"
-
 export default {
     name: "BlockHighlight",
     components: {
@@ -76,8 +72,12 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-location.svg"
             ).then((d) => d.default),
-        SmartLink,
-        ResponsiveImage,
+        SmartLink: () =>
+            import("@/lib-components/SmartLink.vue").then((d) => d.default),
+        ResponsiveImage: () =>
+            import("@/lib-components/ResponsiveImage.vue").then(
+                (d) => d.default
+            ),
     },
     mixins: [formatTimes, formatDates, formatDay, formatMonth, getSectionName],
     props: {

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -76,7 +76,6 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
             ).then((d) => d.default),
-        ,
         SmartLink,
         ResponsiveImage,
     },

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -72,7 +72,6 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-location.svg"
             ).then((d) => d.default),
-        ,
         SvgIconOnline: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -68,13 +68,13 @@ import ResponsiveImage from "@/lib-components/ResponsiveImage"
 export default {
     name: "BlockHighlight",
     components: {
-        SvgIconLocation: () =>
-            import(
-                "ucla-library-design-tokens/assets/svgs/icon-location.svg"
-            ).then((d) => d.default),
         SvgIconOnline: () =>
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
+            ).then((d) => d.default),
+        SvgIconLocation: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-location.svg"
             ).then((d) => d.default),
         SmartLink,
         ResponsiveImage,

--- a/src/lib-components/BlockLocationListItem.vue
+++ b/src/lib-components/BlockLocationListItem.vue
@@ -50,41 +50,7 @@
 </template>
 
 <script>
-import SvgIconClock from "ucla-library-design-tokens/assets/svgs/icon-clock.svg"
-import SvgIconCalendar from "ucla-library-design-tokens/assets/svgs/icon-calendar.svg"
-import SvgIconLocation from "ucla-library-design-tokens/assets/svgs/icon-location.svg"
-
-// AMENITIES
-import SvgIconLight from "ucla-library-design-tokens/assets/svgs/icon-light.svg"
-
-// 24 Hour Study Space - icon-clock
-// import SvgIconClock from "ucla-library-design-tokens/assets/svgs/icon-clock.svg"
-
-// ADA Stations - icon-accessible
-import SvgIconAccessible from "ucla-library-design-tokens/assets/svgs/icon-accessible.svg"
-
-// Cafe - icon-chair
-import SvgIconChair from "ucla-library-design-tokens/assets/svgs/icon-chair.svg"
-
-// Computer/Laptop Access - icon-virtual
-import SvgIconVirtual from "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
-
-// Laptop Lending - icon-laptop
-import SvgIconLaptop from "ucla-library-design-tokens/assets/svgs/icon-laptop.svg"
-
-// Lockers - icon-locker
-import SvgIconLocker from "ucla-library-design-tokens/assets/svgs/icon-locker.svg"
-
-// Printing, Scanning, and Copying - icon-share-printer
-// use svg class names to get rid of the circle background
-import SvgIconSharePrinter from "ucla-library-design-tokens/assets/svgs/icon-share-printer.svg"
-
-// Research Help -  icon-book
-import SvgIconBook from "ucla-library-design-tokens/assets/svgs/icon-book.svg"
-
-import SvgMoleculePlaceholder from "ucla-library-design-tokens/assets/svgs/molecule-placeholder.svg"
-
-// Other Imports
+// Components
 import IconWithLink from "@/lib-components/IconWithLink"
 import SmartLink from "@/lib-components/SmartLink"
 import ResponsiveImage from "@/lib-components/ResponsiveImage"
@@ -92,21 +58,57 @@ import ResponsiveImage from "@/lib-components/ResponsiveImage"
 export default {
     name: "BlockLocationListItem",
     components: {
-        SvgIconClock,
-        SvgIconCalendar,
-        SvgIconLocation,
-        SvgIconLight,
-        SvgIconAccessible,
-        SvgIconChair,
-        SvgIconVirtual,
-        SvgIconLaptop,
-        SvgIconLocker,
-        SvgIconSharePrinter,
-        SvgIconBook,
-        SvgMoleculePlaceholder,
         IconWithLink,
         SmartLink,
         ResponsiveImage,
+        SvgIconClock: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-clock.svg"
+            ).then((d) => d.default),
+        SvgIconAccessible: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-accessible.svg"
+            ).then((d) => d.default),
+        SvgIconChair: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-chair.svg"
+            ).then((d) => d.default),
+        SvgIconVirtual: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
+            ).then((d) => d.default),
+        SvgIconCalendar: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-calendar.svg"
+            ).then((d) => d.default),
+        SvgIconLocation: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-location.svg"
+            ).then((d) => d.default),
+        SvgIconLight: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-light.svg"
+            ).then((d) => d.default),
+        SvgIconLaptop: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-laptop.svg"
+            ).then((d) => d.default),
+        SvgIconLocker: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-locker.svg"
+            ).then((d) => d.default),
+        SvgIconSharePrinter: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-share-printer.svg"
+            ).then((d) => d.default),
+        SvgIconBook: () =>
+            import("ucla-library-design-tokens/assets/svgs/icon-book.svg").then(
+                (d) => d.default
+            ),
+        SvgMoleculePlaceholder: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/molecule-placeholder.svg"
+            ).then((d) => d.default),
     },
     props: {
         image: {

--- a/src/lib-components/BlockMediaWithText.vue
+++ b/src/lib-components/BlockMediaWithText.vue
@@ -79,14 +79,19 @@ import isInternalLink from "@/mixins/isInternalLink"
 import SmartLink from "@/lib-components/SmartLink"
 import ResponsiveImage from "@/lib-components/ResponsiveImage"
 import ButtonLink from "@/lib-components/ButtonLink"
-import SvgIconHeadphones from "ucla-library-design-tokens/assets/svgs/molecule-headphones.svg"
 import SvgIconPlayFilled from "ucla-library-design-tokens/assets/svgs/icon-play-filled.svg"
 
 export default {
     name: "BlockMediaWithText",
     components: {
-        SvgIconHeadphones,
-        SvgIconPlayFilled,
+        SvgIconHeadphones: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/molecule-headphones.svg"
+            ).then((d) => d.default),
+        SvgIconPlayFilled: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-play-filled.svg"
+            ).then((d) => d.default),
         SmartLink,
         ResponsiveImage,
         ButtonLink,

--- a/src/lib-components/BlockMediaWithText.vue
+++ b/src/lib-components/BlockMediaWithText.vue
@@ -92,8 +92,8 @@ export default {
             import("@/lib-components/SmartLink.vue").then((d) => d.default),
         ButtonLink: () =>
             import("@/lib-components/ButtonLink.vue").then((d) => d.default),
-        ResponsiveVideo: () =>
-            import("@/lib-components/ResponsiveVideo.vue").then(
+        ResponsiveImage: () =>
+            import("@/lib-components/ResponsiveImage.vue").then(
                 (d) => d.default
             ),
     },

--- a/src/lib-components/BlockMediaWithText.vue
+++ b/src/lib-components/BlockMediaWithText.vue
@@ -1,4 +1,4 @@
-<!-- <template>
+<template>
     <div class="media-with-text">
         <div class="text-grouping">
             <h3 class="section-header" v-html="sectionHeader" />
@@ -374,4 +374,4 @@ export default {
         }
     }
 }
-</style> -->
+</style>

--- a/src/lib-components/BlockMediaWithText.vue
+++ b/src/lib-components/BlockMediaWithText.vue
@@ -1,4 +1,4 @@
-<template>
+<!-- <template>
     <div class="media-with-text">
         <div class="text-grouping">
             <h3 class="section-header" v-html="sectionHeader" />
@@ -374,4 +374,4 @@ export default {
         }
     }
 }
-</style>
+</style> -->

--- a/src/lib-components/BlockMediaWithText.vue
+++ b/src/lib-components/BlockMediaWithText.vue
@@ -76,10 +76,6 @@
 <script>
 // Helper functions
 import isInternalLink from "@/mixins/isInternalLink"
-import SmartLink from "@/lib-components/SmartLink"
-import ResponsiveImage from "@/lib-components/ResponsiveImage"
-import ButtonLink from "@/lib-components/ButtonLink"
-import SvgIconPlayFilled from "ucla-library-design-tokens/assets/svgs/icon-play-filled.svg"
 
 export default {
     name: "BlockMediaWithText",
@@ -92,9 +88,14 @@ export default {
             import(
                 "ucla-library-design-tokens/assets/svgs/icon-play-filled.svg"
             ).then((d) => d.default),
-        SmartLink,
-        ResponsiveImage,
-        ButtonLink,
+        SmartLink: () =>
+            import("@/lib-components/SmartLink.vue").then((d) => d.default),
+        ButtonLink: () =>
+            import("@/lib-components/ButtonLink.vue").then((d) => d.default),
+        ResponsiveVideo: () =>
+            import("@/lib-components/ResponsiveVideo.vue").then(
+                (d) => d.default
+            ),
     },
     mixins: [isInternalLink],
     props: {

--- a/src/lib-components/IconWithLink.vue
+++ b/src/lib-components/IconWithLink.vue
@@ -8,13 +8,11 @@
 </template>
 
 <script>
-import SmartLink from "@/lib-components/SmartLink"
-
-// SVGs
 export default {
     name: "IconWithLink",
     components: {
-        SmartLink,
+        SmartLink: () =>
+            import("@/lib-components/SmartLink.vue").then((d) => d.default),
         SvgIconConsultation: () =>
             import("ucla-library-design-tokens/assets/svgs/icon-chat.svg").then(
                 (d) => d.default

--- a/src/lib-components/IconWithLink.vue
+++ b/src/lib-components/IconWithLink.vue
@@ -9,81 +9,152 @@
 
 <script>
 import SmartLink from "@/lib-components/SmartLink"
-import SvgIconConsultation from "ucla-library-design-tokens/assets/svgs/icon-chat.svg"
-import SvgIconList from "ucla-library-design-tokens/assets/svgs/icon-list.svg"
-import SvgIconLocation from "ucla-library-design-tokens/assets/svgs/icon-location.svg"
-import SvgIconPhone from "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
-import SvgIconSearch from "ucla-library-design-tokens/assets/svgs/icon-search.svg"
-import SvgIconVirtual from "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
-import SvgIconHeadphones from "ucla-library-design-tokens/assets/svgs/icon-headphones.svg"
-import SvgIconVideo from "ucla-library-design-tokens/assets/svgs/icon-video.svg"
-import SvgIconImageStack from "ucla-library-design-tokens/assets/svgs/icon-image-stack.svg"
-import SvgIconMoney from "ucla-library-design-tokens/assets/svgs/icon-money.svg"
-import SvgIconMessage from "ucla-library-design-tokens/assets/svgs/icon-message.svg"
-import SvgIconPlay from "ucla-library-design-tokens/assets/svgs/icon-play.svg"
-import SvgIconPlayFilled from "ucla-library-design-tokens/assets/svgs/icon-play-filled.svg"
-import SvgIconEye from "ucla-library-design-tokens/assets/svgs/icon-eye.svg"
-import SvgIconCheck from "ucla-library-design-tokens/assets/svgs/icon-check.svg"
-import SvgIconEmail from "ucla-library-design-tokens/assets/svgs/icon-email.svg"
-import SvgIconCard from "ucla-library-design-tokens/assets/svgs/icon-card.svg"
-import SvgIconCalendar from "ucla-library-design-tokens/assets/svgs/icon-calendar.svg"
-import SvgIconLaptop from "ucla-library-design-tokens/assets/svgs/icon-laptop.svg"
-import SvgIconBook from "ucla-library-design-tokens/assets/svgs/icon-book.svg"
-import SvgIconLocker from "ucla-library-design-tokens/assets/svgs/icon-locker.svg"
-import SvgIconPerson from "ucla-library-design-tokens/assets/svgs/icon-person.svg"
-import SvgIconAccessible from "ucla-library-design-tokens/assets/svgs/icon-accessible.svg"
-import SvgIconClock from "ucla-library-design-tokens/assets/svgs/icon-clock.svg"
-import SvgIconChair from "ucla-library-design-tokens/assets/svgs/icon-chair.svg"
-import SvgIconLight from "ucla-library-design-tokens/assets/svgs/icon-light.svg"
-import SvgIconLocationFilled from "ucla-library-design-tokens/assets/svgs/icon-location-filled.svg"
-import SvgIconAlert from "ucla-library-design-tokens/assets/svgs/icon-alert.svg"
-import SvgIconShareEmail from "ucla-library-design-tokens/assets/svgs/icon-share-email.svg"
-import SvgIconSharePrinter from "ucla-library-design-tokens/assets/svgs/icon-share-printer.svg"
-import SvgIconShareFacebook from "ucla-library-design-tokens/assets/svgs/icon-share-facebook.svg"
-import SvgIconShareInstagram from "ucla-library-design-tokens/assets/svgs/icon-share-instagram.svg"
-import SvgIconShareLinkedin from "ucla-library-design-tokens/assets/svgs/icon-share-linkedin.svg"
-import SvgIconShareTwitter from "ucla-library-design-tokens/assets/svgs/icon-share-twitter.svg"
-import SvgIconShareWhatsapp from "ucla-library-design-tokens/assets/svgs/icon-share-whatsapp.svg"
+
 // SVGs
 export default {
     name: "IconWithLink",
     components: {
         SmartLink,
-        SvgIconConsultation,
-        SvgIconList,
-        SvgIconLocation,
-        SvgIconPhone,
-        SvgIconSearch,
-        SvgIconVirtual,
-        SvgIconHeadphones,
-        SvgIconVideo,
-        SvgIconImageStack,
-        SvgIconMoney,
-        SvgIconMessage,
-        SvgIconPlay,
-        SvgIconPlayFilled,
-        SvgIconEye,
-        SvgIconCheck,
-        SvgIconEmail,
-        SvgIconCard,
-        SvgIconCalendar,
-        SvgIconLaptop,
-        SvgIconBook,
-        SvgIconLocker,
-        SvgIconPerson,
-        SvgIconAccessible,
-        SvgIconClock,
-        SvgIconChair,
-        SvgIconLight,
-        SvgIconLocationFilled,
-        SvgIconAlert,
-        SvgIconShareEmail,
-        SvgIconSharePrinter,
-        SvgIconShareFacebook,
-        SvgIconShareInstagram,
-        SvgIconShareLinkedin,
-        SvgIconShareTwitter,
-        SvgIconShareWhatsapp,
+        SvgIconConsultation: () =>
+            import("ucla-library-design-tokens/assets/svgs/icon-chat.svg").then(
+                (d) => d.default
+            ),
+        SvgIconList: () =>
+            import("ucla-library-design-tokens/assets/svgs/icon-list.svg").then(
+                (d) => d.default
+            ),
+        SvgIconLocation: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-location.svg"
+            ).then((d) => d.default),
+        SvgIconPhone: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-phone.svg"
+            ).then((d) => d.default),
+        SvgIconSearch: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-search.svg"
+            ).then((d) => d.default),
+        SvgIconVirtual: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-virtual.svg"
+            ).then((d) => d.default),
+        SvgIconHeadphones: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-headphones.svg"
+            ).then((d) => d.default),
+        SvgIconVideo: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-video.svg"
+            ).then((d) => d.default),
+        SvgIconImageStack: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-image-stack.svg"
+            ).then((d) => d.default),
+        SvgIconMoney: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-money.svg"
+            ).then((d) => d.default),
+        SvgIconMessage: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-message.svg"
+            ).then((d) => d.default),
+        SvgIconPlay: () =>
+            import("ucla-library-design-tokens/assets/svgs/icon-play.svg").then(
+                (d) => d.default
+            ),
+        SvgIconPlayFilled: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-play-filled.svg"
+            ).then((d) => d.default),
+        SvgIconEye: () =>
+            import("ucla-library-design-tokens/assets/svgs/icon-eye.svg").then(
+                (d) => d.default
+            ),
+        SvgIconCheck: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-check.svg"
+            ).then((d) => d.default),
+        SvgIconEmail: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-email.svg"
+            ).then((d) => d.default),
+        SvgIconCard: () =>
+            import("ucla-library-design-tokens/assets/svgs/icon-card.svg").then(
+                (d) => d.default
+            ),
+        SvgIconCalendar: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-calendar.svg"
+            ).then((d) => d.default),
+        SvgIconLaptop: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-laptop.svg"
+            ).then((d) => d.default),
+        SvgIconBook: () =>
+            import("ucla-library-design-tokens/assets/svgs/icon-book.svg").then(
+                (d) => d.default
+            ),
+        SvgIconLocker: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-locker.svg"
+            ).then((d) => d.default),
+        SvgIconPerson: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-person.svg"
+            ).then((d) => d.default),
+        SvgIconAccessible: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-accessible.svg"
+            ).then((d) => d.default),
+        SvgIconClock: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-clock.svg"
+            ).then((d) => d.default),
+        SvgIconChair: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-chair.svg"
+            ).then((d) => d.default),
+        SvgIconLight: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-light.svg"
+            ).then((d) => d.default),
+        SvgIconLocationFilled: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-location-filled.svg"
+            ).then((d) => d.default),
+        SvgIconAlert: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-alert.svg"
+            ).then((d) => d.default),
+        SvgIconShareEmail: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-share-email.svg"
+            ).then((d) => d.default),
+        SvgIconSharePrinter: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-share-printer.svg"
+            ).then((d) => d.default),
+        SvgIconShareFacebook: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-share-facebook.svg"
+            ).then((d) => d.default),
+        SvgIconShareInstagram: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-share-instagram.svg"
+            ).then((d) => d.default),
+        SvgIconShareLinkedin: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-share-linkedin.svg"
+            ).then((d) => d.default),
+        SvgIconShareTwitter: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-share-twitter.svg"
+            ).then((d) => d.default),
+        SvgIconShareWhatsapp: () =>
+            import(
+                "ucla-library-design-tokens/assets/svgs/icon-share-whatsapp.svg"
+            ).then((d) => d.default),
     },
     props: {
         text: {

--- a/src/lib-components/IconWithLink.vue
+++ b/src/lib-components/IconWithLink.vue
@@ -8,11 +8,12 @@
 </template>
 
 <script>
+import SmartLink from "@/lib-components/SmartLink.vue"
+
 export default {
     name: "IconWithLink",
     components: {
-        SmartLink: () =>
-            import("@/lib-components/SmartLink.vue").then((d) => d.default),
+        SmartLink,
         SvgIconConsultation: () =>
             import("ucla-library-design-tokens/assets/svgs/icon-chat.svg").then(
                 (d) => d.default

--- a/src/lib-components/IconWithLink.vue
+++ b/src/lib-components/IconWithLink.vue
@@ -1,4 +1,4 @@
-<!-- <template>
+<template>
     <div class="icon-with-link">
         <smart-link :to="to" class="link">
             <component :is="iconName" class="icon" />
@@ -198,4 +198,4 @@ export default {
         }
     }
 }
-</style> -->
+</style>

--- a/src/lib-components/IconWithLink.vue
+++ b/src/lib-components/IconWithLink.vue
@@ -1,4 +1,4 @@
-<template>
+<!-- <template>
     <div class="icon-with-link">
         <smart-link :to="to" class="link">
             <component :is="iconName" class="icon" />
@@ -198,4 +198,4 @@ export default {
         }
     }
 }
-</style>
+</style> -->

--- a/src/lib-components/SectionStaffArticleList.vue
+++ b/src/lib-components/SectionStaffArticleList.vue
@@ -8,8 +8,8 @@
             />
             <div class="block-staff-article-list">
                 <block-staff-article-list
-                    v-for="item in items"
-                    :key="item.to"
+                    v-for="(item, index) in items"
+                    :key="index"
                     :image="item.image"
                     :to="item.to"
                     :category="item.category"

--- a/src/stories/SectionStaffArticleList.stories.js
+++ b/src/stories/SectionStaffArticleList.stories.js
@@ -1,10 +1,13 @@
 import SectionStaffArticleList from "@/lib-components/SectionStaffArticleList"
 import * as API from "@/stories/mock-api.json"
+// A storybook decorator that allows you to use routing-aware components in your stories
+import StoryRouter from "storybook-vue-router"
 
 // Storybook default settings
 export default {
     title: "SECTION / Staff / Article / List",
     component: SectionStaffArticleList,
+    decorators: [StoryRouter()],
 }
 
 const mock = [


### PR DESCRIPTION
Connected to [APPS-1758](https://jira.library.ucla.edu/browse/APPS-1758)

Lazy load components where needed in:

[BannerFeatured.vue ](https://github.com/UCLALibrary/library-website-nuxt/blob/main/components/BannerFeatured.vue#L141)
[BannerHeader.vue ](https://github.com/UCLALibrary/library-website-nuxt/blob/main/components/BannerHeader.vue#L193)
[BannerText.vue ](https://github.com/UCLALibrary/library-website-nuxt/blob/main/components/BannerText.vue#L157)
[BlockAmenities.vue ](https://github.com/UCLALibrary/library-website-nuxt/blob/main/components/BlockAmenities.vue#L30)
[ BlockCallToAction.vue  ](https://github.com/UCLALibrary/library-website-nuxt/blob/main/components/BlockCallToAction.vue#L26)
[BlockCardWithIllustration.vue](https://github.com/UCLALibrary/library-website-nuxt/blob/main/components/BlockCardWithIllustration.vue#L37)
[BlockHighlight.vue ](https://github.com/UCLALibrary/library-website-nuxt/blob/main/components/BlockHighlight.vue#L105)
BlockLocationListItem.vue
[BlockMediaWithText.vue ](https://github.com/UCLALibrary/library-website-nuxt/blob/main/components/BlockMediaWithText.vue#L115)
IconWithLink.vue