### PR TITLE
feat: APPS:2562 add Flexible/PullQuote component to vue3

### DIFF
--- a/src/lib-components/Flexible/PullQuote.vue
+++ b/src/lib-components/Flexible/PullQuote.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { PropType } from 'vue'
+import type { FlexiblePullQuote } from '@/types/flexible_types'
+
+// COMPONENTS
+import PullQuote from '@/lib-components/PullQuote.vue'
+
+const { block } = defineProps({
+    block: {
+        type: Object as PropType<FlexiblePullQuote>,
+        default: () => { },
+    },
+})
+</script>
+
+<template>
+    <PullQuote
+        v-if="block.pullQuote"
+        :text="block.pullQuote[0].text"
+        :attribution="block.pullQuote[0].attribution"
+    />
+</template>
+
+<style lang="scss" scoped>
+.pull-quote {
+    &.flexible-block {
+        margin: var(--unit-gutter) auto;
+        padding: 0 var(--unit-gutter);
+        max-width: $container-l-main + px;
+
+        @media #{$medium} {
+            margin: var(--unit-gutter);
+        }
+    }
+}
+</style>

--- a/src/lib-components/Flexible/PullQuote.vue
+++ b/src/lib-components/Flexible/PullQuote.vue
@@ -6,19 +6,19 @@ import type { FlexiblePullQuote } from '@/types/flexible_types'
 import PullQuote from '@/lib-components/PullQuote.vue'
 
 const { block } = defineProps({
-    block: {
-        type: Object as PropType<FlexiblePullQuote>,
-        default: () => { },
-    },
+  block: {
+    type: Object as PropType<FlexiblePullQuote>,
+    default: () => { },
+  },
 })
 </script>
 
 <template>
-    <PullQuote
-        v-if="block.pullQuote"
-        :text="block.pullQuote[0].text"
-        :attribution="block.pullQuote[0].attribution"
-    />
+  <PullQuote
+    v-if="block.pullQuote"
+    :text="block.pullQuote[0].text"
+    :attribution="block.pullQuote[0].attribution"
+  />
 </template>
 
 <style lang="scss" scoped>

--- a/src/lib-components/PullQuote.vue
+++ b/src/lib-components/PullQuote.vue
@@ -65,6 +65,12 @@ export default {
     font-weight: 600;
   }
 
+  :deep(.rich-text) {
+    max-width: none;
+    margin: 0;
+    padding-right: 0;
+  }
+
   // Breakpoints
   @media #{$small} {
     --spacing-text-left: 24px;

--- a/src/lib-components/PullQuote.vue
+++ b/src/lib-components/PullQuote.vue
@@ -1,6 +1,12 @@
 <script>
+// COMPONENTS
+import RichText from './RichText.vue'
+
 export default {
   name: 'PullQuote',
+  components: {
+    RichText
+  },
   props: {
     text: {
       type: String,
@@ -16,61 +22,77 @@ export default {
 
 <template>
   <div class="pull-quote">
-    <!-- eslint-disable vue/no-v-html -->
-    <div v-if="text" class="quote" v-html="text" />
-    <div v-if="attribution" class="attribution-block">
+    <RichText
+      v-if="text"
+      class="quote"
+      :rich-text-content="text"
+    />
+    <div
+      v-if="attribution"
+      class="attribution-block"
+    >
       <span class="dash">—</span>
-      <span v-if="attribution" class="attribution" v-html="attribution" />
+      <span
+        v-if="attribution"
+        class="attribution"
+        v-html="attribution"
+      />
     </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
 .pull-quote {
-    background-color: var(--color-white);
-    max-width: var(--container-width);
-    text-align: left;
-    font-family: var(--font-primary);
+  background-color: var(--color-white);
+  max-width: var(--container-width);
+  text-align: left;
+  font-family: var(--font-primary);
+  font-size: 24px;
+  font-style: italic;
+  font-weight: 600;
+  line-height: 150%;
+  letter-spacing: 0.01em;
+  color: var(--color-primary-blue-03);
+  border-left: 4px solid var(--color-default-cyan-03);
+  border-radius: 2px;
+  padding: 24px var(--spacing-text-left);
+  --spacing-text-left: 64px;
+  --container-width: $container-m-text + px;
+
+  :deep(a:link) {
     font-size: 24px;
     font-style: italic;
     font-weight: 600;
-    line-height: 150%;
-    letter-spacing: 0.01em;
-    color: var(--color-primary-blue-03);
-    border-left: 4px solid var(--color-default-cyan-03);
-    border-radius: 2px;
-    padding: 24px var(--spacing-text-left);
-    --spacing-text-left: 64px;
-    --container-width: $container-m-text + px;
+  }
 
-    // Breakpoints
-    @media #{$small} {
-        --spacing-text-left: 24px;
-        --container-width: 100%;
-    }
+  // Breakpoints
+  @media #{$small} {
+    --spacing-text-left: 24px;
+    --container-width: 100%;
+  }
 
-    .attribution-block {
-        padding-top: 24px;
-    }
+  .attribution-block {
+    padding-top: 24px;
+  }
 
-    .dash {
-        font-size: 48px;
-        font-style: normal;
-        font-weight: 300;
-        color: var(--color-secondary-grey-05);
-        position: absolute;
-        height: 58px;
-    }
+  .dash {
+    font-size: 48px;
+    font-style: normal;
+    font-weight: 300;
+    color: var(--color-secondary-grey-05);
+    position: absolute;
+    height: 58px;
+  }
 
-    .attribution {
-        font-weight: 400;
-        font-size: 20px;
-        font-style: normal;
-        line-height: 140%;
-        align-items: center;
-        text-transform: uppercase;
-        color: var(--color-secondary-grey-05);
-        margin-left: 50px;
-    }
+  .attribution {
+    font-weight: 400;
+    font-size: 20px;
+    font-style: normal;
+    line-height: 140%;
+    align-items: center;
+    text-transform: uppercase;
+    color: var(--color-secondary-grey-05);
+    margin-left: 50px;
+  }
 }
 </style>

--- a/src/lib-components/index.js
+++ b/src/lib-components/index.js
@@ -42,6 +42,7 @@ export { default as FlexibleImpactNumberCards } from './Flexible/ImpactNumberCar
 export { default as FlexibleMediaGalleryBannerImage } from './Flexible/MediaGallery/BannerImage.vue'
 export { default as FlexibleMediaGalleryNewLightbox } from './Flexible/MediaGallery/NewLightbox.vue'
 export { default as FlexibleMediaGalleryThumbnailCard } from './Flexible/MediaGallery/ThumbnailCard.vue'
+export { default as FlexiblePullQuote } from './Flexible/PullQuote.vue'
 export { default as FooterMain } from './FooterMain.vue'
 export { default as FooterPrimary } from './FooterPrimary.vue'
 export { default as FooterSock } from './FooterSock.vue'

--- a/src/stories/Flexible_PullQuote.spec.js
+++ b/src/stories/Flexible_PullQuote.spec.js
@@ -1,10 +1,10 @@
-describe("FLEXIBLE / Pull Quote", () => {
-  it("Default", () => {
+describe('FLEXIBLE / Pull Quote', () => {
+  it('Default', () => {
     cy.visit(
-      "/iframe.html?id=flexible-pull-quote--default&args=&viewMode=story"
+      '/iframe.html?id=flexible-pull-quote--default&args=&viewMode=story'
     )
-    cy.get(".pull-quote").should("exist")
+    cy.get('.pull-quote').should('exist')
 
-    cy.percySnapshot("FLEXIBLE / Pull Quote: Default")
+    cy.percySnapshot('FLEXIBLE / Pull Quote: Default')
   })
 })

--- a/src/stories/Flexible_PullQuote.spec.js
+++ b/src/stories/Flexible_PullQuote.spec.js
@@ -1,0 +1,10 @@
+describe("FLEXIBLE / Pull Quote", () => {
+  it("Default", () => {
+    cy.visit(
+      "/iframe.html?id=flexible-pull-quote--default&args=&viewMode=story"
+    )
+    cy.get(".pull-quote").should("exist")
+
+    cy.percySnapshot("FLEXIBLE / Pull Quote: Default")
+  })
+})

--- a/src/stories/Flexible_PullQuote.stories.js
+++ b/src/stories/Flexible_PullQuote.stories.js
@@ -1,7 +1,7 @@
-import FlexiblePullQuote from "@/lib-components/Flexible/PullQuote"
+import FlexiblePullQuote from '@/lib-components/Flexible/PullQuote'
 
 export default {
-  title: "FLEXIBLE / Pull Quote",
+  title: 'FLEXIBLE / Pull Quote',
   component: FlexiblePullQuote,
 }
 
@@ -9,11 +9,11 @@ const mock = {
   pullQuote: [
     {
       text: 'There are three ways to ultimate success: <a href="https://blog.iamsecond.com/mister-rogers">The first way is to be kind</a>. The second way is to be kind. The third way is to be kind.',
-      attribution: "Mr. Rodgers",
+      attribution: 'Mr. Rodgers',
     },
     {
-      text: "Better is the enemy of good.",
-      attribution: "Voltaire",
+      text: 'Better is the enemy of good.',
+      attribution: 'Voltaire',
     },
   ],
 }

--- a/src/stories/Flexible_PullQuote.stories.js
+++ b/src/stories/Flexible_PullQuote.stories.js
@@ -1,0 +1,55 @@
+import FlexiblePullQuote from "@/lib-components/Flexible/PullQuote"
+
+export default {
+  title: "FLEXIBLE / Pull Quote",
+  component: FlexiblePullQuote,
+}
+
+const mock = {
+  pullQuote: [
+    {
+      text: 'There are three ways to ultimate success: <a href="https://blog.iamsecond.com/mister-rogers">The first way is to be kind</a>. The second way is to be kind. The third way is to be kind.',
+      attribution: "Mr. Rodgers",
+    },
+    {
+      text: "Better is the enemy of good.",
+      attribution: "Voltaire",
+    },
+  ],
+}
+
+export function Default() {
+  return {
+    data() {
+      return { block: mock }
+    },
+    components: { FlexiblePullQuote },
+    template: `
+        <flexible-pull-quote
+            :block="block"
+        />
+    `,
+  }
+}
+
+const mockNoAttribution = {
+  pullQuote: [
+    {
+      text: 'Human greatness does not lie in wealth or power, but in character and goodness. People are just people, and all people have faults and shortcomings, but all of us are born with a <a href="https://www.good.is/">basic goodness</a>.',
+    },
+  ],
+}
+
+export function NoAttribution() {
+  return {
+    data() {
+      return { block: mockNoAttribution }
+    },
+    components: { FlexiblePullQuote },
+    template: `
+      <flexible-pull-quote
+          :block="block"
+      />
+    `,
+  }
+}

--- a/src/stories/PullQuote.stories.js
+++ b/src/stories/PullQuote.stories.js
@@ -6,8 +6,8 @@ export default {
 }
 
 const mock = {
-  text: 'Vestibulum ac nunc blandit elit hendrerit venenatis hendrerit eget dolor. Curabitur a purus vel felis vulputate pretium. Duis ligula quam, faucibus nec gravida eget, vehicula eget mauris. Sed consequat pulvinar nisi, in suscipit est pretium',
-  attribution: 'Duis Blandit',
+  text: 'You get to decide where your time goes. You can either spend it <strong>moving forward</strong>, or you can spend it <a href="https://dothethings.com/always-putting-out-fires-in-business/">putting out fires</a>. You decide. And if you don’t decide, <em>others will decide for you</em>.',
+  attribution: 'Tony Morgan',
 }
 
 export function Default() {
@@ -28,7 +28,7 @@ export function Default() {
 }
 
 const mockNoAttribution = {
-  text: 'Duis ligula quam, faucibus nec gravida eget, vehicula eget mauris. Sed consequat pulvinar nisi, in suscipit.',
+  text: 'If I could reach up and hold a star for every time you have made me smile, <a href="https://earthsky.org/astronomy-essentials/visible-planets-tonight-mars-jupiter-venus-saturn-mercury/">the entire evening sky</a> would be in the palm of my hand.',
 }
 
 export function NoAttribution() {

--- a/src/types/flexible_types.ts
+++ b/src/types/flexible_types.ts
@@ -171,7 +171,7 @@ export interface FlexibleImpactNumberCards extends FlexibleBlock {
 
 export interface FlexiblePullQuote extends FlexibleBlock {
   pullQuote: {
-    text: string,
+    text: string
     attribution: string
   }[]
 }

--- a/src/types/flexible_types.ts
+++ b/src/types/flexible_types.ts
@@ -168,3 +168,10 @@ export interface FlexibleHighlightBlock extends FlexibleBlock {
 export interface FlexibleImpactNumberCards extends FlexibleBlock {
   impactNumberCards: FlexibleImpactNumberCard[]
 }
+
+export interface FlexiblePullQuote extends FlexibleBlock {
+  pullQuote: {
+    text: string,
+    attribution: string
+  }[]
+}


### PR DESCRIPTION
Connected to [APPS-2562](https://uclalibrary.atlassian.net/jira/software/c/projects/APPS/boards/12?selectedIssue=APPS-2562)

**Component Created:** `Flexible/PullQuote.vue`

**Stories:** `~/stories/Flexible_PullQuote.stories.js`

**Spec:** `~/stories/Flexible_PullQuote.spec.js`

**Notes:**
May have to add  this v-deep page level because of the RichText styling..
```
:deep(.pull-quote) {
    padding: 24px var(--spacing-text-left);
    --spacing-text-left: 64px;
    --container-width: $container-m-text + px;
  }
```

---

<img width="1124" alt="Screenshot 2024-02-21 at 4 57 10 PM" src="https://github.com/UCLALibrary/ucla-library-website-components/assets/751697/9b661ad3-a541-4352-9b95-786a40a6634b">

---

<img width="1288" alt="Screenshot 2024-02-21 at 12 20 26 PM" src="https://github.com/UCLALibrary/ucla-library-website-components/assets/751697/14795814-a3b2-46ea-9d81-7d1aaa80af13">

---

<img width="1058" alt="Screenshot 2024-02-21 at 12 21 51 PM" src="https://github.com/UCLALibrary/ucla-library-website-components/assets/751697/7ed364b6-dbde-46c3-9ba6-637132196b0d">

Updates `PullQuote.vue` with `<RichText>` for the text

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR



[APPS-2562]: https://uclalibrary.atlassian.net/browse/APPS-2562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ