### PR TITLE
chore: update to latest design tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
                 "sass-loader": "^10.1.1",
                 "semantic-release": "^19.0.2",
                 "storybook-vue-router": "^1.0.7",
-                "ucla-library-design-tokens": "^5.5.0",
+                "ucla-library-design-tokens": "^5.5.1",
                 "vue": "^2.6.14",
                 "vue-loader": "^15.9.8",
                 "vue-router": "^3.5.4",
@@ -35635,9 +35635,9 @@
             }
         },
         "node_modules/ucla-library-design-tokens": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/ucla-library-design-tokens/-/ucla-library-design-tokens-5.5.0.tgz",
-            "integrity": "sha512-Y2qRlOdTbtU03S+/0gRQn/h2SypxP0QEPxkqLKDDVgDePR9tepf7iOCkWWUwfvcRtyEWtQirsC20e13kKAbBLg==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/ucla-library-design-tokens/-/ucla-library-design-tokens-5.5.1.tgz",
+            "integrity": "sha512-PuPLeUCi3L3bfjz5yI8lKXsnmYpOJq9tNsIs+jVDPRhTT4gi3I+HTAO7CGpqYuvavdV+s4fTvctO9KkSEm7Dtg==",
             "dev": true
         },
         "node_modules/uglify-js": {
@@ -65700,9 +65700,9 @@
             }
         },
         "ucla-library-design-tokens": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/ucla-library-design-tokens/-/ucla-library-design-tokens-5.5.0.tgz",
-            "integrity": "sha512-Y2qRlOdTbtU03S+/0gRQn/h2SypxP0QEPxkqLKDDVgDePR9tepf7iOCkWWUwfvcRtyEWtQirsC20e13kKAbBLg==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/ucla-library-design-tokens/-/ucla-library-design-tokens-5.5.1.tgz",
+            "integrity": "sha512-PuPLeUCi3L3bfjz5yI8lKXsnmYpOJq9tNsIs+jVDPRhTT4gi3I+HTAO7CGpqYuvavdV+s4fTvctO9KkSEm7Dtg==",
             "dev": true
         },
         "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "sass-loader": "^10.1.1",
         "semantic-release": "^19.0.2",
         "storybook-vue-router": "^1.0.7",
-        "ucla-library-design-tokens": "^5.5.0",
+        "ucla-library-design-tokens": "^5.5.1",
         "vue": "^2.6.14",
         "vue-loader": "^15.9.8",
         "vue-router": "^3.5.4",


### PR DESCRIPTION
fixes issues with repeated duplicate svg ids