### PR TITLE
fix: update mixin

### DIFF
--- a/src/mixins/getParentPageUrl.js
+++ b/src/mixins/getParentPageUrl.js
@@ -8,7 +8,8 @@ export default {
     methods: {
         getParentPageUrl(uri = "") {
             let output = uri.split("/")
-            if (output[0] === "") {
+            console.log(output)
+            if (output.length === 2) {
                 return "/"
             } else {
                 output.pop()

--- a/src/mixins/getParentPageUrl.js
+++ b/src/mixins/getParentPageUrl.js
@@ -1,6 +1,7 @@
 export default {
     /**
      * Take a URI and figure out what "section" of the site it is pointing too
+     * If output = ["", "page"] then the parent page is the homepage
      * @param {String} uri
      * @returns {String}
      */
@@ -8,7 +9,6 @@ export default {
     methods: {
         getParentPageUrl(uri = "") {
             let output = uri.split("/")
-            console.log(output)
             if (output.length === 2) {
                 return "/"
             } else {


### PR DESCRIPTION
Update logic of parent page url 
When `output` array length is equal to 2 (like ["", "page"] then the parent page is the homepage)