### PR TITLE
fix: update placeholder image height

### DIFF
--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -359,7 +359,6 @@ export default {
     .image-container {
         .molecule-no-image {
             width: 100%;
-            height: 179.2px;
             margin-right: var(--space-xl);
             background: var(--gradient-01);
             overflow: hidden;
@@ -401,6 +400,7 @@ export default {
         flex-direction: column;
         .molecule-no-image {
             width: 100%;
+            height: 179.2px;
         }
         &:not(.has-triangle) {
             .meta {
@@ -425,6 +425,9 @@ export default {
                     object-fit: cover;
                 }
             }
+            .molecule-no-image {
+                height: 272px;
+            }
         }
     }
     &:not(&.is-vertical) {
@@ -438,6 +441,9 @@ export default {
 
             .image {
                 width: 100%;
+            }
+            .molecule-no-image {
+                height: 261px;
             }
         }
         .meta {
@@ -537,8 +543,14 @@ export default {
             margin-top: 0;
         }
         &.is-vertical {
+            .molecule-no-image {
+                height: 220px;
+            }
             &.has-triangle {
                 ::v-deep .image {
+                    height: 200px;
+                }
+                .molecule-no-image {
                     height: 200px;
                 }
             }
@@ -581,6 +593,11 @@ export default {
         &:not(&.is-vertical) {
             .image {
                 max-width: 100%;
+            }
+            .image-container {
+                .molecule-no-image {
+                    height: 200px;
+                } 
             }
         }
     }

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -356,20 +356,22 @@ export default {
         color: var(--color-secondary-grey-04);
         margin: var(--space-s) 0;
     }
-    .molecule-no-image {
-        width: 100%;
-        height: 272px;
-        margin-right: var(--space-xl);
-        background: var(--gradient-01);
-        overflow: hidden;
-        display: flex;
-        align-items: center;
-        position: relative;
+    .image-container {
+        .molecule-no-image {
+            width: 100%;
+            height: 179.2px;
+            margin-right: var(--space-xl);
+            background: var(--gradient-01);
+            overflow: hidden;
+            display: flex;
+            align-items: center;
+            position: relative;
 
-        .molecule {
-            flex-shrink: 0;
-            position: absolute;
-            opacity: 0.7;
+            .molecule {
+                flex-shrink: 0;
+                position: absolute;
+                opacity: 0.7;
+            }
         }
     }
     .text {
@@ -549,7 +551,7 @@ export default {
             .clipped-date {
                 display: none;
             }
-
+            
             .image-container,
             .meta {
                 width: 100%;

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -544,7 +544,7 @@ export default {
         }
         &.is-vertical {
             .molecule-no-image {
-                height: 220px;
+                height: 226px;
             }
             &.has-triangle {
                 ::v-deep .image {

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -597,7 +597,7 @@ export default {
             .image-container {
                 .molecule-no-image {
                     height: 200px;
-                } 
+                }
             }
         }
     }

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -551,7 +551,7 @@ export default {
             .clipped-date {
                 display: none;
             }
-            
+
             .image-container,
             .meta {
                 width: 100%;

--- a/src/stories/SectionTeaserCard.stories.js
+++ b/src/stories/SectionTeaserCard.stories.js
@@ -16,7 +16,7 @@ export default {
 
 const mock = [
     {
-        image: API.image,
+        image: null,
         to: "/visit/foo/bar/",
         category: "Feugiat",
         title: "Vel Quam Elementum",

--- a/src/stories/SectionTeaserHighlight.stories.js
+++ b/src/stories/SectionTeaserHighlight.stories.js
@@ -16,7 +16,7 @@ export default {
 
 const mock = [
     {
-        image: API.image,
+        image: null,
         to: "/visit/foo/bar/",
         category: "Ullamco",
         title: "Fames ac turpis egestas sed tempus lorem ipsum",

--- a/src/stories/SectionTeaserList.stories.js
+++ b/src/stories/SectionTeaserList.stories.js
@@ -15,7 +15,7 @@ export default {
 
 const mock = [
     {
-        image: API.image,
+        image: null,
         to: "/visit/foo/bar/",
         category: "Ullamco",
         title: "Fames ac turpis egestas sed tempus lorem ipsum",


### PR DESCRIPTION
Connected to [APPS-2168](https://jira.library.ucla.edu/browse/APPS-2168)
- updates block-highlight to display placeholder image at appropriate heights for most common devices (dynamic height to come in responsive-image update, post launch)
https://deploy-preview-326--ucla-library-storybook.netlify.app/?path=/story/section-teaser-card--default
