### PR TITLE
feat: add footerMain

### DIFF
--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -442,8 +442,16 @@
         />
         <hr />
 
-        <h2>Footer Sponsor MEAP</h2>
+        <h2>FooterSponsor MEAP</h2>
         <footer-sponsor :funders="mockFooterSponsor.funders" />
+        <hr />
+
+        <h2>FooterMain MEAP</h2>
+        <footer-main
+            :funders="mockFooterSponsor.funders"
+            :social-items="mockFooterPrimary.socialItems"
+            :press-items="mockFooterPrimary.pressItems"
+        />
         <hr />
 
         <h1>FlexibleBlock Components</h1>

--- a/src/lib-components/BlockSponsor.vue
+++ b/src/lib-components/BlockSponsor.vue
@@ -11,11 +11,13 @@
 
 <script>
 import ResponsiveImage from "@/lib-components/ResponsiveImage"
+import SmartLink from "@/lib-components/SmartLink.vue"
 
 export default {
     name: "BlockSponsor",
     components: {
         ResponsiveImage,
+        SmartLink,
     },
     props: {
         funderLogo: {

--- a/src/lib-components/FooterMain.vue
+++ b/src/lib-components/FooterMain.vue
@@ -1,0 +1,56 @@
+<template>
+    <footer  class="footer-main">
+        <footer-sponsor
+            v-if="funders"
+            :funders="funders"
+            class="sponsor"
+        />
+        <footer-primary 
+            :social-items="socialItems" 
+            :press-items="pressItems" 
+            :form="false" 
+            class="primary"
+        />
+        <footer-sock
+            class="sock"
+        />
+    </footer>
+</template>
+
+<script>
+import FooterSponsor from "@/lib-components/FooterSponsor"
+import FooterPrimary from "@/lib-components/FooterPrimary"
+import FooterSock from "@/lib-components/FooterSock"
+
+export default {
+    name: "FooterMain",
+    components: {
+        FooterSponsor,
+        FooterPrimary,
+        FooterSock
+    },
+    props: {
+        funders: {
+            type: Array,
+            default: () => [],
+        },
+        socialItems: {
+            type: Array,
+            default: () => [],
+        },
+        pressItems: {
+            type: Array,
+            default: () => [],
+        },
+        sock: {
+            type: Array,
+            default: () => [],
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.footer-main {
+}
+</style>

--- a/src/lib-components/FooterPrimary.vue
+++ b/src/lib-components/FooterPrimary.vue
@@ -1,5 +1,5 @@
 <template>
-    <footer class="footer-primary">
+    <div class="footer-primary">
         <svg-molecule-half class="molecule-half-svg" aria-hidden="true" />
         <div :class="classes">
             <div class="footer-links">
@@ -19,7 +19,7 @@
                     </li>
                 </ul>
 
-                <ul class="press-links">
+                <ul class="press-links" v-if="parsedPressItems">
                     <li
                         v-for="item in parsedPressItems"
                         :key="item.id"
@@ -60,7 +60,7 @@
                 </div>
             </form>
         </div>
-    </footer>
+    </div>
 </template>
 
 <script>

--- a/src/lib-components/FooterSock.vue
+++ b/src/lib-components/FooterSock.vue
@@ -1,5 +1,5 @@
 <template>
-    <footer class="footer-sock">
+    <div class="footer-sock">
         <div class="container">
             <div class="regents">
                 &#169; {{ year }} Regents of the University of California
@@ -17,7 +17,7 @@
                 </li>
             </ul>
         </div>
-    </footer>
+    </div>
 </template>
 
 <script>

--- a/src/lib-components/index.js
+++ b/src/lib-components/index.js
@@ -34,6 +34,7 @@ export { default as FooterPrimary } from "./FooterPrimary.vue"
 export { default as BlockSponsor } from "./BlockSponsor.vue"
 export { default as FooterSponsor } from "./FooterSponsor.vue"
 export { default as FooterSock } from "./FooterSock.vue"
+export { default as FooterMain } from "./FooterMain.vue"
 
 export { default as FlexibleBlocks } from "./FlexibleBlocks.vue"
 export { default as FlexibleAssociatedTopicCards } from "./Flexible/AssociatedTopicCards.vue"

--- a/src/stories/FooterMain.spec.js
+++ b/src/stories/FooterMain.spec.js
@@ -1,0 +1,9 @@
+describe("FOOTER / Main", () => {
+    it("Default", () => {
+        cy.visit("/iframe.html?id=footer-main--default&args=&viewMode=story")
+
+        cy.get(".footer-main").should("exist")
+
+        cy.percySnapshot("FOOTER / Main: Default")
+    })
+})

--- a/src/stories/FooterMain.stories.js
+++ b/src/stories/FooterMain.stories.js
@@ -1,0 +1,162 @@
+// Storybook default settings
+import Vue from "vue"
+import Vuex from "vuex"
+import FooterMain from "@/lib-components/FooterMain"
+import StoryRouter from "storybook-vue-router"
+
+Vue.use(Vuex)
+
+export default {
+    title: "FOOTER / Main",
+    component: FooterMain,
+    decorators: [StoryRouter()],
+}
+
+const mock = {
+    funders: [
+        {
+            id: "28231",
+            funderLogo: [
+                {
+                    id: "28636",
+                    src: "https://static.library.ucla.edu/craftassetstest/_fullscreen/logo-arcadia1.svg",
+                    height: 569,
+                    width: 2560,
+                    srcset: "https://static.library.ucla.edu/craftassetstest/_375xAUTO_crop_center-center_none/logo-arcadia1.svg 375w, https://static.library.ucla.edu/craftassetstest/_960xAUTO_crop_center-center_none/logo-arcadia1.svg 960w",
+                    alt: "Logo arcadia1",
+                    focalPoint: [0.5, 0.5],
+                    altText: null,
+                },
+            ],
+            funderName: "Hostess Cupcakes",
+            funderUrl:
+                "https://www.hostesscakes.com/products/cupcakes/chocolate/",
+        },
+        {
+            id: "28259",
+            funderLogo: [
+                {
+                    id: "28637",
+                    src: "https://static.library.ucla.edu/craftassetstest/_fullscreen/logo-library.svg",
+                    height: 490,
+                    width: 2560,
+                    srcset: "https://static.library.ucla.edu/craftassetstest/_375xAUTO_crop_center-center_none/logo-library.svg 375w, https://static.library.ucla.edu/craftassetstest/_960xAUTO_crop_center-center_none/logo-library.svg 960w, https://static.library.ucla.edu/craftassetstest/_1280xAUTO_crop_center-center_none/logo-library.svg 1280w, https://static.library.ucla.edu/craftassetstest/_1920xAUTO_crop_center-center_none/logo-library.svg 1920w, https://static.library.ucla.edu/craftassetstest/_2560xAUTO_crop_center-center_none/logo-library.svg 2560w",
+                    alt: "Etch-a-Sketch",
+                    focalPoint: [0.5, 0.5],
+                    altText: null,
+                },
+            ],
+            funderName: "Etch A Sketch",
+            funderUrl: "https://en.wikipedia.org/wiki/Etch_A_Sketch",
+        },
+    ],
+    socialItems: [
+        {
+            id: "11777",
+            name: "Twotter",
+            to: "https://twitter.com/",
+            classes: null,
+            target: "1",
+        },
+        {
+            id: "11778",
+            name: "Fatebook",
+            to: "https://www.facebook.com/",
+            classes: null,
+            target: "1",
+        },
+        {
+            id: "11779",
+            name: "Instagrim",
+            to: "https://www.instagram.com/",
+            classes: null,
+            target: "1",
+        },
+        {
+            id: "11780",
+            name: "FooTube",
+            to: "https://www.youtube.com/",
+            classes: null,
+            target: "1",
+        },
+    ],
+    pressItems: [
+        {
+            id: "11781",
+            name: "Dress to Depress",
+            to: "https://test-craft.library.ucla.edu/press-room",
+            classes: null,
+            target: "",
+        },
+        {
+            id: "11782",
+            name: "Careers at USC",
+            to: "https://test-craft.library.ucla.edu/careers-at-ucla",
+            classes: null,
+            target: "",
+        },
+    ],
+    sock: [
+        {
+            id: "1628",
+            name: "EEEmergency",
+            to: "https://test-craft.library.ucla.edu/emergency",
+            classes: null,
+            target: "",
+        },
+        {
+            id: "1627",
+            name: "AAAccessibility",
+            to: "https://test-craft.library.ucla.edu/accessibility",
+            classes: null,
+            target: "",
+        },
+        {
+            id: "1629",
+            name: "PPPrivacy & Terms of Use",
+            to: "https://test-craft.library.ucla.edu/privacy-terms-of-use",
+            classes: null,
+            target: "",
+        },
+        {
+            id: "9511",
+            name: "CCCreative Commons Attribution 4.0",
+            to: "https://creativecommons.org/licenses/by/4.0/",
+            classes: null,
+            target: "1",
+        },
+    ],
+}
+
+export const Default = () => ({
+    store: new Vuex.Store({
+        state: {
+            footerPrimary: {
+                nodes: [
+                    {
+                        children: mock.socialItems,
+                    },
+                    {
+                        children: mock.pressItems,
+                    },
+                ],
+            },
+            footerSock: {
+                nodes: mock.sock,
+            },
+        },
+    }),
+    components: { FooterMain },
+    data() {
+        return {
+            ...mock,
+        }
+    },
+
+    template: `
+        <footer-main
+            :funders="funders"
+            :social-items="socialItems"
+            :press-items="pressItems"
+        />`,
+})


### PR DESCRIPTION
Connected to [APPS-1778](https://jira.library.ucla.edu/browse/APPS-1778)

Currently FooterPrimary, FooterSock, and FooterSponsor are using the footer tag as the parent element. Instead, we need a single footer tag that includes each of these footer sections.

Acceptance criteria:

There is a single footer tag used as a container that can include the FooterPrimary, FooterSock and/or FooterSponsor