### PR TITLE
ci: Add storybook deploy on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,19 @@ jobs:
         path: storybook-static
         key: storybook-${{ github.sha }}
     - run: npm run build-storybook
+    - name: Deploy to Netlify (merged)
+      if: github.ref_name=='main'
+      uses: nwtgck/actions-netlify@b7c1504e00c6b8a249d1848cc1b522a4865eed99 # v1.2.3
+      with:
+        production-deploy: true
+        deploy-message: https://github.com/UCLALibrary/ucla-library-website-component/commit/${{ github.sha }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        publish-dir: './storybook-static'
+        fails-without-credentials: true
+        github-deployment-environment: test
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_STORYBOOK }}
     - name: Deploy to Netlify (preview)
       if: github.ref_name!='main'
       uses: nwtgck/actions-netlify@b7c1504e00c6b8a249d1848cc1b522a4865eed99 # v1.2.3


### PR DESCRIPTION
Connected to [APPS-1820](https://jira.library.ucla.edu/browse/APPS-1820)

**Notes:**

GH Action ci.yml updated to deploy storybook to Netlify on merge to main.

