### PR TITLE
feat: add search-margin styling to divider

### DIFF
--- a/src/lib-components/DividerWayFinder.vue
+++ b/src/lib-components/DividerWayFinder.vue
@@ -43,6 +43,9 @@ export default {
     &.color-default {
         --color-border: var(--color-default-cyan-03);
     }
+    &.search-margin {
+        margin: var(--space-2xl) auto;
+    }
 
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
adds search-margin styling at component level so that we can remove styling from page templates