### PR TITLE
fix: SimpleCard truncaton

### DIFF
--- a/src/lib-components/BlockSimpleCard.vue
+++ b/src/lib-components/BlockSimpleCard.vue
@@ -10,6 +10,8 @@
 
         <div v-if="text" class="text">{{ parsedText }}</div>
 
+        <div class="spacer" />
+
         <div class="svg-meta" aria-hidden="true">
             <component :is="parsedIconName" class="svg" />
         </div>
@@ -111,8 +113,12 @@ export default {
 
     .text {
         @include step--1;
-        flex: 1;
         @include truncate(5);
+    }
+
+    .spacer {
+        flex-basis: 0;
+        flex-grow: 1;
     }
 
     .svg-meta {

--- a/src/stories/BlockSimpleCard.stories.js
+++ b/src/stories/BlockSimpleCard.stories.js
@@ -80,3 +80,16 @@ export const InternalLinkGuide = () => ({
         />
     `,
 })
+
+export const LongText = () => ({
+    data() {
+        return { card: {
+            to: "sink-hole",
+            title: "Sink Hole",
+            text:
+                "Adipisicing do enim voluptate amet nisi eiusmod ex aliqua exercitation nulla sint magna proident proident. Exercitation in et enim est esse consectetur ex dolore labore ut laborum non minim ea. In ad excepteur cillum commodo veniam dolore labore cupidatat. Ea fugiat occaecat et fugiat consectetur do consectetur anim cillum. Ex nulla est ex cillum esse. Aliquip deserunt consequat pariatur sunt labore occaecat. Excepteur nostrud ex ex anim ut irure tempor eu quis id cupidatat consectetur. Mollit adipisicing cupidatat occaecat labore cupidatat culpa sit pariatur. Anim reprehenderit dolore est aliqua id pariatur quis exercitation incididunt do magna. Reprehenderit irure duis aliqua ullamco sint incididunt commodo exercitation reprehenderit. Non esse quis consectetur eiusmod. Labore dolore ex commodo culpa incididunt ipsum nulla elit tempor in officia eiusmod. Velit incididunt Lorem eiusmod eu anim dolore voluptate elit nisi aliquip est elit qui occaecat. Consequat cillum consectetur pariatur magna incididunt tempor eu do commodo laboris proident id dolor. Pariatur sint incididunt Lorem anim est nostrud qui excepteur eu fugiat exercitation exercitation. Lorem laboris reprehenderit ipsum aliquip ullamco sunt aute culpa occaecat in aliquip incididunt consequat nostrud.",
+        } }
+    },
+    components: { BlockSimpleCard },
+    template: `<block-simple-card v-bind="card" style="max-width: 300px;"/>`,
+})

--- a/src/stories/BlockSimpleCard.stories.js
+++ b/src/stories/BlockSimpleCard.stories.js
@@ -83,12 +83,13 @@ export const InternalLinkGuide = () => ({
 
 export const LongText = () => ({
     data() {
-        return { card: {
-            to: "sink-hole",
-            title: "Sink Hole",
-            text:
-                "Adipisicing do enim voluptate amet nisi eiusmod ex aliqua exercitation nulla sint magna proident proident. Exercitation in et enim est esse consectetur ex dolore labore ut laborum non minim ea. In ad excepteur cillum commodo veniam dolore labore cupidatat. Ea fugiat occaecat et fugiat consectetur do consectetur anim cillum. Ex nulla est ex cillum esse. Aliquip deserunt consequat pariatur sunt labore occaecat. Excepteur nostrud ex ex anim ut irure tempor eu quis id cupidatat consectetur. Mollit adipisicing cupidatat occaecat labore cupidatat culpa sit pariatur. Anim reprehenderit dolore est aliqua id pariatur quis exercitation incididunt do magna. Reprehenderit irure duis aliqua ullamco sint incididunt commodo exercitation reprehenderit. Non esse quis consectetur eiusmod. Labore dolore ex commodo culpa incididunt ipsum nulla elit tempor in officia eiusmod. Velit incididunt Lorem eiusmod eu anim dolore voluptate elit nisi aliquip est elit qui occaecat. Consequat cillum consectetur pariatur magna incididunt tempor eu do commodo laboris proident id dolor. Pariatur sint incididunt Lorem anim est nostrud qui excepteur eu fugiat exercitation exercitation. Lorem laboris reprehenderit ipsum aliquip ullamco sunt aute culpa occaecat in aliquip incididunt consequat nostrud.",
-        } }
+        return {
+            card: {
+                to: "sink-hole",
+                title: "Sink Hole",
+                text: "Adipisicing do enim voluptate amet nisi eiusmod ex aliqua exercitation nulla sint magna proident proident. Exercitation in et enim est esse consectetur ex dolore labore ut laborum non minim ea. In ad excepteur cillum commodo veniam dolore labore cupidatat. Ea fugiat occaecat et fugiat consectetur do consectetur anim cillum. Ex nulla est ex cillum esse. Aliquip deserunt consequat pariatur sunt labore occaecat. Excepteur nostrud ex ex anim ut irure tempor eu quis id cupidatat consectetur. Mollit adipisicing cupidatat occaecat labore cupidatat culpa sit pariatur. Anim reprehenderit dolore est aliqua id pariatur quis exercitation incididunt do magna. Reprehenderit irure duis aliqua ullamco sint incididunt commodo exercitation reprehenderit. Non esse quis consectetur eiusmod. Labore dolore ex commodo culpa incididunt ipsum nulla elit tempor in officia eiusmod. Velit incididunt Lorem eiusmod eu anim dolore voluptate elit nisi aliquip est elit qui occaecat. Consequat cillum consectetur pariatur magna incididunt tempor eu do commodo laboris proident id dolor. Pariatur sint incididunt Lorem anim est nostrud qui excepteur eu fugiat exercitation exercitation. Lorem laboris reprehenderit ipsum aliquip ullamco sunt aute culpa occaecat in aliquip incididunt consequat nostrud.",
+            },
+        }
     },
     components: { BlockSimpleCard },
     template: `<block-simple-card v-bind="card" style="max-width: 300px;"/>`,


### PR DESCRIPTION
It looks like chrome was applying `-webkit-line-clamp` by shrinking the text box and inserting an ellepsis, but then letting the box grow again and reveal more lines of text when applying `flex-grow`.

This PR disables `flex-grow` and inserts an empty spacer div to keep the icon at the bottom of the card.