### PR TITLE
fix: update search when clearing search bar

### DIFF
--- a/src/lib-components/SearchGeneric.vue
+++ b/src/lib-components/SearchGeneric.vue
@@ -22,6 +22,7 @@
                     class="search-input"
                     :model-value.sync="searchWords"
                     :placeholder="placeholder"
+                    @clear="doSearch"
                     @keyup.native.enter="doSearch"
                 />
                 <button class="button-submit" type="submit" @click="doSearch">

--- a/src/lib-components/SearchInput.vue
+++ b/src/lib-components/SearchInput.vue
@@ -106,6 +106,7 @@ export default {
             console.log("in clear")
             this.searchInputModelValue = ""
             this.$emit("update:modelValue", "")
+            this.$emit("clear", "")
         },
         onInput(e) {
             this.searchInputModelValue = e.target.value


### PR DESCRIPTION
connected to [APPS-2541](https://uclalibrary.atlassian.net/browse/APPS-2541)

emits a "search-ready" event which triggers a route update, api call, &c in library-website-nuxt

The only way to test this is locally with `npm run build && npm link` and `npm link ucla-library-website-components` in the website repo. I can confirm that it fixed the issue.

[APPS-2541]: https://uclalibrary.atlassian.net/browse/APPS-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ