### PR TITLE
feat: use rich-text in site alert and spaces, increase alert display time

### DIFF
--- a/src/lib-components/BlockSpaces.vue
+++ b/src/lib-components/BlockSpaces.vue
@@ -13,7 +13,7 @@
                 <h3 v-else class="space-title-no-link" v-html="title" />
             </div>
             <div class="meta">
-                <div class="text" v-html="text" />
+                <rich-text v-if="text" class="text" :rich-text-content="text" />
                 <!-- if no buttonUrl -  do not display button -->
                 <button-link
                     v-if="to"
@@ -143,6 +143,7 @@ export default {
             .text {
                 @include step-0;
                 margin: 0 24px var(--space-m) 40px;
+                padding: 0;
             }
             .button {
                 margin-left: 40px;

--- a/src/lib-components/BlockSpaces.vue
+++ b/src/lib-components/BlockSpaces.vue
@@ -1,6 +1,6 @@
 <template>
     <li class="block-spaces">
-        <div class="container">
+        <component :is="to ? 'SmartLink' : 'div'" :to="to" class="container">
             <div class="arrow-and-title">
                 <svg-heading-arrow class="heading-arrow" />
                 <!-- if the is a link (:to) - display as a link -->
@@ -25,7 +25,7 @@
                     link-target="_blank"
                 />
             </div>
-        </div>
+        </component>
     </li>
 </template>
 
@@ -101,14 +101,6 @@ export default {
             .space-title {
                 @include step-2;
                 color: var(--color-primary-blue-03);
-                a::after {
-                    content: "";
-                    position: absolute;
-                    left: 0;
-                    top: 0;
-                    right: 0;
-                    bottom: 0;
-                }
             }
         }
 
@@ -164,6 +156,12 @@ export default {
         }
         &:hover {
             @include card-horizontal-hover;
+
+            text-decoration: none !important;
+
+            ::v-deep a.smart-link, ::v-deep button.smart-link {
+                text-decoration: none !important;
+            }
         }
     }
 

--- a/src/lib-components/BlockSpaces.vue
+++ b/src/lib-components/BlockSpaces.vue
@@ -157,11 +157,11 @@ export default {
         &:hover {
             @include card-horizontal-hover;
 
-            text-decoration: none !important;
+            text-decoration: none;
 
             ::v-deep a.smart-link,
             ::v-deep button.smart-link {
-                text-decoration: none !important;
+                text-decoration: none;
             }
         }
     }

--- a/src/lib-components/BlockSpaces.vue
+++ b/src/lib-components/BlockSpaces.vue
@@ -33,6 +33,7 @@
 // https://calendar.library.ucla.edu/admin/api/1.1/endpoint/space_locations
 import SmartLink from "@/lib-components/SmartLink"
 import ButtonLink from "@/lib-components/ButtonLink"
+import RichText from "@/lib-components/RichText"
 
 import SvgHeadingArrow from "ucla-library-design-tokens/assets/svgs/graphic-chevron-right.svg"
 
@@ -42,6 +43,7 @@ export default {
         SvgHeadingArrow,
         SmartLink,
         ButtonLink,
+        RichText,
     },
     props: {
         to: {

--- a/src/lib-components/BlockSpaces.vue
+++ b/src/lib-components/BlockSpaces.vue
@@ -159,7 +159,8 @@ export default {
 
             text-decoration: none !important;
 
-            ::v-deep a.smart-link, ::v-deep button.smart-link {
+            ::v-deep a.smart-link,
+            ::v-deep button.smart-link {
                 text-decoration: none !important;
             }
         }

--- a/src/lib-components/SiteNotificationAlert.vue
+++ b/src/lib-components/SiteNotificationAlert.vue
@@ -8,7 +8,11 @@
         </button>
 
         <div class="message">
-            <rich-text v-if="text" class="message-text" :rich-text-content="text" />
+            <rich-text
+                v-if="text"
+                class="message-text"
+                :rich-text-content="text"
+            />
             <button-link
                 class="button-dismiss"
                 label="Dismiss"

--- a/src/lib-components/SiteNotificationAlert.vue
+++ b/src/lib-components/SiteNotificationAlert.vue
@@ -8,7 +8,9 @@
         </button>
 
         <div class="message">
-            <div class="message-text" v-html="text" />
+            <div class="message-text">
+                <rich-text v-if="text" class="text" :rich-text-content="text" />
+            </div>
             <button-link
                 class="button-dismiss"
                 label="Dismiss"
@@ -39,7 +41,7 @@ export default {
         },
         time: {
             type: Number,
-            default: 10000,
+            default: 13500,
         },
     },
     data() {
@@ -125,7 +127,6 @@ export default {
             white-space: nowrap;
         }
     }
-
     .message {
         display: flex;
         flex-direction: column;
@@ -148,10 +149,15 @@ export default {
 
             color: var(--color-black);
             font-family: var(--font-primary);
-            font-size: 16px;
-            font-weight: 400;
-            letter-spacing: 0.01em;
-            line-height: 22px;
+            .text {
+                padding: 0;
+                ::v-deep p {
+                    font-size: 16px;
+                    font-weight: 400;
+                    letter-spacing: 0.01em;
+                    line-height: 22px; 
+                }
+            }
         }
 
         .button-dismiss {

--- a/src/lib-components/SiteNotificationAlert.vue
+++ b/src/lib-components/SiteNotificationAlert.vue
@@ -161,11 +161,11 @@ export default {
                 line-height: 22px;
             }
             ::v-deep a {
-                    font-size: 16px;
-                    font-weight: 400;
-                    letter-spacing: 0.01em;
-                    line-height: 22px;
-                }
+                font-size: 16px;
+                font-weight: 400;
+                letter-spacing: 0.01em;
+                line-height: 22px;
+            }
         }
 
         .button-dismiss {

--- a/src/lib-components/SiteNotificationAlert.vue
+++ b/src/lib-components/SiteNotificationAlert.vue
@@ -159,13 +159,13 @@ export default {
                 font-weight: 400;
                 letter-spacing: 0.01em;
                 line-height: 22px;
-                a {
+            }
+            ::v-deep a {
                     font-size: 16px;
                     font-weight: 400;
                     letter-spacing: 0.01em;
                     line-height: 22px;
                 }
-            }
         }
 
         .button-dismiss {

--- a/src/lib-components/SiteNotificationAlert.vue
+++ b/src/lib-components/SiteNotificationAlert.vue
@@ -8,9 +8,7 @@
         </button>
 
         <div class="message">
-            <div class="message-text">
-                <rich-text v-if="text" class="text" :rich-text-content="text" />
-            </div>
+            <rich-text v-if="text" class="message-text" :rich-text-content="text" />
             <button-link
                 class="button-dismiss"
                 label="Dismiss"
@@ -24,11 +22,13 @@
 
 <script>
 import ButtonLink from "./ButtonLink.vue"
+import RichText from "./RichText.vue"
 
 export default {
     name: "SiteNotificationAlert",
     components: {
         ButtonLink,
+        RichText,
     },
     props: {
         title: {
@@ -149,19 +149,17 @@ export default {
 
             color: var(--color-black);
             font-family: var(--font-primary);
-            .text {
-                padding: 0;
-                ::v-deep p {
+            padding: 0;
+            ::v-deep p {
+                font-size: 16px;
+                font-weight: 400;
+                letter-spacing: 0.01em;
+                line-height: 22px;
+                a {
                     font-size: 16px;
                     font-weight: 400;
                     letter-spacing: 0.01em;
                     line-height: 22px;
-                    a {
-                        font-size: 16px;
-                        font-weight: 400;
-                        letter-spacing: 0.01em;
-                        line-height: 22px;
-                    }
                 }
             }
         }

--- a/src/lib-components/SiteNotificationAlert.vue
+++ b/src/lib-components/SiteNotificationAlert.vue
@@ -155,7 +155,13 @@ export default {
                     font-size: 16px;
                     font-weight: 400;
                     letter-spacing: 0.01em;
-                    line-height: 22px; 
+                    line-height: 22px;
+                    a {
+                        font-size: 16px;
+                        font-weight: 400;
+                        letter-spacing: 0.01em;
+                        line-height: 22px;
+                    } 
                 }
             }
         }

--- a/src/lib-components/SiteNotificationAlert.vue
+++ b/src/lib-components/SiteNotificationAlert.vue
@@ -161,7 +161,7 @@ export default {
                         font-weight: 400;
                         letter-spacing: 0.01em;
                         line-height: 22px;
-                    } 
+                    }
                 }
             }
         }

--- a/src/stories/BlockSpaces.stories.js
+++ b/src/stories/BlockSpaces.stories.js
@@ -16,7 +16,7 @@ const mock = {
     to: "https://calendar.library.ucla.edu",
     title: "Bureaux de Garcons",
     location: "Fast Lane Building",
-    text: "<h4>Cat</h4><p>Eclectic sophisticated carefully curated lovely Baggu Muji sharp finest efficient perfect. Hub Boeing 787 lovely Melbourne flat white ryokan. Global iconic Gaggenau Muji bulletin premium espresso delightful destination vibrant remarkable elegant bureaux boutique. Sunspel exclusive first-class espresso, Fast Lane intricate Melbourne Airbus A380 pintxos Shinkansen Swiss vibrant the highest quality.</p>",
+    text: "<p>Eclectic sophisticated carefully curated lovely Baggu Muji sharp finest efficient perfect. Hub <a href='https://www.boeing.com/commercial/787'>Boeing 787</a> lovely Melbourne flat white ryokan. Global iconic Gaggenau Muji bulletin premium espresso delightful destination vibrant remarkable elegant bureaux boutique. Sunspel exclusive first-class espresso, Fast Lane intricate Melbourne Airbus A380 pintxos Shinkansen Swiss vibrant the highest quality.</p>",
 }
 
 const mock2 = {

--- a/src/stories/BlockSpaces.stories.js
+++ b/src/stories/BlockSpaces.stories.js
@@ -5,6 +5,7 @@ import BlockSpaces from "@/lib-components/BlockSpaces"
 import StoryRouter from "storybook-vue-router"
 
 // Storybook default settings
+//TODO update stories with rich-text
 export default {
     title: "BLOCK / Spaces",
     component: BlockSpaces,

--- a/src/stories/SiteNotificationAlert.stories.js
+++ b/src/stories/SiteNotificationAlert.stories.js
@@ -7,7 +7,7 @@ export default {
     title: "Global / SiteNotificationAlert",
     component: SiteNotificationAlert,
 }
-
+//TODO update message text as rich text
 export const Default = () => ({
     data() {
         return {

--- a/src/stories/mock-api.json
+++ b/src/stories/mock-api.json
@@ -265,7 +265,7 @@
     ],
     "alert": {
         "title": "Dropio, heroku",
-        "text": "Napster mozy sococo orkut convore scribd napster, twones diigo joukuu weebly. Sclipo jibjab scribd.",
+        "text": "Napster mozy sococo orkut <a href='http://google.com/'>convore scribd napster</a>, twones diigo joukuu weebly. <i>Sclipo jibjab scribd</i>.",
         "textLong": "Greplin prezi zillow zoosk orkut, zoosk gooru. Kiko xobni joukuu ideeli bitly joukuu, squidoo heroku hulu sifteo, zooomr jumo dropio chumby. Qeyno wikia oooooc jajah, ebay qeyno lala, jajah lijit. Etsy wufoo flickr movity sclipo heroku, oooooc etsy oooooc. Vimeo foodzie zoosk ebay, wesabe. Ebay doostang vuvox, xobni. Mozy joyent dropio gooru kippt, greplin skype. Kiko napster geni dogster yoono yammer disqus, hipmunk xobni odeo zynga loopt. Groupon klout divvyshot zinch elgg yoono airbnb, orkut zinch chartly squidoo."
     },
     "categories": [


### PR DESCRIPTION
Connected to [APPS-2172](https://jira.library.ucla.edu/browse/APPS-2172)
Connected to [APPS-2169](https://jira.library.ucla.edu/browse/APPS-2169)
Connected to [APPS-2158](https://jira.library.ucla.edu/browse/APPS-2158)

- replaces plain text with rich text for BlockSpaces and SiteNotificationAlert
- increases SiteNotificationAlert display time
- adjusts SiteNotificationAlert styling

* to-do: update stories with rich-text

![Screen Shot 2023-01-31 at 5 26 48 PM](https://user-images.githubusercontent.com/44713143/215923468-0c4cea59-2121-4f3c-9a78-32f3232d9f7b.png)

![Screen Shot 2023-01-31 at 5 33 24 PM](https://user-images.githubusercontent.com/44713143/215923521-7c335d2f-4d10-4f68-83f4-220fe0f9219d.png)


