### PR TITLE
feat: MediaItem component

### DIFF
--- a/src/lib-components/Media/Item.vue
+++ b/src/lib-components/Media/Item.vue
@@ -1,0 +1,89 @@
+<template>
+    <component
+        :is="mediaComponent"
+        v-bind="mediaComponentProps"
+    />
+</template>
+
+<script>
+import pickBy from "lodash/pickBy"
+
+export default {
+    name: "ResponsiveMedia",
+    components: {
+        ResponsiveImage: () =>
+            import("@/lib-components/ResponsiveImage").then(
+                (d) => d.default
+            ),
+        ResponsiveVideo: () =>
+            import("@/lib-components/ResponsiveVideo").then(
+                (d) => d.default
+            ),
+    },
+    props: {
+        type: {type: String, default: ""},
+        
+        // the image / video / audio / embed
+        mediaItem: {type: Object, default: () => ({})},
+        
+        // sizing for the container (not the media item itself)
+        height: {type: Number, default: 0},
+        width: {type: Number, default: 0},
+        aspectRatio: {type: Number, default: 0},
+        
+        // Layout options
+        backgroundColor: {type: String, default: ""},
+        focalPoint: {type: Object, default: () => ({})},
+        mode: {type: String, default: "intrinsic-ratio"},
+        objectFit: {type: String, default: ""},
+        
+        // video options
+        controls: {type: Boolean, default: false},
+        loop: {type: Boolean, default: false},
+        muted: {type: Boolean, default: true},
+        playsinline: {type: Boolean, default: true},
+    },
+    data() {
+        return {
+            hasLoaded: false,
+            hasErrored: false,
+        }
+    },
+    computed: {
+        mediaComponent() {
+            return {
+                image: "ResponsiveImage",
+                video: "ResponsiveVideo",
+            }[this.mediaType]
+        },
+        mediaComponentProps() {
+            return {
+                ...pickBy(this.$props, (key, value) => value), // only truthy prop values
+                image: this.mediaItem, // name currently used for Image and Video
+            }
+        },
+        mediaType() {
+            if (this.type || this.mediaItem.type) {
+                return this.type
+            } else if (this.mediaItem.videoUrl) {
+                return "video"
+            } else if (this.mediaItem.src) {
+                return "image"
+            } else {
+                return "image"
+            }
+        },
+    },
+    methods: {
+        onLoad() {
+            this.hasLoaded = true
+        },
+        onError() {
+            this.hasErrored = true
+        },
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/lib-components/Media/Item.vue
+++ b/src/lib-components/Media/Item.vue
@@ -1,8 +1,5 @@
 <template>
-    <component
-        :is="mediaComponent"
-        v-bind="mediaComponentProps"
-    />
+    <component :is="mediaComponent" v-bind="mediaComponentProps" />
 </template>
 
 <script>
@@ -12,36 +9,32 @@ export default {
     name: "ResponsiveMedia",
     components: {
         ResponsiveImage: () =>
-            import("@/lib-components/ResponsiveImage").then(
-                (d) => d.default
-            ),
+            import("@/lib-components/ResponsiveImage").then((d) => d.default),
         ResponsiveVideo: () =>
-            import("@/lib-components/ResponsiveVideo").then(
-                (d) => d.default
-            ),
+            import("@/lib-components/ResponsiveVideo").then((d) => d.default),
     },
     props: {
-        type: {type: String, default: ""},
-        
+        type: { type: String, default: "" },
+
         // the image / video / audio / embed
-        mediaItem: {type: Object, default: () => ({})},
-        
+        mediaItem: { type: Object, default: () => ({}) },
+
         // sizing for the container (not the media item itself)
-        height: {type: Number, default: 0},
-        width: {type: Number, default: 0},
-        aspectRatio: {type: Number, default: 0},
-        
+        height: { type: Number, default: 0 },
+        width: { type: Number, default: 0 },
+        aspectRatio: { type: Number, default: 0 },
+
         // Layout options
-        backgroundColor: {type: String, default: ""},
-        focalPoint: {type: Object, default: () => ({})},
-        mode: {type: String, default: "intrinsic-ratio"},
-        objectFit: {type: String, default: ""},
-        
+        backgroundColor: { type: String, default: "" },
+        focalPoint: { type: Object, default: () => ({}) },
+        mode: { type: String, default: "intrinsic-ratio" },
+        objectFit: { type: String, default: "" },
+
         // video options
-        controls: {type: Boolean, default: false},
-        loop: {type: Boolean, default: false},
-        muted: {type: Boolean, default: true},
-        playsinline: {type: Boolean, default: true},
+        controls: { type: Boolean, default: false },
+        loop: { type: Boolean, default: false },
+        muted: { type: Boolean, default: true },
+        playsinline: { type: Boolean, default: true },
     },
     data() {
         return {
@@ -85,5 +78,4 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
-</style>
+<style lang="scss" scoped></style>

--- a/src/stories/MediaItem.spec.js
+++ b/src/stories/MediaItem.spec.js
@@ -1,0 +1,27 @@
+describe("GLOBAL / Media", () => {
+    describe("Image", () => {
+        before(() => {
+            cy.visit(
+                "/iframe.html?id=global-media-item--default"
+            )
+        })
+    
+        it("uses ResponsiveImage", () => {
+            cy.get(".responsive-image").should("exist")
+            cy.get(".responsive-video").should("not.exist")
+        })
+    })
+
+    describe("Video", () => {
+        before(() => {
+            cy.visit(
+                "/iframe.html?id=global-media-item--video"
+            )
+        })
+    
+        it("uses ResponsiveVideo", () => {
+            cy.get(".responsive-image").should("not.exist")
+            cy.get(".responsive-video").should("exist")
+        })
+    })
+})

--- a/src/stories/MediaItem.spec.js
+++ b/src/stories/MediaItem.spec.js
@@ -1,11 +1,9 @@
 describe("GLOBAL / Media", () => {
     describe("Image", () => {
         before(() => {
-            cy.visit(
-                "/iframe.html?id=global-media-item--default"
-            )
+            cy.visit("/iframe.html?id=global-media-item--default")
         })
-    
+
         it("uses ResponsiveImage", () => {
             cy.get(".responsive-image").should("exist")
             cy.get(".responsive-video").should("not.exist")
@@ -14,11 +12,9 @@ describe("GLOBAL / Media", () => {
 
     describe("Video", () => {
         before(() => {
-            cy.visit(
-                "/iframe.html?id=global-media-item--video"
-            )
+            cy.visit("/iframe.html?id=global-media-item--video")
         })
-    
+
         it("uses ResponsiveVideo", () => {
             cy.get(".responsive-image").should("not.exist")
             cy.get(".responsive-video").should("exist")

--- a/src/stories/MediaItem.stories.js
+++ b/src/stories/MediaItem.stories.js
@@ -1,0 +1,59 @@
+import MediaItem from "@/lib-components/Media/Item"
+
+// Import mock api data
+import * as API from "@/stories/mock-api.json"
+
+const Template = (args, { argTypes }) => ({
+    props: Object.keys(argTypes),
+    components: { MediaItem },
+    template: `<media-item v-bind="$props"/>`,
+})
+
+export default {
+    title: "GLOBAL / Media Item",
+    component: MediaItem,
+    argTypes: {
+      type: {
+        options: [null, 'image', 'video'],
+        control: { type: 'radio' },
+      },
+    },
+}
+
+// Variations of stories below
+export const Default = Template.bind({})
+Default.args = {
+    type: null,
+    mediaItem: API.image,
+}
+
+export const ImageSquareRatio = Template.bind({})
+ImageSquareRatio.args = {
+    type: null,
+    mediaItem: API.image,
+    aspectRatio: 100,
+}
+
+export const ImageObjectFitContain = Template.bind({})
+ImageObjectFitContain.args = {
+    type: null,
+    mediaItem: API.image,
+    aspectRatio: 100,
+    objectFit: "contain",
+
+}
+
+export const Video = Template.bind({})
+Video.args = {
+    type: null,
+    mediaItem: API.video,
+    objectFit: "cover",
+}
+
+export const VideoWithControls = Template.bind({})
+VideoWithControls.args = {
+    type: null,
+    mediaItem: API.video,
+    controls: true,
+    objectFit: "cover",
+}

--- a/src/stories/MediaItem.stories.js
+++ b/src/stories/MediaItem.stories.js
@@ -13,10 +13,10 @@ export default {
     title: "GLOBAL / Media Item",
     component: MediaItem,
     argTypes: {
-      type: {
-        options: [null, 'image', 'video'],
-        control: { type: 'radio' },
-      },
+        type: {
+            options: [null, "image", "video"],
+            control: { type: "radio" },
+        },
     },
 }
 
@@ -40,7 +40,6 @@ ImageObjectFitContain.args = {
     mediaItem: API.image,
     aspectRatio: 100,
     objectFit: "contain",
-
 }
 
 export const Video = Template.bind({})


### PR DESCRIPTION
Connected to [APPS-1975](https://jira.library.ucla.edu/browse/APPS-1975)

**Component Created:** ~/lib-components/Media/Item.vue

**Stories:** ~/stories/MediaItem.stories.js

**Spec:** ~/stories/MediaItem.spec.js

**Notes:**

Takes a 'media-item' object representing a piece of media (only image and video to start, audio and embeds to come), and passes it on to the correct subcomponent for its media type (e.g. ResponsiveImage or ResponsiveVideo). This can be specified explicitly with a prop or figured out by inspecting the media-item prop

Props are based on ResponsiveImage and ResponsiveVideo with some changes, but props like "src" or "videoUrl" are removed. These should always be passed as attributes of the "media-item" object. The idea is that "media-item" has all the information that is constant for a given item, while MediaItems props have information specific to how it used in a given context (eg whether to show video controls).

Puts the component in a new "Media/" directory, where we can gather things like the gallery components as we move forward.

**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR
