### PR TITLE
feat: update styles to work with halfWidth option in redactor

### DIFF
--- a/src/lib-components/RichText.vue
+++ b/src/lib-components/RichText.vue
@@ -95,39 +95,31 @@ export default {
         }
     }
 
-    ::v-deep .figure {
+    ::v-deep img {
+        height: auto;
+        object-fit: cover;
+        display: inline-block;
+    }
+
+    ::v-deep figure {
         width: 100%;
-        margin: var(--space-s);
+        margin: var(--space-s) !important;
 
-        display: flex;
-        flex-direction: column;
-    }
-
-    ::v-deep .image-right {
-        float: right;
-        margin-left: var(--space-s);
-    }
-
-    ::v-deep .image-left {
-        float: left;
-        margin-right: var(--space-s);
+        a[target="_blank"]:after {
+            display: none;
+        }
     }
 
     ::v-deep figcaption {
         font-family: var(--font-secondary);
         @include step--1;
         color: var(--color-secondary-grey-05);
-        padding: 16px 16px 26px 16px;
+        padding: var(--space-s) var(--space-s) 0 var(--space-s);
     }
 
     ::v-deep iframe {
         width: 100%;
         height: 400px;
-        object-fit: cover;
-    }
-
-    ::v-deep img {
-        height: auto;
         object-fit: cover;
     }
 
@@ -242,11 +234,18 @@ export default {
     @media #{$medium} {
         padding-right: 0;
         max-width: $container-l-main + px;
+
+        ::v-deep figure {
+            width: 100% !important;
+            max-width: 100% !important;
+            height: auto;
+        }
     }
 
     @media #{$small} {
-        ::v-deep .figure {
-            width: 100%;
+        ::v-deep figure {
+            width: 100% !important;
+            max-width: 100% !important;
             height: auto;
         }
         ::v-deep iframe {

--- a/src/lib-components/RichText.vue
+++ b/src/lib-components/RichText.vue
@@ -258,6 +258,18 @@ export default {
         ::v-deep figure {
             width: 100%;
             height: auto;
+            margin: 0;
+        }
+        ::v-deep .image--right {
+            margin-left: 0;
+        }
+
+        ::v-deep figcaption {
+            padding-bottom: var(--space-s);
+        }
+
+        ::v-deep .image--left {
+            margin-right: 0;
         }
         ::v-deep .image--half {
             width: 100%;

--- a/src/lib-components/RichText.vue
+++ b/src/lib-components/RichText.vue
@@ -103,11 +103,29 @@ export default {
 
     ::v-deep figure {
         width: 100%;
-        margin: var(--space-s) !important;
-
+        margin: var(--space-s);
+        display: flex;
+        flex-direction: column;
         a[target="_blank"]:after {
             display: none;
         }
+    }
+
+    ::v-deep .image--right {
+        float: right;
+        margin-left: var(--space-s);
+    }
+
+    ::v-deep .image--left {
+        float: left;
+        margin-right: var(--space-s);
+    }
+
+    ::v-deep .image--center {
+        margin: 0 auto;
+    }
+    ::v-deep .image--half {
+        width: 50%;
     }
 
     ::v-deep figcaption {
@@ -234,19 +252,15 @@ export default {
     @media #{$medium} {
         padding-right: 0;
         max-width: $container-l-main + px;
-
-        ::v-deep figure {
-            width: 100% !important;
-            max-width: 100% !important;
-            height: auto;
-        }
     }
 
     @media #{$small} {
         ::v-deep figure {
-            width: 100% !important;
-            max-width: 100% !important;
+            width: 100%;
             height: auto;
+        }
+        ::v-deep .image--half {
+            width: 100%;
         }
         ::v-deep iframe {
             width: 100%;


### PR DESCRIPTION
Connected to [APPS-2055](https://jira.library.ucla.edu/browse/APPS-2055)

Adds styles to work with adding a halfWidth option for images to the redactor plugin


[APPS-2055]: https://uclalibrary.atlassian.net/browse/APPS-2055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ