### PR TITLE
fix: change section summary to richtext in section wrapper

### DIFF
--- a/src/lib-components/SectionWrapper.vue
+++ b/src/lib-components/SectionWrapper.vue
@@ -8,12 +8,14 @@
                 class="section-title"
                 v-text="sectionTitle"
             />
-            <div
+
+            <RichText
                 v-if="sectionSummary"
                 class="section-summary"
                 v-html="sectionSummary"
             />
         </div>
+
         <slot />
     </section>
 </template>


### PR DESCRIPTION
Connected to [APPS-2338](https://jira.library.ucla.edu/browse/APPS-2338) && [APPS-2319](https://jira.library.ucla.edu/browse/APPS-2319)

Change section-summary to `richtext` in section wrapper so the styles in the Craft are displayed in production.

<img width="734" alt="Screenshot 2023-08-10 at 11 44 10 AM" src="https://github.com/UCLALibrary/ucla-library-website-components/assets/751697/d4e43cb9-4e68-451d-9eb9-98b8a27e9b22">

