### PR TITLE
fix: video embed display

### DIFF
--- a/src/lib-components/Media/Item.vue
+++ b/src/lib-components/Media/Item.vue
@@ -132,6 +132,11 @@ export default {
         width: 100%;
         height: 100%;
         z-index: 0;
+
+        ::v-deep figure, ::v-deep iframe {
+            width: 100%;
+            height: 100%;
+        }
     }
     .sizer {
         width: 100%;

--- a/src/lib-components/Media/Item.vue
+++ b/src/lib-components/Media/Item.vue
@@ -133,7 +133,8 @@ export default {
         height: 100%;
         z-index: 0;
 
-        ::v-deep figure, ::v-deep iframe {
+        ::v-deep figure,
+        ::v-deep iframe {
             width: 100%;
             height: 100%;
         }

--- a/src/stories/mock/Media.js
+++ b/src/stories/mock/Media.js
@@ -29,7 +29,7 @@ export const VideoFile = [
 ]
 
 export const VideoEmbed =
-    '<iframe width="100%" height="100%" src="https://www.youtube.com/embed/3sQ9k4yvvPw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>'
+    '<figure><iframe width="560" height="315" src="https://www.youtube.com/embed/3sQ9k4yvvPw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></figure>'
 
 export const AudioFile = [
     {


### PR DESCRIPTION
closes https://jira.library.ucla.edu/browse/APPS-2099

- when craft inserts a <figure> tag around embedded iframe, ensures that it fills the available MediaItem space
- override hard-coded iframe width and height