### PR TITLE
fix: add default image to BlockStaffArticleList

### DIFF
--- a/src/lib-components/BlockStaffArticleList.vue
+++ b/src/lib-components/BlockStaffArticleList.vue
@@ -8,7 +8,7 @@
             class="image"
         />
         <div v-else class="molecule-no-image">
-            <molecue-placeholder class="molecule" aria-hidden="true" />
+            <molecule-placeholder class="molecule" aria-hidden="true" />
         </div>
         <div class="meta">
             <div class="category" v-html="category" />
@@ -32,7 +32,7 @@
 <script>
 import format from "date-fns/format"
 import ResponsiveImage from "@/lib-components/ResponsiveImage"
-import MolecuePlaceholder from "ucla-library-design-tokens/assets/svgs/molecule-placeholder.svg"
+import MoleculePlaceholder from "ucla-library-design-tokens/assets/svgs/molecule-placeholder.svg"
 
 export default {
     name: "BlockStaffArticleList",

--- a/src/lib-components/BlockStaffArticleList.vue
+++ b/src/lib-components/BlockStaffArticleList.vue
@@ -1,19 +1,21 @@
 <template>
     <li class="block-staff-article-item">
         <responsive-image
+            v-if="imageExists"
             :image="image"
             :aspect-ratio="imageAspectRatio"
             :object-fit="cover"
             class="image"
         />
+        <div v-else class="molecule-no-image">
+            <molecue-placeholder class="molecule" aria-hidden="true" />
+        </div>
         <div class="meta">
             <div class="category" v-html="category" />
             <router-link class="title" :to="to" v-html="title" />
-            <!--eslint-disable vue/no-use-v-if-with-v-for-->
-            <div class="byline">
+            <div class="byline" v-if="authors || date">
                 <div
                     v-for="author in authors"
-                    v-if="authors"
                     :key="author.id"
                     class="author"
                     v-html="author.title"
@@ -30,11 +32,13 @@
 <script>
 import format from "date-fns/format"
 import ResponsiveImage from "@/lib-components/ResponsiveImage"
+import MolecuePlaceholder from "ucla-library-design-tokens/assets/svgs/molecule-placeholder.svg"
 
 export default {
     name: "BlockStaffArticleList",
     components: {
         ResponsiveImage,
+        MolecuePlaceholder,
     },
     props: {
         image: {
@@ -74,6 +78,9 @@ export default {
         parsedDate() {
             return format(new Date(this.date), "MMMM d, Y")
         },
+        imageExists() {
+            return this.image && Object.keys(this.image) != 0 ? true : false
+        },
     },
 }
 </script>
@@ -94,6 +101,14 @@ export default {
     .image {
         width: 50%;
         margin-right: var(--space-xl);
+    }
+
+    .molecule-no-image {
+        width: 50%;
+        height: 240px;
+        margin-right: var(--space-xl);
+        background: var(--gradient-01);
+        overflow: hidden;
     }
 
     .meta {

--- a/src/lib-components/BlockStaffArticleList.vue
+++ b/src/lib-components/BlockStaffArticleList.vue
@@ -105,7 +105,7 @@ export default {
 
     .molecule-no-image {
         width: 50%;
-        height: 240px;
+        height: 272px;
         margin-right: var(--space-xl);
         background: var(--gradient-01);
         overflow: hidden;
@@ -174,11 +174,13 @@ export default {
         flex-direction: column;
         flex-wrap: wrap;
 
-        .image {
+        .image,
+        .molecule-no-image {
             width: 100%;
             margin-right: 0;
             margin-bottom: var(--space-l);
         }
+
         .meta {
             width: 100%;
 

--- a/src/lib-components/BlockStaffArticleList.vue
+++ b/src/lib-components/BlockStaffArticleList.vue
@@ -38,7 +38,7 @@ export default {
     name: "BlockStaffArticleList",
     components: {
         ResponsiveImage,
-        MolecuePlaceholder,
+        MoleculePlaceholder,
     },
     props: {
         image: {

--- a/src/stories/BlockStaffArticleList.stories.js
+++ b/src/stories/BlockStaffArticleList.stories.js
@@ -142,3 +142,21 @@ export const LongDescription = () => ({
       />
   `,
 })
+
+export const NoImage = () => ({
+    data() {
+        return { ...mock, image: {} }
+    },
+    components: { BlockStaffArticleList },
+    template: `
+      <block-staff-article-list
+          :image="image"
+          :to="to"
+          :category="category"
+          :title="title"
+          :date="date"
+          :authors="authors"
+          :description="description"
+      />
+  `,
+})


### PR DESCRIPTION
Connected to [APPS-1889](https://jira.library.ucla.edu/browse/APPS-1889)

fix: add default image to BlockStaffArticleList

<img width="1043" alt="Screen Shot 2022-09-06 at 5 47 53 PM" src="https://user-images.githubusercontent.com/34147754/188764991-19943d29-2cd7-42ca-afc8-b54ee5c769aa.png">
