### PR TITLE
fix: APPS-2434   Fix meap filters when covering block-highlight component

### DIFF
--- a/src/lib-components/BlockHighlight.vue
+++ b/src/lib-components/BlockHighlight.vue
@@ -309,7 +309,7 @@ export default {
         }
     }
     .meta {
-        z-index: 10;
+        z-index: 0;
         width: 100%;
     }
     .category {


### PR DESCRIPTION
Connected to [APPS-2434](https://jira.library.ucla.edu/browse/APPS-2434)
