### PR TITLE
fix: Add focal point to responsive image

### DIFF
--- a/src/lib-components/Flexible/MediaGallery/BannerImage.vue
+++ b/src/lib-components/Flexible/MediaGallery/BannerImage.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="banner-image" @click="$emit('toggleThumbnails')">
-        <responsive-image :image="image" :aspect-ratio="60">
+        <responsive-image :image="image" :aspect-ratio="60" object-fit="cover">
             <div v-if="nItems > 1 && !expanded">
                 <div class="gradient" />
                 <svg-molecule-image-stack class="molecule-image-stack" />

--- a/src/lib-components/Flexible/MediaGallery/ThumbnailCard.vue
+++ b/src/lib-components/Flexible/MediaGallery/ThumbnailCard.vue
@@ -1,6 +1,11 @@
 <template>
     <div class="thumbnail-card">
-        <responsive-image :image="image" :aspect-ratio="60" class="image" />
+        <responsive-image
+            :image="image"
+            :aspect-ratio="60"
+            class="image"
+            object-fit="cover"
+        />
         <h3 class="caption-title" v-text="captionTitle" />
         <p class="caption-text" v-text="captionText" />
     </div>

--- a/src/lib-components/ResponsiveImage.vue
+++ b/src/lib-components/ResponsiveImage.vue
@@ -8,6 +8,7 @@
             :srcset="image.srcset || srcset"
             :sizes="image.sizes || sizes"
             :object-fit="objectFit"
+            :style="parsedFocalPoint"
             class="media"
             @load="onLoad"
             @error="onError"
@@ -74,6 +75,16 @@ export default {
         }
     },
     computed: {
+        parsedFocalPoint() {
+            let objectPosition = ""
+            if (this.image.focalPoint && this.image.focalPoint.length > 0) {
+                let points = this.image.focalPoint.map((obj) => {
+                    return obj * 100 + "%"
+                })
+                objectPosition = `object-position:${points.join(" ")}`
+            }
+            return objectPosition
+        },
         parsedAspectRatio() {
             const height = this.image.height || this.height
             const width = this.image.width || this.width

--- a/src/stories/MediaGallery_ThumbnailCard.stories.js
+++ b/src/stories/MediaGallery_ThumbnailCard.stories.js
@@ -12,6 +12,23 @@ const mock = {
     image: API.image,
 }
 
+const mockFocalPoint = {
+    id: "43141",
+    captionTitle: "Ramakatane archive 15",
+    captionText:
+        "Man standing with foot on stool wearing a panama hat and sandals with coat in hand, photographed in Mr. M.T. Ramakatane's City Centre Studio",
+    sortOrder: 5,
+    image: {
+        id: "42883",
+        src: "https://static.library.ucla.edu/craftassetsprod/images/_fullscreen/Ramakatane-archive-15.jpeg",
+        height: 2547,
+        width: 2560,
+        srcset: "https://static.library.ucla.edu/craftassetsprod/images/_375xAUTO_crop_center-center_none/Ramakatane-archive-15.jpeg 375w, https://static.library.ucla.edu/craftassetsprod/images/_960xAUTO_crop_center-center_none/Ramakatane-archive-15.jpeg 960w, https://static.library.ucla.edu/craftassetsprod/images/_1280xAUTO_crop_center-center_none/Ramakatane-archive-15.jpeg 1280w, https://static.library.ucla.edu/craftassetsprod/images/_1920xAUTO_crop_center-center_none/Ramakatane-archive-15.jpeg 1920w, https://static.library.ucla.edu/craftassetsprod/images/_2560xAUTO_crop_center-center_none/Ramakatane-archive-15.jpeg 2560w",
+        alt: "Ramakatane archive 15",
+        focalPoint: [0.5599, 0.3008],
+        altText: "Ramakatane archive 15",
+    },
+}
 // Variations of stories below
 export const Default = () => ({
     data() {
@@ -26,4 +43,19 @@ export const Default = () => ({
         :caption-text="image.alt"
       />
   `,
+})
+
+export const FocalPoint = () => ({
+    data() {
+        return { ...mockFocalPoint }
+    },
+    components: { FlexibleMediaGalleryThumbnailCard },
+    template: `
+    <flexible-media-gallery-thumbnail-card
+      style="max-width: 400px"
+      :image="image"
+      :caption-title="captionTitle"
+      :caption-text="captionText"
+    />
+`,
 })

--- a/src/stories/mock-api.json
+++ b/src/stories/mock-api.json
@@ -7,7 +7,8 @@
         "title": "Lorem ipsum",
         "caption": "Lorem ipsum",
         "height": 1080,
-        "width": 1920
+        "width": 1920,
+        "focalPoint":[0.5,0.5]
     },
     "images": [
         {


### PR DESCRIPTION
Connected to [APPS-1804](https://jira.library.ucla.edu/browse/APPS-1804)

Add focalPoint from craft image data as object-position css property.

https://deploy-preview-122--ucla-library-storybook.netlify.app/?path=/story/media-gallery-thumbnail-card--focal-point



