### PR TITLE
feat: updates section-banner spacing

### DIFF
--- a/src/lib-components/SectionWrapper.vue
+++ b/src/lib-components/SectionWrapper.vue
@@ -53,6 +53,9 @@ export default {
     &.theme-white {
         padding: 0 var(--unit-gutter);
         margin: var(--space-3xl) auto;
+        &.section-banner {
+            margin-top: 0;
+        }
     }
 
     &.theme-divider {


### PR DESCRIPTION
Connected to [APPS-1904](https://jira.library.ucla.edu/browse/APPS-1904)

- Updates SectionWrapper with .section-banner styling to override margin-top on BannerHeader components
- Resolves spacing issue on MEAP News and Resource detail pages here at the component level

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
meap-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR

<img width="1314" alt="Screen Shot 2022-09-12 at 3 32 11 PM" src="https://user-images.githubusercontent.com/44713143/189770074-a40ec165-bb06-4e73-bfdd-cc398b4f335e.png">

