### PR TITLE
feat: ModalLightbox component

### DIFF
--- a/src/lib-components/FlexibleBlocks.vue
+++ b/src/lib-components/FlexibleBlocks.vue
@@ -28,6 +28,7 @@ import _kebabCase from "lodash/kebabCase"
 import omit from "lodash/omit"
 import SectionWrapper from "./SectionWrapper.vue"
 import DividerWayFinder from "./DividerWayFinder.vue"
+import SectionHeader from "./SectionHeader.vue"
 
 const NEVER_GRAY = [
     "flexible-associated-topic-cards",
@@ -106,6 +107,7 @@ export default {
                 (d) => d.default
             ),
         DividerWayFinder,
+        SectionHeader,
     },
 
     props: {

--- a/src/lib-components/ModalLightbox.vue
+++ b/src/lib-components/ModalLightbox.vue
@@ -1,0 +1,102 @@
+<template>
+    <div ref="lightbox" class="lightbox">
+        <div />
+        <!-- empty div to fill first row center -->
+        <button class="button-close" @click="$emit('closeModal')">
+            <svg-icon-close aria-label="Close" />
+        </button>
+        <slot />
+    </div>
+</template>
+
+<script>
+import SvgIconClose from "ucla-library-design-tokens/assets/svgs/icon-close-large.svg"
+
+export default {
+    name: "ModalLightbox",
+    components: {
+        SvgIconClose,
+    },
+    props: {
+        extraStyle: {
+            type: Object,
+            default: () => {},
+        },
+    },
+    mounted() {
+        this.$refs.lightbox.focus()
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+@import "src/styles/vue-glide.scss";
+
+.lightbox {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+
+    background: var(--color-primary-blue-05);
+    z-index: 800;
+
+    display: grid;
+    grid-template-columns: 1fr 75vw 1fr;
+    grid-template-rows: 1fr 75vh 1fr;
+    grid-template-areas:
+        ". . closeButton"
+        ". main ."
+        ". . .";
+    grid-gap: var(--gap-width);
+    grid-auto-flow: row;
+
+    justify-content: stretch;
+
+    > * {
+        grid-area: main;
+        // width: 100%;
+    }
+
+    .button-close {
+        grid-area: closeButton;
+        align-self: end;
+        justify-self: start;
+
+        // width: auto;
+        padding: 0;
+    }
+
+    // Override colors of all the SVG icons
+    ::v-deep svg {
+        display: block;
+
+        .svg__fill--primary-blue-03,
+        .svg__fill--primary-blue-01 {
+            fill: none;
+        }
+
+        .svg__stroke--primary-blue-03,
+        .svg__stroke--default-cyan-02 {
+            stroke: var(--color-white);
+        }
+    }
+
+    @media #{$has-hover} {
+        ::v-deep button:disabled {
+            cursor: default;
+        }
+    }
+
+    ::v-deep button:disabled {
+        ::v-deep svg {
+            .svg__fill--primary-blue-03 {
+                fill: var(--color-white);
+            }
+        }
+    }
+}
+</style>

--- a/src/stories/ModalLightbox.spec.js
+++ b/src/stories/ModalLightbox.spec.js
@@ -1,0 +1,8 @@
+describe("MEDIA GALLERY / New Lightbox", () => {
+    it("Default", () => {
+        cy.visit("/iframe.html?id=modal-lightbox--default&args=&viewMode=story")
+        cy.get(".lightbox").should("exist")
+
+        cy.percySnapshot()
+    })
+})

--- a/src/stories/ModalLightbox.stories.js
+++ b/src/stories/ModalLightbox.stories.js
@@ -1,0 +1,22 @@
+import ModalLightbox from "@/lib-components/ModalLightbox"
+// import MediaSlideshow from "@/lib-components/Media/Slideshow.vue"
+
+import { Gallery as MEDIA_GALLERY_MOCK } from "@/stories/mock/Media"
+
+// Storybook default settings
+export default {
+    title: "Modal Lightbox",
+    component: ModalLightbox,
+}
+
+export const Default = () => ({
+    data() {
+        return {
+            slotStyles: {
+                background: "white",
+            },
+        }
+    },
+    components: { ModalLightbox },
+    template: `<modal-lightbox><div :style="slotStyles" /></modal-lightbox>`,
+})


### PR DESCRIPTION
Connected to [APPS-1590](https://jira.library.ucla.edu/browse/APPS-1590)

**Component Created:** ModalLightbox.vue

**Stories:** ~/stories/ModalLightbox.stories.js

**Spec:** ~/stories/ModalLightbox.spec.js

**Notes:**

Tried to adapt something that could be used for both MediaGallery and Campus Map layouts, but that proved too difficult. This is the Map layout, and can be generalized to other cases. Main content is inserted in a slot, and presented in the middle 75% of each window axis.

Also fixes an error warning about loading SectionHeader in FlexibleBlocks


**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR
