### PR TITLE
feat: updates NavPrimary and BannerText spacing

### DIFF
--- a/src/lib-components/BannerText.vue
+++ b/src/lib-components/BannerText.vue
@@ -363,7 +363,7 @@ export default {
         justify-content: flex-start;
         align-items: center;
         gap: 4px;
-        margin-bottom: var(--space-m);
+        margin-bottom: 4px;
     }
     .content .text {
         @include step-0;

--- a/src/lib-components/NavPrimary.vue
+++ b/src/lib-components/NavPrimary.vue
@@ -237,6 +237,8 @@ export default {
         z-index: 10;
     }
     .support-links {
+        // removing support-link from nav-primary with display
+        display: none;
         position: relative;
         z-index: 10;
 


### PR DESCRIPTION
Connected to [APPS-1733](https://jira.library.ucla.edu/browse/APPS-1733)

- removes support-us links display in NavPrimary
- updates contact-info spacing in BannerText to be consistent with BannerHeader

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR
