### PR TITLE
fix: use the desktop Header in static build

### DIFF
--- a/src/lib-components/HeaderSmart.vue
+++ b/src/lib-components/HeaderSmart.vue
@@ -37,10 +37,12 @@ export default {
             return this.$store.state.header.secondary
         },
         isMobile() {
-            return this.$store.state.winWidth <= 1024 ? true : false
+            return this.$store.state.winWidth <= 1024
         },
         whichHeader() {
-            return this.isMobile ? "header-main-responsive" : "header-main"
+            return process.client && this.isMobile
+                ? "header-main-responsive"
+                : "header-main"
         },
     },
 }


### PR DESCRIPTION
fixes a bug where menu links were not included in the static render, and thus not crawled, leaving some pages undiscovered