### PR TITLE
feat: add byline props to SectionTeaserCard

### DIFF
--- a/src/lib-components/SectionTeaserCard.vue
+++ b/src/lib-components/SectionTeaserCard.vue
@@ -14,6 +14,8 @@
             :image-aspect-ratio="60"
             :is-vertical="true"
             :is-online="card.isOnline"
+            :byline-one="card.bylineOne"
+            :byline-two="card.bylineTwo"
         />
     </ul>
 </template>


### PR DESCRIPTION
- adds bylineOne and bylineTwo props to SectionTeaserCard to accommodate postDate display for articles

![Screen Shot 2022-12-06 at 2 06 20 PM](https://user-images.githubusercontent.com/44713143/206033554-19f3aee7-5e7e-4d25-9199-0496a7899f93.png)
