### PR TITLE
fix: APPS-1912 Update Byline in BannerHeader

### DIFF
--- a/src/lib-components/BannerHeader.vue
+++ b/src/lib-components/BannerHeader.vue
@@ -26,11 +26,6 @@
         <div class="meta">
             <h1 class="title" v-html="title" />
             <div class="meta-text">
-                <rich-text
-                    v-if="text"
-                    class="snippet"
-                    :rich-text-content="text"
-                />
                 <div class="byline" v-if="byline.length">
                     <div
                         v-for="(item, index) in byline"
@@ -109,6 +104,8 @@
                 :to="to"
             />
         </div>
+
+        <rich-text v-if="text" class="snippet" :rich-text-content="text" />
     </div>
 </template>
 

--- a/src/lib-components/BannerHeader.vue
+++ b/src/lib-components/BannerHeader.vue
@@ -509,10 +509,11 @@ export default {
     }
     .byline {
         display: flex;
-        flex-direction: row;
+        flex-direction: column;
         flex-wrap: nowrap;
-        align-items: center;
+        align-items: flex-start;
         margin-bottom: var(--space-m);
+        justify-content: space-evenly;
     }
     .byline-item,
     .schedule-item,
@@ -533,23 +534,6 @@ export default {
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
-    }
-    .schedule-item,
-    .byline-item {
-        &:after {
-            content: "|";
-            color: var(--color-secondary-grey-02);
-            margin: 0 10px;
-            height: 18px;
-            display: inline-block;
-            position: relative;
-        }
-        &:last-child {
-            margin-right: 0;
-        }
-        &:last-child:after {
-            display: none;
-        }
     }
 
     .contact-info-group {
@@ -598,19 +582,6 @@ export default {
         }
         .title {
             margin-top: var(--space-m);
-        }
-        .byline,
-        .schedule {
-            display: flex;
-            flex-direction: column;
-            padding-left: 0;
-            align-items: flex-start;
-        }
-        .schedule-item,
-        .byline-item {
-            &:after {
-                display: none;
-            }
         }
     }
     @media #{$medium} and (min-width: 928px) {

--- a/src/stories/BannerHeader.stories.js
+++ b/src/stories/BannerHeader.stories.js
@@ -190,14 +190,10 @@ const article = {
     dateCreated: "2022-02-09T10:57:46-08:00",
     byline: [
         {
-            id: "3062",
-            title: "Jen Diamond",
-            to: "",
+            title: " Written by Courtney Hoffner",
         },
         {
-            id: "3062",
-            title: "Courtney Hoffner",
-            to: "",
+            title: "Illustrations by Jen Diamond",
         },
     ],
     locations: [
@@ -213,6 +209,7 @@ const article = {
         },
     ],
     alignRight: true,
+    text: "Turtles are an order of reptiles known as Testudines, characterized by a shell developed mainly from their ribs. Turtles are groups, big ones and small ones.",
 }
 
 export const ArticleDetail = () => ({
@@ -229,6 +226,7 @@ export const ArticleDetail = () => ({
            :byline="byline"
            :dateCreated="dateCreated"
            :locations="locations"
+           :text="text"
        />
     `,
 })


### PR DESCRIPTION
Connected to [APPS-1912](https://jira.library.ucla.edu/browse/APPS-1912)

Stack the byline section for consistency across all BannerHeaders

<img width="1492" alt="Screen Shot 2022-09-15 at 2 43 34 PM" src="https://user-images.githubusercontent.com/751697/190514205-fcf4ec12-3505-494a-b43f-6fbc44ac9fee.png">

![Screen Shot 2022-09-15 at 2 41 46 PM](https://user-images.githubusercontent.com/751697/190513924-e2a8d97f-93a9-497a-a086-3d7ec7fef4e6.png)

