### PR TITLE
fix: replace p tag with div and replace v-html to v-text in some cases

### DIFF
--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -81,7 +81,7 @@
                 </div>
             </div>
             <!-- changing p tag to div fixes nodemismatch errors -->
-            <p v-if="text" class="text" v-html="text" />
+            <div v-if="text" class="text" v-text="text" />
         </div>
     </li>
 </template>

--- a/src/lib-components/BlockSpaces.vue
+++ b/src/lib-components/BlockSpaces.vue
@@ -13,7 +13,7 @@
                 <h3 v-else class="space-title-no-link" v-html="title" />
             </div>
             <div class="meta">
-                <p class="text" v-html="text" />
+                <div class="text" v-text="text" />
                 <!-- if no buttonUrl -  do not display button -->
                 <button-link
                     v-if="to"

--- a/src/lib-components/IconWithLink.vue
+++ b/src/lib-components/IconWithLink.vue
@@ -2,11 +2,11 @@
     <div class="icon-with-link">
         <smart-link :to="to" class="icon-with-link-container link" v-if="to">
             <component :is="iconName" class="icon" aria-hidden="true" />
-            <span class="text" v-html="text" />
+            <div class="text" v-text="text" />
         </smart-link>
         <div v-else class="icon-with-link-container">
             <component :is="iconName" class="icon" aria-hidden="true" />
-            <span class="text" v-html="text" />
+            <div class="text" v-text="text" />
         </div>
     </div>
 </template>

--- a/src/lib-components/SectionWrapper.vue
+++ b/src/lib-components/SectionWrapper.vue
@@ -1,7 +1,11 @@
 <template>
     <section :class="classes">
         <div v-if="sectionTitle" class="section-header">
-            <h2 v-if="sectionTitle" class="section-title" v-text="sectionTitle" />
+            <h2
+                v-if="sectionTitle"
+                class="section-title"
+                v-text="sectionTitle"
+            />
             <p
                 v-if="sectionSummary"
                 class="section-summary"


### PR DESCRIPTION
Connected to [APPS-1839](https://jira.library.ucla.edu/browse/APPS-1839)

**Notes:**

Replaced p tag with div and replace v-html to v-text in some cases.

Files changed:

- src/lib-components/BlockHighlight.vue
- src/lib-components/BlockSpaces.vue
- src/lib-components/IconWithLink.vue
- src/lib-components/SectionWrapper.vue

It's ideal to not use v-html anywhere. https://eslint.vuejs.org/rules/no-v-html.html

![image](https://user-images.githubusercontent.com/47605309/186976119-b309f672-9044-4c07-a9f9-a2d02145fea1.png)

![image](https://user-images.githubusercontent.com/47605309/186976255-aa477340-bf8c-4194-9a28-227303a272c9.png)

![image](https://user-images.githubusercontent.com/47605309/186976188-40371433-6930-4ea7-aa86-6e4897ca9d4e.png)

![image](https://user-images.githubusercontent.com/47605309/186976088-8ecd9bb2-12fb-4417-abf9-7e7e8250b37d.png)



**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR
