### PR TITLE
fix: keyboard tab key use and acronym

### DIFF
--- a/src/lib-components/HeaderMainResponsive.vue
+++ b/src/lib-components/HeaderMainResponsive.vue
@@ -1,8 +1,15 @@
 <template>
     <nav role="navigation" aria-label="Menu" :class="classes">
         <div v-if="!isOpened" class="collapsed-menu">
-            <router-link to="/" :aria-label="parseAriaLabel">
-                <h1 v-if="title" class="title">{{ title }}</h1>
+            <router-link
+                class="clickable-parent"
+                to="/"
+                :aria-label="parseAriaLabel"
+            >
+                <h1 v-if="title" class="title">
+                    <span class="full-title"> {{ title }} </span>
+                    <span class="acronym" v-if="acronym"> {{ acronym }} </span>
+                </h1>
                 <component
                     v-else
                     :is="`LogoLibrary`"
@@ -23,8 +30,18 @@
         </div>
         <div v-else class="expanded-menu-container">
             <div class="expanded-menu">
-                <router-link to="/" :aria-label="parseAriaLabel">
-                    <h1 v-if="title" class="title opened-title">{{ title }}</h1>
+                <router-link
+                    class="clickable-parent"
+                    to="/"
+                    :aria-label="parseAriaLabel"
+                    @click.native="toggleMenu"
+                >
+                    <h1 v-if="title" class="title opened-title">
+                        <span class="full-title"> {{ title }} </span>
+                        <span class="acronym" v-if="acronym">
+                            {{ acronym }}
+                        </span>
+                    </h1>
                     <component
                         v-else
                         :is="`LogoLibrary`"
@@ -153,6 +170,10 @@ export default {
             type: String,
             default: "",
         },
+        acronym: {
+            type: String,
+            default: "",
+        },
     },
     data() {
         return {
@@ -168,6 +189,7 @@ export default {
                 "header-main-responsive",
                 this.isOpened ? "fullHeight" : "collapsedHeight",
                 { "has-title": this.title },
+                { "has-acronym": this.acronym },
             ]
         },
         parseAriaLabel() {
@@ -330,8 +352,16 @@ export default {
 
     .nav-menu-primary {
         margin: 64px var(--unit-gutter);
+        z-index: 10;
+        position: relative;
+    }
+    &.has-acronym .acronym {
+        display: none;
     }
     &.has-title {
+        .clickable-parent {
+            position: relative;
+        }
         .title {
             font-family: "Karbon", Helvetica, Arial, sans-serif;
             font-size: var(--step-1);
@@ -340,6 +370,8 @@ export default {
             color: var(--color-primary-blue-03);
             text-transform: initial;
             letter-spacing: normal;
+            @include min-clickable-area;
+
             &.opened-title {
                 color: white;
             }
@@ -427,6 +459,14 @@ export default {
     }
 
     @media #{$medium} {
+        &.has-acronym {
+            .full-title {
+                display: none;
+            }
+            .acronym {
+                display: block;
+            }
+        }
         .collapsed-menu {
             --unit-gutter: 24px;
         }

--- a/src/lib-components/NavMenuItem.vue
+++ b/src/lib-components/NavMenuItem.vue
@@ -1,6 +1,6 @@
 <template>
     <li :class="classes">
-        <span class="section-name" v-html="item.name" />
+        <button class="section-name" v-html="item.name" />
 
         <ul class="sub-menu">
             <li
@@ -90,6 +90,7 @@ export default {
         letter-spacing: 0.1em;
         cursor: pointer;
         position: relative;
+        width: 100%;
 
         &::after {
             content: "";
@@ -136,6 +137,9 @@ export default {
     .sub-menu-link {
         padding: 12px 32px;
         display: block;
+    }
+    .sub-menu-link:focus {
+        border: 1px solid white;
     }
 
     // States

--- a/src/lib-components/NavMenuItemResponsive.vue
+++ b/src/lib-components/NavMenuItemResponsive.vue
@@ -1,11 +1,12 @@
 <template>
     <li class="nav-menu-item">
-        <span
+        <button
             class="section-name block"
             :data-sub-menu-title-id="index"
             @click="toggleItem(index)"
-            >{{ item.name }}</span
         >
+            {{ item.name }}
+        </button>
 
         <ul :data-sub-menu-item-id="index" class="sub-menu hidden">
             <li
@@ -66,7 +67,7 @@ export default {
     watch: {
         goBack: function (newVal) {
             // console.log("goback value updated " + newVal)
-            this.resetAccordion()
+            if (newVal) this.resetAccordion()
         },
     },
     methods: {
@@ -107,6 +108,7 @@ export default {
         },
         resetAccordion() {
             // this.$emit("shouldOpen")
+
             const subMenuTitleElement = document.querySelectorAll(
                 "[data-sub-menu-title-id]"
             )
@@ -133,6 +135,7 @@ export default {
 .nav-menu-item {
     margin: 0;
     padding: 0;
+    position: relative;
 
     // Top level menu
     .section-name {
@@ -147,6 +150,7 @@ export default {
         position: relative;
         color: white;
         cursor: pointer;
+        @include min-clickable-area;
 
         &.block {
             display: block;

--- a/src/lib-components/NavPrimary.vue
+++ b/src/lib-components/NavPrimary.vue
@@ -1,11 +1,14 @@
 <template>
-    <nav :class="classes">
+    <nav aria-label="Primary  Navigation" :class="classes">
         <div class="item-top">
             <router-link
                 to="/"
                 :aria-label="title ? '' : `UCLA Library home page`"
             >
-                <h1 v-if="title" class="title">{{ title }}</h1>
+                <h1 v-if="title" class="title">
+                    <span class="full-title"> {{ title }} </span>
+                    <span class="acronym" v-if="acronym"> {{ acronym }} </span>
+                </h1>
                 <svg-logo-ucla-library
                     v-else
                     class="svg logo-ucla"
@@ -87,6 +90,10 @@ export default {
             type: String,
             default: "",
         },
+        acronym: {
+            type: String,
+            default: "",
+        },
     },
     data() {
         return {
@@ -101,6 +108,7 @@ export default {
                 { "is-opened": this.isOpened },
                 { "not-hovered": this.activeMenuIndex == -1 },
                 { "has-title": this.title },
+                { "has-acronym": this.acronym },
             ]
         },
         noChildren() {
@@ -270,10 +278,10 @@ export default {
         width: 100%;
         z-index: -10;
     }
+    &.has-acronym .acronym {
+        display: none;
+    }
     &.has-title {
-        .background-blue {
-            height: 110%;
-        }
         .nochildren-links {
             margin: 0 5px;
             padding: 0;
@@ -315,12 +323,12 @@ export default {
 
     // Hover states
     @media (max-width: 1330px) {
-        &.has-title {
-            .title {
-                width: 98px;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
+        &.has-acronym {
+            .full-title {
+                display: none;
+            }
+            .acronym {
+                display: block;
             }
         }
     }

--- a/src/lib-components/NavSecondary.vue
+++ b/src/lib-components/NavSecondary.vue
@@ -1,5 +1,5 @@
 <template>
-    <nav class="nav-secondary">
+    <nav aria-label="Secondary Navigation" class="nav-secondary">
         <div :class="classes">
             <router-link
                 to="/"

--- a/src/stories/HeaderMainResponsive.stories.js
+++ b/src/stories/HeaderMainResponsive.stories.js
@@ -251,6 +251,7 @@ export const Microsite = () => ({
         :secondary-nav="parsedSecondaryItems"
         current-path="/about/foo/bar"
         title="Modern Endangered Archives Program"
+        acronym="MEAP"
     />
     `,
 })

--- a/src/stories/NavPrimary.stories.js
+++ b/src/stories/NavPrimary.stories.js
@@ -116,7 +116,7 @@ const micrositeItems = [
     },
     {
         id: "25359",
-        name: "Funded Projects",
+        name: "Projects",
         to: null,
         classes: "",
         target: "",
@@ -188,6 +188,7 @@ export const WithMicrositeTitle = () => ({
             :items="micrositeItems"
             current-path="/about/foo/bar"
             title="Modern Endangered Archives Program"
+            acronym="MEAP"
         />
     `,
 })


### PR DESCRIPTION
Connected to [APPS-1843](https://jira.library.ucla.edu/browse/APPS-1843)

	modified:   src/lib-components/HeaderMainResponsive.vue
	modified:   src/lib-components/NavMenuItem.vue
	modified:   src/lib-components/NavMenuItemResponsive.vue
	modified:   src/lib-components/NavPrimary.vue
	modified:   src/lib-components/NavSecondary.vue
	modified:   src/stories/HeaderMainResponsive.stories.js
	modified:   src/stories/NavPrimary.stories.js

**Notes:**

This will fix the keyboard tab use in the navigation on the desktop. Also will add acronym support on smaller viewports.

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR
