### PR TITLE
fix: SectionWrapper child component margins

### DIFF
--- a/src/lib-components/SectionWrapper.vue
+++ b/src/lib-components/SectionWrapper.vue
@@ -64,7 +64,7 @@ export default {
     }
     .section-summary {
         @include step-0;
-        margin-top: var(--space-m);
+        margin-bottom: var(--space-m);
 
         ::v-deep p {
             margin: 0;
@@ -72,10 +72,19 @@ export default {
     }
 
     // Configure spacing of child components (individual components might override things like max-width)
-    * {
+    > * {
         max-width: #{$container-l-main}px;
         padding: 0;
-        margin: 0 auto;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    > :first-child {
+        margin-top: 0;
+    }
+
+    > :last-child {
+        margin-bottom: 0;
     }
 }
 </style>


### PR DESCRIPTION
- all margins: set only for child components, instead of all children
- vertical margins: only set top of first child, bottom of last, so we don't override spacing between elements within the section-wrapper