### PR TITLE
fix: update location list hours

### DIFF
--- a/src/lib-components/BlockLocationListItem.vue
+++ b/src/lib-components/BlockLocationListItem.vue
@@ -11,7 +11,6 @@
                     <molecule-placeholder class="molecule" aria-hidden="true" />
                 </div>
             </smart-link>
-
             <div class="library">
                 <div>
                     <smart-link v-if="to" :to="to" class="title">
@@ -22,7 +21,7 @@
                     </smart-link>
                 </div>
                 <div class="text">
-                    <div v-if="libcalHoursData" class="time">
+                    <div v-if="libcalHoursData && isUclaLibrary" class="time">
                         <IconClock />
                         <span v-if="libcalHoursData.day">{{
                             libcalHoursData.day
@@ -143,14 +142,6 @@ export default {
             default: "",
         },
         to: {
-            type: String,
-            default: "",
-        },
-        day: {
-            type: String,
-            default: "",
-        },
-        hour: {
             type: String,
             default: "",
         },

--- a/src/lib-components/SectionLocationList.vue
+++ b/src/lib-components/SectionLocationList.vue
@@ -9,13 +9,12 @@
                 :title="item.title"
                 :to="item.to"
                 :affiliateLibraryUrl="item.affiliateLibraryUrl"
-                :day="item.day"
-                :hour="item.hour"
                 :address="item.address"
                 :addressLink="item.addressLink"
                 :amenities="item.amenities"
                 :reserveSeat="item.reserveSeat"
                 :isUclaLibrary="item.isUclaLibrary"
+                :libcal-location-id-for-hours="item.libcalLocationIdForHours"
                 class="block-location-list-item"
             />
         </ul>

--- a/src/stories/BlockLocationListItem.stories.js
+++ b/src/stories/BlockLocationListItem.stories.js
@@ -7,8 +7,7 @@ const mock = {
     isUclaLibrary: false,
     title: "Arts Library",
     image: API.image,
-    day: "Today",
-    hour: "8am - 5pm",
+    libcalLocationIdForHours: "2081",
     reserveSeat: "http://google.com/reserveSeat",
     address: "1400 Public Affairs Building Los Angeles, CA 90095-1392",
     addressLink: "http://google.com/address",
@@ -48,8 +47,7 @@ export const Default = () => ({
             :title="title"
             :to="to"
             :image="image"
-            :day="day"
-            :hour="hour"
+
             :address="address"
             :addressLink="addressLink"
             :amenities="amenities"
@@ -69,8 +67,7 @@ export const NoHours = () => ({
             :title="title"
             :to="to"
             :image="image"
-            :day="day"
-            :hour="hour"
+
             :address="address"
             :addressLink="addressLink"
             :amenities="amenities"
@@ -90,14 +87,12 @@ export const TextHours = () => ({
             :title="title"
             :to="to"
             :image="image"
-            :day="day"
-            :hour="hour"
             :address="address"
             :addressLink="addressLink"
             :amenities="amenities"
             :reserveSeat="reserveSeat"
             :isUclaLibrary="isUclaLibrary"
-            libcalLocationIdForHours="4695"
+            libcalLocationIdForHours="2081"
         />
     `,
 })

--- a/src/stories/BlockLocationListItem.stories.js
+++ b/src/stories/BlockLocationListItem.stories.js
@@ -4,7 +4,7 @@ import BlockLocationListItem from "@/lib-components/BlockLocationListItem"
 import StoryRouter from "storybook-vue-router"
 
 const mock = {
-    isUclaLibrary: false,
+    isUclaLibrary: true,
     title: "Arts Library",
     image: API.image,
     libcalLocationIdForHours: "2081",

--- a/src/stories/SectionLocationList.stories.js
+++ b/src/stories/SectionLocationList.stories.js
@@ -16,13 +16,11 @@ export default {
 
 const mock = [
     {
-        isUclaLibrary: false,
+        isUclaLibrary: true,
         locationType: "uclaLibrary",
         campusMapId: "81513",
         libcalLocationIdForHours: "2081",
         libcalSpacesUrl: "https://calendar.library.ucla.edu/spaces?lid=6578",
-        day: "Today",
-        hour: "8am - 5pm",
         reserveSeat: "http://google.com/reserveSeat",
         title: "Louise M. Darling Biomedical Library",
         image: API.image,
@@ -49,11 +47,9 @@ const mock = [
     },
     {
         locationType: "uclaLibrary",
-        isUclaLibrary: false,
+        isUclaLibrary: true,
         title: "Arts Library",
         image: API.image,
-        day: "Today",
-        hour: "8am - 5pm",
         reserveSeat: "http://google.com/reserveSeat",
         address: "1400 Public Affairs Building Los Angeles, CA 90095-1392",
         addressLink: "http://google.com/address",
@@ -70,6 +66,7 @@ const mock = [
         locationType: "affiliateLibrary",
         affiliateLibraryUrl: "https://pubmed.ncbi.nlm.nih.gov/?otool=uclalib",
         campusMapId: "324",
+        isUclaLibrary: false,
         libcalLocationIdForHours: "2082",
         libcalSpacesUrl: "https://calendar.library.ucla.edu/spaces?lid=657",
         title: "William Andrews Clark Memorial Library",

--- a/src/stories/SectionLocationList.stories.js
+++ b/src/stories/SectionLocationList.stories.js
@@ -49,6 +49,7 @@ const mock = [
         locationType: "uclaLibrary",
         isUclaLibrary: true,
         title: "Arts Library",
+        libcalLocationIdForHours: "4690",
         image: API.image,
         reserveSeat: "http://google.com/reserveSeat",
         address: "1400 Public Affairs Building Los Angeles, CA 90095-1392",


### PR DESCRIPTION
Connected to [APPS-2143](https://jira.library.ucla.edu/browse/APPS-2143)
https://deploy-preview-314--ucla-library-storybook.netlify.app/?path=/story/section-location-list--default
Cards display accurate hours.
Only UCLA libraries display hours.
