### PR TITLE
fix: external link styling

### DIFF
--- a/src/lib-components/RichText.vue
+++ b/src/lib-components/RichText.vue
@@ -143,18 +143,17 @@ export default {
 
     ::v-deep a[target="_blank"] {
         position: relative;
-        margin-right: 16px;
     }
 
     ::v-deep a[target="_blank"]:after {
         content: url("node_modules/ucla-library-design-tokens/assets/svgs/icon-external-link.svg");
         display: inline-block;
+        background-size: contain;
         scale: 0.6;
         margin-left: -0.3em;
-        position: absolute;
-        bottom: 2.3px;
         width: 1em;
         height: 1em;
+        vertical-align: text-top;
     }
 
     ::v-deep ul,


### PR DESCRIPTION
Connected to [APPS-2208](https://jira.library.ucla.edu/browse/APPS-2208)

firefox:
<img width="1008" alt="firefox" src="https://user-images.githubusercontent.com/44713143/218175403-d3044050-e9e7-438d-acf1-f05797d71c62.png">

chrome:
<img width="953" alt="chrome" src="https://user-images.githubusercontent.com/44713143/218175432-5f76737a-ab48-42be-adee-00896aaf97bd.png">

safari:
<img width="852" alt="safari" src="https://user-images.githubusercontent.com/44713143/218175489-665bc4c0-4415-402f-9d7d-fc36eab8ae91.png">

