### PR TITLE
ci: Lint PR labels and titles

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,3 +15,12 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  check_labels:
+    name: Check labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          any_of: breaking,documentation,enhancement,feature,performance,refactor,bugfix,fix,chore,ci,test,
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `agilepathway/label-checker` to `.github/workflows/lint-pr.yml` to require PR labels in addition to a semantic PR title