### PR TITLE
fix: update masthead text color to white

### DIFF
--- a/src/lib-components/MastheadSecondary.vue
+++ b/src/lib-components/MastheadSecondary.vue
@@ -83,6 +83,11 @@ export default {
             object-fit: cover;
         }
     }
+    .rich-text {
+        ::v-deep p {
+            color: var(--color-white);
+        }
+    }
 
     .container {
         max-width: $container-l-cta + px;


### PR DESCRIPTION
https://github.com/UCLALibrary/ucla-library-website-components/pull/274 requires this addition for styling
- updates rich-text in masthead-secondary to white