### PR TITLE
fix: flexible blocks' last item is always white

### DIFF
--- a/src/lib-components/FlexibleBlocks.vue
+++ b/src/lib-components/FlexibleBlocks.vue
@@ -104,7 +104,7 @@ export default {
             let output = this.blocks
                 .map((obj) => {
                     // Normalize componentName
-                    console.log(obj)
+                    // console.log(obj)
                     return {
                         ...obj,
                         componentName: convertName(obj.typeHandle),
@@ -124,7 +124,7 @@ export default {
                 } else {
                     output[index].theme = "white"
                 }
-
+                output[output.length - 1].theme = "white"
                 output[index].needsDivider =
                     index > 0 &&
                     output[index].theme == "white" &&
@@ -132,6 +132,11 @@ export default {
                         ? true
                         : false
             }
+            // Last flexible block will always be white
+
+            console.log(
+                "this is last item" + JSON.stringify(output[output.length - 1])
+            )
             return output
         },
         registeredComponents() {

--- a/src/lib-components/FlexibleBlocks.vue
+++ b/src/lib-components/FlexibleBlocks.vue
@@ -104,7 +104,6 @@ export default {
             let output = this.blocks
                 .map((obj) => {
                     // Normalize componentName
-                    // console.log(obj)
                     return {
                         ...obj,
                         componentName: convertName(obj.typeHandle),

--- a/src/lib-components/FlexibleBlocks.vue
+++ b/src/lib-components/FlexibleBlocks.vue
@@ -123,6 +123,7 @@ export default {
                 } else {
                     output[index].theme = "white"
                 }
+                // Last flexible block will always be white
                 output[output.length - 1].theme = "white"
                 output[index].needsDivider =
                     index > 0 &&
@@ -131,11 +132,7 @@ export default {
                         ? true
                         : false
             }
-            // Last flexible block will always be white
 
-            console.log(
-                "this is last item" + JSON.stringify(output[output.length - 1])
-            )
             return output
         },
         registeredComponents() {

--- a/src/stories/FlexibleBlocks.stories.js
+++ b/src/stories/FlexibleBlocks.stories.js
@@ -65,6 +65,7 @@ export const GrayBackgrounds = () => ({
                 },
                 mockRichText,
                 mockRichText,
+                mockCardWithImage,
             ],
         }
     },

--- a/src/stories/FlexibleBlocks.stories.js
+++ b/src/stories/FlexibleBlocks.stories.js
@@ -59,6 +59,11 @@ export const GrayBackgrounds = () => ({
                     typeHandle: "rich-text",
                     richText: "<h4>FlexibleRichText</h4>",
                 },
+                {
+                    typeHandle: "rich-text",
+                    richText: "<h4>FlexibleRichText</h4>",
+                },
+                mockRichText,
                 mockRichText,
             ],
         }


### PR DESCRIPTION
Connected to [APPS-1872](https://jira.library.ucla.edu/browse/APPS-1872)

fix: flexible blocks' last item is always white
![Screen Shot 2022-09-01 at 12 54 12 PM](https://user-images.githubusercontent.com/34147754/188000763-a19049c8-0c9f-4bf0-8346-070f8b328d6a.png)
