### PR TITLE
fix: updates responsive image and gallery caption

### DIFF
--- a/src/lib-components/Flexible/MediaGallery/ThumbnailCard.vue
+++ b/src/lib-components/Flexible/MediaGallery/ThumbnailCard.vue
@@ -69,6 +69,7 @@ export default {
     .caption-text {
         @include step-0;
         color: var(--color-secondary-grey-05);
+        @include truncate($lines: 4);
     }
 
     @media #{$has-hover} {

--- a/src/lib-components/ResponsiveImage.vue
+++ b/src/lib-components/ResponsiveImage.vue
@@ -129,6 +129,7 @@ export default {
         width: 100%;
         height: 100%;
         z-index: 0;
+        object-fit: cover;
     }
     .caption {
         display: none;


### PR DESCRIPTION
Connected to [UX-834](https://jira.library.ucla.edu/browse/UX-834)

- adds object-fit: cover property to responsive image to resolve staff profile image bug
- adds clamp to media gallery caption text

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR
