### PR TITLE
fix: v-text to v-html

### DIFF
--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -81,7 +81,7 @@
                 </div>
             </div>
             <!-- changing p tag to div fixes nodemismatch errors -->
-            <div v-if="text" class="text" v-text="text" />
+            <div v-if="text" class="text" v-html="text" />
         </div>
     </li>
 </template>

--- a/src/stories/BlockHighlight.stories.js
+++ b/src/stories/BlockHighlight.stories.js
@@ -28,7 +28,7 @@ const mock = {
     title: "Fames ac turpis egestas sed tempus",
     startDate: "2022-03-31T07:00:00+00:00",
     endDate: "2021-11-26T11:00:00-08:00",
-    text: "Mauris rhoncus aenean vel elit scelerisque mauris pellentesque pulvinar. Egestas integer eget aliquet nibh praesent tristique. Quis imperdiet massa tincidunt nunc pulvinar sapien.",
+    text: "<p>La Niña is an oceanic and atmospheric phenomenon that is the colder counterpart of El Niño, as part of the broader El Niño–Southern Oscillation climate pattern.</p>",
     imageAspectRatio: 60,
     locations: [
         { title: "Powellarium", to: "/location/bar" },


### PR DESCRIPTION
fix: v-text to v-html

Added html to story as an example

bug seen on meap site where rich text was not being transformed to html 
![Screen Shot 2022-08-26 at 3 37 39 PM](https://user-images.githubusercontent.com/34147754/186999598-85da0877-5821-4494-9db0-1f50289241b0.png)

