### PR TITLE
fix: clear focus when closing Nav menu

### DIFF
--- a/src/lib-components/NavPrimary.vue
+++ b/src/lib-components/NavPrimary.vue
@@ -159,6 +159,12 @@ export default {
     methods: {
         toggleMenu() {
             this.isOpened = !this.isOpened
+            if (!this.isOpened) {
+                // clear focus after clicking to allow menu to close
+                document.body.setAttribute("tabindex", "-1");
+                document.body.focus();
+                document.body.removeAttribute("tabindex");
+            }
         },
         setActive(index) {
             // On hover, set current active menu item


### PR DESCRIPTION
addresses a bug where, after selecting an item from the nav menu, that item received browser focus and so was rendered visible

before: https://6323a033c2a821125c629a06--ucla-library-storybook.netlify.app/?path=/story/nav-primary--default
after: https://deploy-preview-192--ucla-library-storybook.netlify.app/?path=/story/nav-primary--default