### PR TITLE
fix: height of block highlight used in section teaser list

### DIFF
--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -442,9 +442,10 @@ export default {
 
             .image {
                 width: 100%;
+                height: 272px;
             }
             .molecule-no-image {
-                height: 261px;
+                height: 272px;
             }
         }
         .meta {


### PR DESCRIPTION
Before:
<img width="1060" alt="Screenshot 2023-02-10 at 4 35 14 PM" src="https://user-images.githubusercontent.com/8161144/218203752-d36c938f-e3fc-4ae4-9043-595cb5d6dbc7.png">

After:
<img width="1025" alt="Screenshot 2023-02-10 at 4 37 31 PM" src="https://user-images.githubusercontent.com/8161144/218203780-e62ef358-12f6-4cf2-83e2-fb80276d2b18.png">
