### PR TITLE
fix: update masthead primary story and add smart-link to search home

### DIFF
--- a/src/lib-components/MastheadPrimary.vue
+++ b/src/lib-components/MastheadPrimary.vue
@@ -26,31 +26,15 @@ export default {
         SvgLogoUclaLibraryUnderline,
         "search-home": SearchHome,
     },
-    data() {
-        return {
-            linkItems: [
-                {
-                    text: "Course Reserves",
-                    url: "https://catalog.library.ucla.edu/vwebv/enterCourseReserve.do",
-                    target: "_blank",
-                },
-                {
-                    text: "UCLA Research Guides",
-                    url: "https://guides.library.ucla.edu/",
-                    target: "",
-                },
-                {
-                    text: "Databases A-Z",
-                    url: "https://guides.library.ucla.edu/az.php",
-                    target: "_blank",
-                },
-            ],
-            advancedSearchLink: {
-                text: "Advanced Search",
-                url: "https://www.library.ucla.edu/search",
-                target: "_blank",
-            },
-        }
+    props: {
+        linkItems: {
+            type: Array,
+            default: () => [],
+        },
+        advancedSearchLink: {
+            type: Object,
+            default: () => {},
+        },
     },
 }
 </script>

--- a/src/lib-components/SearchHome.vue
+++ b/src/lib-components/SearchHome.vue
@@ -36,14 +36,12 @@
                         :key="link.url"
                         class="link"
                         :href="link.url"
-                        :target="link.target"
                         v-text="link.text"
                     />
                 </div>
                 <div v-if="advancedSearchLink" class="advanced-links">
                     <a
                         :href="advancedSearchLink.url"
-                        :target="advancedSearchLink.target"
                         v-text="advancedSearchLink.text"
                     />
                 </div>

--- a/src/lib-components/SearchHome.vue
+++ b/src/lib-components/SearchHome.vue
@@ -31,17 +31,17 @@
 
             <nav v-if="linkItems.length || advancedSearchLink" class="links">
                 <div v-if="linkItems.length" class="regular-links">
-                    <a
+                    <smart-link
                         v-for="link in linkItems"
                         :key="link.url"
                         class="link"
-                        :href="link.url"
+                        :to="link.url"
                         v-text="link.text"
                     />
                 </div>
                 <div v-if="advancedSearchLink" class="advanced-links">
-                    <a
-                        :href="advancedSearchLink.url"
+                    <smart-link
+                        :to="advancedSearchLink.url"
                         v-text="advancedSearchLink.text"
                     />
                 </div>
@@ -52,6 +52,7 @@
 
 <script>
 import IconSearch from "ucla-library-design-tokens/assets/svgs/icon-search.svg"
+import SmartLink from "@/lib-components/SmartLink.vue"
 
 const tabs = [
     {
@@ -69,6 +70,7 @@ const tabs = [
 export default {
     components: {
         IconSearch,
+        SmartLink,
     },
     props: {
         /**

--- a/src/stories/MastheadPrimary.stories.js
+++ b/src/stories/MastheadPrimary.stories.js
@@ -5,7 +5,36 @@ export default {
     title: "MASTHEAD / Primary",
     component: MastheadPrimary,
 }
+const mock = {
+    linkItems: [
+        {
+            text: "Course Reserves",
+            url: "https://catalog.library.ucla.edu/vwebv/enterCourseReserve.do",
+            target: "_blank",
+        },
+        {
+            text: "UCLA Research Guides",
+            url: "https://guides.library.ucla.edu/",
+            target: "",
+        },
+        {
+            text: "Databases A-Z",
+            url: "https://guides.library.ucla.edu/az.php",
+            target: "_blank",
+        },
+    ],
+    advancedSearchLink: {
+        text: "Advanced Search",
+        url: "https://www.library.ucla.edu/search",
+        target: "_blank",
+    },
+}
 export const Default = () => ({
-    template: `<masthead-primary/>`,
+    data() {
+        return {
+            ...mock,
+        }
+    },
+    template: `<masthead-primary :link-items="linkItems" :advanced-search-link="advancedSearchLink"/>`,
     components: { MastheadPrimary },
 })

--- a/src/stories/MastheadPrimary.stories.js
+++ b/src/stories/MastheadPrimary.stories.js
@@ -10,17 +10,14 @@ const mock = {
         {
             text: "Course Reserves",
             url: "https://catalog.library.ucla.edu/vwebv/enterCourseReserve.do",
-            target: "_blank",
         },
         {
             text: "UCLA Research Guides",
             url: "https://guides.library.ucla.edu/",
-            target: "",
         },
         {
             text: "Databases A-Z",
             url: "https://guides.library.ucla.edu/az.php",
-            target: "_blank",
         },
     ],
     advancedSearchLink: {


### PR DESCRIPTION
 - Remove `target` from Masthead Primary story
 - Update `SearchHome` to use `SmartLink`
