### PR TITLE
fix: add null checks

### DIFF
--- a/src/lib-components/Flexible/MediaGallery.vue
+++ b/src/lib-components/Flexible/MediaGallery.vue
@@ -13,7 +13,11 @@
             @closeModal="hideLightboxModal"
             @keydown.native.esc="hideLightboxModal"
         />
+
         <flexible-media-gallery-banner-image
+            v-if="
+                block.mediaGallery && block.mediaGallery[selectionIndex].image
+            "
             :image="block.mediaGallery[selectionIndex].image[0]"
             :n-items="nItems"
             :expanded="expandThumbnails"

--- a/src/mixins/getSectionName.js
+++ b/src/mixins/getSectionName.js
@@ -8,7 +8,9 @@ export default {
     methods: {
         getSectionName(uri = "") {
             let output = "default"
-
+            if (uri == null) {
+                return output // don't try string method .includes
+            }
             switch (true) {
                 case uri.includes("/help/"):
                 case uri.includes("/projects/"):


### PR DESCRIPTION
Connected to [APPS-1719](https://jira.library.ucla.edu/browse/APPS-1719)

**Component Updated:** src/lib-components/Flexible/MediaGallery.vue

**Notes:**

Add null check for getsection name for external resource on help topics page.
If someone accidentally adds video to media gallery it will not give 404

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


![image](https://user-images.githubusercontent.com/4259468/183779408-00d06b57-aa26-4fdf-8615-2611cc5d72e5.png)

![image](https://user-images.githubusercontent.com/4259468/183779485-07316120-0bf4-4b25-b128-bad569dd2082.png)
