### PR TITLE
fix: update navbreadcrumb

### DIFF
--- a/src/mixins/getMeapParentPageTitle.js
+++ b/src/mixins/getMeapParentPageTitle.js
@@ -14,7 +14,9 @@ export default {
                     output = "News"
                     break
 
-                case uri.includes("/about/") && !uri.includes("/news/"):
+                case uri.includes("/about/") &&
+                    !uri.includes("/news/") &&
+                    uri != "/about/":
                     output = "About"
                     break
 

--- a/src/mixins/getParentPageUrl.js
+++ b/src/mixins/getParentPageUrl.js
@@ -2,6 +2,7 @@ export default {
     /**
      * Take a URI and figure out what "section" of the site it is pointing too
      * If output = ["", "page"] then the parent page is the homepage
+     * If output = ["", "page", ""] then pop the last empty string off
      * @param {String} uri
      * @returns {String}
      */
@@ -9,11 +10,21 @@ export default {
     methods: {
         getParentPageUrl(uri = "") {
             let output = uri.split("/")
-            if (output.length === 2) {
-                return "/"
-            } else {
+            if (output[output.length - 1] === "") {
                 output.pop()
-                return output.join("/")
+                if (output.length === 2) {
+                    return "/"
+                } else {
+                    output.pop()
+                    return output.join("/")
+                }
+            } else {
+                if (output.length === 2) {
+                    return "/"
+                } else {
+                    output.pop()
+                    return output.join("/")
+                }
             }
         },
     },


### PR DESCRIPTION
Connected to [APPS-1892](https://jira.library.ucla.edu/browse/APPS-1892)

In static mode routes have a trailing slash appended to them. 
NavBreadcrumb should work for `/projects/justino-valentim-collection/` or `/projects/justino-valentim-collection`