### PR TITLE
fix: APPS-1996 banner featured image video logic

### DIFF
--- a/src/lib-components/BannerFeatured.vue
+++ b/src/lib-components/BannerFeatured.vue
@@ -278,6 +278,51 @@ export default {
                 `color-${this.sectionName}`,
             ]
         },
+
+        isVideo() {
+            let fileName = this.image.src.toLowerCase()
+            let extension = fileName.split(".").pop()
+            if (
+                extension == "mp4" ||
+                extension == "m4a" ||
+                extension == "f4v" ||
+                extension == "m4b" ||
+                extension == "mov"
+            ) {
+                return true
+            } else {
+                return false
+            }
+        },
+        parseImage() {
+            if (this.isVideo) return null
+            let imageObj = this.image
+            console.log("image obj: " + JSON.stringify(imageObj))
+            return imageObj
+        },
+        parseVideo() {
+            if (!this.isVideo) return null
+            let videoObj = {}
+            let mainVideo = this.image
+            videoObj = {
+                videoUrl: mainVideo.src,
+                sizes: mainVideo.sizes,
+                height: mainVideo.height,
+                width: mainVideo.width,
+                altText: mainVideo.alt,
+                caption: mainVideo.caption,
+                poster: mainVideo.poster,
+            }
+
+            console.log("video obj: " + JSON.stringify(videoObj))
+            return videoObj
+        },
+        parsedMediaComponent() {
+            return this.isVideo ? "responsive-video" : "responsive-image"
+        },
+        parsedMediaProp() {
+            return this.isVideo ? this.parseVideo : this.parseImage
+        },
         bylineArticleExists() {
             return (
                 this.byline &&
@@ -314,12 +359,7 @@ export default {
         sectionName() {
             return this.section || this.getSectionName(this.to)
         },
-        parsedMediaComponent() {
-            return this.image ? "responsive-image" : "responsive-video"
-        },
-        parsedMediaProp() {
-            return this.image ? this.image : this.video
-        },
+
         parsedRatio() {
             // If on mobile, change ratio of image
             let output = this.ratio

--- a/src/lib-components/BannerFeatured.vue
+++ b/src/lib-components/BannerFeatured.vue
@@ -211,10 +211,6 @@ export default {
             type: Object,
             default: () => {},
         },
-        video: {
-            type: Object,
-            default: () => {},
-        },
         title: {
             type: String,
             required: true,

--- a/src/lib-components/Flexible/BannerFeatured.vue
+++ b/src/lib-components/Flexible/BannerFeatured.vue
@@ -12,7 +12,6 @@
             :prompt="parsePrompt"
             :locations="parsedLocations"
             :category="parsedCategory"
-            :video="parseVideo"
         />
         <banner-featured
             v-if="block && block.content && !block.content[0].contentLink"
@@ -27,7 +26,6 @@
             :locations="parsedLocations"
             :category="parsedCategory"
             :alignment="parsedAlignment"
-            :video="parseVideo"
         />
     </div>
 </template>
@@ -49,38 +47,7 @@ export default {
     },
     mixins: [getPrompt],
     computed: {
-        isVideo() {
-            let fileName = ""
-            if (
-                this.block.content[0].contentLink &&
-                this.block.content[0].contentLink[0].heroImage
-            ) {
-                console.log(
-                    "Internal video: " +
-                        JSON.stringify(
-                            this.block.content[0].contentLink[0].heroImage[0]
-                        )
-                )
-                fileName =
-                    this.block.content[0].contentLink[0].heroImage[0].image[0].src.toLowerCase()
-            } else if (this.block.content[0].image) {
-                console.log("External video")
-                fileName = this.block.content[0].image[0].src.toLowerCase()
-            }
-            let extension = fileName.split(".").pop()
-            if (
-                extension == "mp4" ||
-                extension == "m4a" ||
-                extension == "f4v" ||
-                extension == "m4b" ||
-                extension == "mov"
-            ) {
-                return true
-            }
-            return false
-        },
         parseImage() {
-            if (this.isVideo) return null
             let imageObj = {}
             if (
                 this.block.content[0].contentLink &&
@@ -93,39 +60,6 @@ export default {
 
             console.log("image obj: " + JSON.stringify(imageObj))
             return imageObj
-        },
-        parseVideo() {
-            if (!this.isVideo) return null
-            let videoObj = {}
-            if (
-                this.block.content[0].contentLink &&
-                this.block.content[0].contentLink[0].heroImage
-            ) {
-                let mainVideo =
-                    this.block.content[0].contentLink[0].heroImage[0].image[0]
-                videoObj = {
-                    videoUrl: mainVideo.src,
-                    sizes: mainVideo.sizes,
-                    height: mainVideo.height,
-                    width: mainVideo.width,
-                    altText: mainVideo.alt,
-                    caption: mainVideo.caption,
-                    poster: mainVideo.poster,
-                }
-            } else if (this.block.content[0].image) {
-                let mainVideo = this.block.content[0].image[0]
-                videoObj = {
-                    videoUrl: mainVideo.src,
-                    sizes: mainVideo.sizes,
-                    height: mainVideo.height,
-                    width: mainVideo.width,
-                    altText: mainVideo.alt,
-                    caption: mainVideo.caption,
-                    poster: mainVideo.poster,
-                }
-            }
-            console.log("video obj: " + JSON.stringify(videoObj))
-            return videoObj
         },
         parsedAlignment() {
             return this.block.content[0].alignment === "right" ? true : false

--- a/src/stories/BannerFeatured.stories.js
+++ b/src/stories/BannerFeatured.stories.js
@@ -14,7 +14,6 @@ export default {
 
 const mock = {
     image: API.image,
-    video: API.video,
     to: "/help/foo/bar/",
     title: "Curabitur Tortor Pellentesque Nibh Aenean",
     category: "Ullamcorper",
@@ -272,12 +271,13 @@ export const Video = () => ({
     data() {
         return {
             ...mock,
+            image: API.video,
         }
     },
     components: { BannerFeatured },
     template: `
         <banner-featured
-            :video="video"
+            :image="image"
             :category="category"
             :to="to"
             :title="title"

--- a/src/stories/BannerFeatured.stories.js
+++ b/src/stories/BannerFeatured.stories.js
@@ -302,7 +302,7 @@ export const WithBlockForm = () => ({
     components: { BannerFeatured },
     template: `
         <banner-featured
-            :video="video"
+            :image="image"
             :category="category"
             :title="title"
             :description="description"

--- a/src/stories/BannerHeader.stories.js
+++ b/src/stories/BannerHeader.stories.js
@@ -12,7 +12,7 @@ export default {
 
 const mock = {
     image: API.image,
-    video: API.video,
+    video: API.videoVideoUrl,
     to: "/applicants/foo/bar/",
     title: "Curabitur Tortor Pellentesque Nibh Aenean",
     category: "Lectus",

--- a/src/stories/MediaItem.stories.js
+++ b/src/stories/MediaItem.stories.js
@@ -45,14 +45,14 @@ ImageObjectFitContain.args = {
 export const Video = Template.bind({})
 Video.args = {
     type: null,
-    mediaItem: API.video,
+    mediaItem: API.videoVideoUrl,
     objectFit: "cover",
 }
 
 export const VideoWithControls = Template.bind({})
 VideoWithControls.args = {
     type: null,
-    mediaItem: API.video,
+    mediaItem: API.videoVideoUrl,
     controls: true,
     objectFit: "cover",
 }

--- a/src/stories/ResponsiveVideo.stories.js
+++ b/src/stories/ResponsiveVideo.stories.js
@@ -11,7 +11,7 @@ export default {
 export const ImageWithVideo = () => ({
     data() {
         return {
-            image: API.video,
+            image: API.videoVideoUrl,
         }
     },
     components: { ResponsiveVideo },
@@ -21,7 +21,7 @@ export const ImageWithVideo = () => ({
 export const VideoWithControls = () => ({
     data() {
         return {
-            image: API.video,
+            image: API.videoVideoUrl,
         }
     },
     components: { ResponsiveVideo },

--- a/src/stories/mock-api.json
+++ b/src/stories/mock-api.json
@@ -43,6 +43,11 @@
         "alt": "Ucla impact report animation",
         "focalPoint": [0.5, 0.5]
     },
+    "videoVideoUrl": {
+        "height": 1892,
+        "width": 3360,
+        "videoUrl": "https://static.library.ucla.edu/ucla-impact-report-animation.mp4"
+    },
     "links": [
         {
             "name": "Loripsum",

--- a/src/stories/mock-api.json
+++ b/src/stories/mock-api.json
@@ -9,7 +9,7 @@
         "caption": "Lorem ipsum",
         "height": 1080,
         "width": 1920,
-        "focalPoint":[0.5,0.5]
+        "focalPoint": [0.5, 0.5]
     },
     "images": [
         {
@@ -35,9 +35,13 @@
         "title": "Lorem ipsum"
     },
     "video": {
-        "height": 1892,
-        "width": 3360,
-        "videoUrl": "https://static.library.ucla.edu/ucla-impact-report-animation.mp4"
+        "id": "42094",
+        "src": "https://static.library.ucla.edu/craftassetstest/images/ucla-impact-report-animation.mp4",
+        "height": null,
+        "width": null,
+        "srcset": "",
+        "alt": "Ucla impact report animation",
+        "focalPoint": [0.5, 0.5]
     },
     "links": [
         {


### PR DESCRIPTION
Connected to [APPS-1996](https://jira.library.ucla.edu/browse/APPS-1996)
fix: APPS-1996 banner featured image video logic
- Update Banner Featured to decide whether a file is a video or an image. 
- Remove video prop from BannerFeatured because data only comes from Image.gql fragment

