### PR TITLE
fix: add molecule svg with blue background when there is no event image prop for blockhighlight

### DIFF
--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -6,11 +6,15 @@
             <time v-if="startDate" class="day" v-html="parsedDateDay" />
         </div>
         <responsive-image
+            v-if="image"
             :image="image"
             :aspect-ratio="imageAspectRatio"
             :object-fit="cover"
             class="image"
         />
+        <div v-else class="molecule-no-image">
+            <molecule-placeholder class="molecule" aria-hidden="true" />
+        </div>
 
         <div v-if="hasTriangle" class="clipped">
             <div class="floating-highlight" />
@@ -95,6 +99,7 @@
 // Components
 import ResponsiveImage from "@/lib-components/ResponsiveImage.vue"
 import SmartLink from "@/lib-components/SmartLink.vue"
+import MoleculePlaceholder from "ucla-library-design-tokens/assets/svgs/molecule-placeholder.svg"
 
 // Utility functions
 import formatTimes from "@/mixins/formatEventTimes"
@@ -116,6 +121,7 @@ export default {
             ).then((d) => d.default),
         SmartLink,
         ResponsiveImage,
+        MoleculePlaceholder,
     },
     mixins: [formatTimes, formatDates, formatDay, formatMonth, getSectionName],
     props: {
@@ -331,7 +337,13 @@ export default {
         color: var(--color-secondary-grey-05);
         margin: var(--space-s) 0;
     }
-
+    .molecule-no-image {
+        width: 50%;
+        height: 272px;
+        margin-right: var(--space-xl);
+        background: var(--gradient-01);
+        overflow: hidden;
+    }
     .text {
         @include step-0;
         color: var(--color-black);
@@ -361,6 +373,9 @@ export default {
     // Variations
     &.is-vertical {
         flex-direction: column;
+        .molecule-no-image {
+            width: 100%;
+        }
         &:not(.has-triangle) {
             .meta {
                 margin-top: 16px;

--- a/src/stories/BlockHighlight.stories.js
+++ b/src/stories/BlockHighlight.stories.js
@@ -37,7 +37,7 @@ const mock = {
 }
 
 const mock2 = {
-    image: API.image,
+    //image: API.image,
     to: "/about/foo/bar/",
     category: "Lerisque",
     title: "Orci Dapibus",

--- a/src/stories/BlockHighlight.stories.js
+++ b/src/stories/BlockHighlight.stories.js
@@ -37,7 +37,7 @@ const mock = {
 }
 
 const mock2 = {
-    //image: API.image,
+    image: null, //API.image,
     to: "/about/foo/bar/",
     category: "Lerisque",
     title: "Orci Dapibus",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4259468/200098471-40f4b825-88a9-4fc7-bc62-73e0ff049e0c.png)
