### PR TITLE
fix: hide disc list marker

### DIFF
--- a/src/lib-components/BlockLocationListItem.vue
+++ b/src/lib-components/BlockLocationListItem.vue
@@ -24,7 +24,7 @@
                     <div v-if="libcalHoursData && isUclaLibrary" class="time">
                         <IconClock />
                         <span v-if="libcalHoursData.day">{{
-                            libcalHoursData.day
+                            'Today'
                         }}</span>
                         <div
                             class="hour"

--- a/src/lib-components/RichText.vue
+++ b/src/lib-components/RichText.vue
@@ -189,6 +189,7 @@ export default {
         background-position-y: 5px; // This will shift the bullet down as needed
         background-size: 24px;
         padding-left: 40px;
+        overflow: hidden;
     }
 
     ::v-deep table {


### PR DESCRIPTION
Connected to [APPS-2214](https://jira.library.ucla.edu/browse/APPS-2214)
Connected to [APPS-2229](https://jira.library.ucla.edu/browse/APPS-2229)

- hides disc list marker that was appearing in browser
- updates BlockLocationListItem to display "Today" rather than day of the week
