### PR TITLE
fix: disappearing menus, part 2

### DIFF
--- a/src/lib-components/HeaderMainResponsive.vue
+++ b/src/lib-components/HeaderMainResponsive.vue
@@ -1,6 +1,6 @@
 <template>
     <nav role="navigation" aria-label="Menu" :class="classes">
-        <div v-if="!isOpened" class="collapsed-menu">
+        <div v-show="!isOpened" class="collapsed-menu">
             <router-link
                 class="clickable-parent"
                 to="/"
@@ -29,7 +29,7 @@
                 <component :is="`IconMenu`" class="hamburguer" />
             </button>
         </div>
-        <div v-else class="expanded-menu-container">
+        <div v-show="isOpened" class="expanded-menu-container">
             <div class="expanded-menu">
                 <router-link
                     class="clickable-parent"

--- a/src/lib-components/HeaderSmart.vue
+++ b/src/lib-components/HeaderSmart.vue
@@ -40,9 +40,7 @@ export default {
             return this.$store.state.winWidth <= 1024
         },
         whichHeader() {
-            return process.client && this.isMobile
-                ? "header-main-responsive"
-                : "header-main"
+            return this.isMobile ? "header-main-responsive" : "header-main"
         },
     },
 }


### PR DESCRIPTION
the previous fix, in HeaderSmart for the main site, was hydrating incorrectly, resulting in both nav headers appearing

this PR reverts changes to HeaderSmart and instead modifies HeaderMainResponsive to always render the menu content (but only show it when opened)

https://github.com/UCLALibrary/meap-website-nuxt/pull/88, which would have made the same bad fix to the MEAP site, has been cancelled unmerged. The improved HeaderMainResponsive is used in both sites.