### PR TITLE
refactor: refactor masthead primary search links

### DIFF
--- a/src/lib-components/MastheadPrimary.vue
+++ b/src/lib-components/MastheadPrimary.vue
@@ -26,31 +26,15 @@ export default {
         SvgLogoUclaLibraryUnderline,
         "search-home": SearchHome,
     },
-    data() {
-        return {
-            linkItems: [
-                {
-                    text: "Course Reserves",
-                    url: "https://catalog.library.ucla.edu/vwebv/enterCourseReserve.do",
-                    target: "_blank",
-                },
-                {
-                    text: "UCLA Research Guides",
-                    url: "https://guides.library.ucla.edu/",
-                    target: "",
-                },
-                {
-                    text: "Databases A-Z",
-                    url: "https://guides.library.ucla.edu/az.php",
-                    target: "_blank",
-                },
-            ],
-            advancedSearchLink: {
-                text: "Advanced Search",
-                url: "https://www.library.ucla.edu/search",
-                target: "_blank",
-            },
-        }
+    props: {
+        linkItems: {
+            type: Array,
+            default: () => [],
+        },
+        advancedSearchLink: {
+            type: Object,
+            default: () => {},
+        },
     },
 }
 </script>

--- a/src/stories/MastheadPrimary.stories.js
+++ b/src/stories/MastheadPrimary.stories.js
@@ -5,7 +5,36 @@ export default {
     title: "MASTHEAD / Primary",
     component: MastheadPrimary,
 }
+const mock = {
+    linkItems: [
+        {
+            text: "Course Reserves",
+            url: "https://catalog.library.ucla.edu/vwebv/enterCourseReserve.do",
+            target: "_blank",
+        },
+        {
+            text: "UCLA Research Guides",
+            url: "https://guides.library.ucla.edu/",
+            target: "",
+        },
+        {
+            text: "Databases A-Z",
+            url: "https://guides.library.ucla.edu/az.php",
+            target: "_blank",
+        },
+    ],
+    advancedSearchLink: {
+        text: "Advanced Search",
+        url: "https://www.library.ucla.edu/search",
+        target: "_blank",
+    },
+}
 export const Default = () => ({
-    template: `<masthead-primary/>`,
+    data() {
+        return {
+            ...mock,
+        }
+    },
+    template: `<masthead-primary :link-items="linkItems" :advanced-search-link="advancedSearchLink"/>`,
     components: { MastheadPrimary },
 })


### PR DESCRIPTION
Connected to [APPS-2092](https://jira.library.ucla.edu/browse/APPS-2092)

Refactor MastHead Primary to take search links as props, not hardcoded in data
