### PR TITLE
fix: BlockHighlight responsive title max-width

### DIFF
--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -576,7 +576,7 @@ export default {
                 margin-bottom: var(--space-l);
             }
         }
-        &.is-vertical.has-triangle{
+        &.is-vertical.has-triangle {
             .meta {
                 padding: 0;
                 .title {

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -576,13 +576,11 @@ export default {
                 margin-bottom: var(--space-l);
             }
         }
-        &.is-vertical.has-triangle 
-            .title {
-                max-width: 680px;
-            }
-            .meta {
-                padding: 0;
-            
+        &.is-vertical.has-triangle .title {
+            max-width: 680px;
+        }
+        .meta {
+            padding: 0;
 
             .category {
                 padding-right: 72px;

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -576,28 +576,32 @@ export default {
                 margin-bottom: var(--space-l);
             }
         }
-        &.is-vertical.has-triangle .title {
-            max-width: 680px;
-        }
-        .meta {
-            padding: 0;
+        &.is-vertical.has-triangle{
+            .meta {
+                padding: 0;
+                .title {
+                    max-width: 680px;
+                }
 
-            .category {
-                padding-right: 72px;
+                .category {
+                    padding-right: 72px;
+                }
             }
-        }
-        .schedule {
-            flex-direction: column;
-        }
+            .schedule {
+                flex-direction: column;
+            }
 
-        .schedule-item:after {
-            display: none;
+            .schedule-item:after {
+                display: none;
+            }
         }
     }
     @media #{$small} {
         &.is-vertical.has-triangle {
-            .title {
-                max-width: 320px;
+            .meta {
+                .title {
+                    max-width: 320px;
+                }
             }
         }
         &:not(&.is-vertical) {

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -576,8 +576,13 @@ export default {
                 margin-bottom: var(--space-l);
             }
         }
-        &.is-vertical.has-triangle .meta {
-            padding: 0;
+        &.is-vertical.has-triangle 
+            .title {
+                max-width: 680px;
+            }
+            .meta {
+                padding: 0;
+            
 
             .category {
                 padding-right: 72px;
@@ -592,6 +597,11 @@ export default {
         }
     }
     @media #{$small} {
+        &.is-vertical.has-triangle {
+            .title {
+                max-width: 300px;
+            }
+        }
         &:not(&.is-vertical) {
             .image {
                 max-width: 100%;

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -600,7 +600,7 @@ export default {
         &.is-vertical.has-triangle {
             .meta {
                 .title {
-                    max-width: 320px;
+                    max-width: 312px;
                 }
             }
         }

--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -599,7 +599,7 @@ export default {
     @media #{$small} {
         &.is-vertical.has-triangle {
             .title {
-                max-width: 300px;
+                max-width: 320px;
             }
         }
         &:not(&.is-vertical) {

--- a/src/stories/BlockHighlight.stories.js
+++ b/src/stories/BlockHighlight.stories.js
@@ -151,6 +151,28 @@ export const LongTitleNoDate = () => ({
   `,
 })
 
+export const LongTitleNoDateNoEyebrow = () => ({
+    data() {
+        return {
+            ...mock,
+        }
+    },
+    components: { BlockHighlight },
+    template: `
+      <block-highlight
+          :image="image"
+          :to="to"
+          title="Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum"
+          :text="text"
+          :has-triangle="true"
+          :is-vertical="true"
+          :image-aspect-ratio="60"
+          :locations="locations"
+          :section-handle="sectionHandle"
+      />
+  `,
+})
+
 export const Card = () => ({
     data() {
         return { ...mock }


### PR DESCRIPTION
Connected to [WST-116](https://jira.library.ucla.edu/browse/WST-116)

sets max-width for highlight title on tablet and mobile to prevent text overlaying on image
https://deploy-preview-340--ucla-library-storybook.netlify.app/?path=/story/block-highlight--long-title-no-date-no-eyebrow