### PR TITLE
fix: Impact Report home page cannot be a nuxt link on drupal environment

### DIFF
--- a/src/lib-components/NavPrimary.vue
+++ b/src/lib-components/NavPrimary.vue
@@ -4,6 +4,7 @@
             <router-link
                 to="/"
                 :aria-label="title ? '' : `UCLA Library home page`"
+                v-if="items && items.length > 0"
             >
                 <div v-if="title" class="title">
                     <span class="full-title"> {{ title }} </span>
@@ -15,6 +16,21 @@
                     alt="UCLA Library logo blue"
                 />
             </router-link>
+            <a
+                href="/"
+                :aria-label="title ? '' : `UCLA Library home page`"
+                v-else
+            >
+                <div v-if="title" class="title">
+                    <span class="full-title"> {{ title }} </span>
+                    <span class="acronym" v-if="acronym"> {{ acronym }} </span>
+                </div>
+                <svg-logo-ucla-library
+                    v-else
+                    class="svg logo-ucla"
+                    alt="UCLA Library logo blue"
+                />
+            </a>
         </div>
 
         <ul class="menu">

--- a/src/stories/NavPrimary.stories.js
+++ b/src/stories/NavPrimary.stories.js
@@ -157,6 +157,13 @@ export const Default = () => ({
         />
     `,
 })
+export const ImpactReport = () => ({
+    components: { NavPrimary },
+    template: `
+        <nav-primary
+        />
+    `,
+})
 
 export const ExtraSupportLinks = () => ({
     data() {


### PR DESCRIPTION
Connected to [APPS-2034](https://jira.library.ucla.edu/browse/APPS-2034)
Impact Report home page cannot be a nuxt link on drupal environment
