### PR TITLE
feat: adds development text to footer-sponsor

### DIFF
--- a/src/lib-components/FlexibleBlocks.vue
+++ b/src/lib-components/FlexibleBlocks.vue
@@ -3,7 +3,7 @@
         <h2 class="more-information">More Information</h2>
         <div v-for="(block, index) in parsedBlocks" :key="index">
             <section-wrapper v-if="block.needsDivider" theme="divider"
-                ><DividerGeneral
+                ><DividerWayFinder
             /></section-wrapper>
             <section-wrapper :theme="block.theme">
                 <component
@@ -20,7 +20,7 @@
 // Helpers
 import _kebabCase from "lodash/kebabCase"
 import SectionWrapper from "./SectionWrapper.vue"
-import DividerGeneral from "./DividerGeneral.vue"
+import DividerWayFinder from "./DividerWayFinder.vue"
 
 const NEVER_GRAY = [
     "flexible-associated-topic-cards",
@@ -89,7 +89,7 @@ export default {
             import("@/lib-components/Flexible/AssociatedTopicCards.vue").then(
                 (d) => d.default
             ),
-        DividerGeneral,
+        DividerWayFinder,
     },
 
     props: {

--- a/src/lib-components/FooterSponsor.vue
+++ b/src/lib-components/FooterSponsor.vue
@@ -1,14 +1,18 @@
 <template>
     <div class="footer-sponsor">
-        <block-sponsor
-            v-for="(item, index) in parsedFunders"
-            :key="index"
-            class="sponsor-item"
-            :funderLogo="item.funderLogo"
-            :funderName="item.funderName"
-            :funderUrl="item.funderUrl"
-        />
-    </div>
+        <div class="sponsor-text"> Text TK from Development, program generously supported by
+            </div>
+        <div class="sponsor-logos">
+            <block-sponsor
+                v-for="(item, index) in parsedFunders"
+                :key="index"
+                class="sponsor-item"
+                :funderLogo="item.funderLogo"
+                :funderName="item.funderName"
+                :funderUrl="item.funderUrl"
+            />
+            </div>
+   </div>
 </template>
 
 <script>
@@ -40,32 +44,49 @@ export default {
 
 <style lang="scss" scoped>
 .footer-sponsor {
-    max-width: 100%;
     background-color: var(--color-secondary-grey-01);
-    padding: 64px;
-
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xl);
+    justify-content: center;
+    padding: 0 var(--unit-gutter);
+}
+.sponsor-text {
+    @include overline;
+    line-height: $line-height-0;
+    color: var(--color-secondary-grey-05);
+    padding-top: 64px;
+    text-align: center;
+}
+.sponsor-logos {
+    max-width: 100%;
+    padding-bottom: 64px;
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
     justify-content: center;
     align-content: space-between;
-    gap: var(--space-l);
+    gap: var(--space-xl);
     .sponsor-item {
         width: 100%;
     }
+}
 
-    // Breakpoints
-    @media #{$medium} {
-        display: flex;
+// Breakpoints
+@media #{$medium} {
+    .sponsor-logos {
         flex-direction: column;
-        padding: 24px 32px;
+        padding-bottom: 32px;
     }
+    .sponsor-text {
+        padding-top: 32px;
+    }
+}
 
-    @media #{$small} {
-        display: flex;
+@media #{$small} {
+    .sponsor-logos {
         flex-direction: column;
         align-content: space-between;
-        gap: var(--space-l);
     }
 }
 </style>


### PR DESCRIPTION
Connected to [UX-692](https://jira.library.ucla.edu/browse/UX-692)

Adds text (to come from development, will be the same for all microsites) to FooterSponsor


**Checklist:**

-   [/] I checked that it is working locally in the dev server
-   [/] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [/] I added a screenshot of it working
-   [/] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [/] I used a conventional commit message
-   [/] I assigned myself to this PR
- 
<img width="1030" alt="Screen Shot 2022-08-25 at 3 50 54 PM" src="https://user-images.githubusercontent.com/44713143/186782331-942f9b08-1ac6-4435-8bf7-78e63580c04a.png">

