### PR TITLE
feat: APPS-2265, Add clickoutside feature to search-generic component

### DIFF
--- a/src/lib-components/SearchGenericFilters.vue
+++ b/src/lib-components/SearchGenericFilters.vue
@@ -2,7 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import type { PropType } from 'vue'
 
-// import { onClickOutside } from '@vueuse/core'
+import { onClickOutside } from '@vueuse/core'
 
 import SearchGenericFilterButtons from './SearchGenericFilterButtons.vue'
 import BaseRadioGroup from './BaseRadioGroup.vue'
@@ -94,15 +94,6 @@ const parsedFilters = computed(() => {
   })
 })
 
-// Logic to hide the dropdowns when clicked outside anywhere
-
-/* function closeFilterDropDowns() {
-
-  for (item in parsedFilters.value) {
-    item.isVisible = false
-  }
-} */
-
 function toggleTransition(index: number) {
   // Toggles visibility state for the given index
   openItemIndex.value = openItemIndex.value === index ? -1 : index
@@ -123,10 +114,14 @@ function doSearch() {
 watch(queryFilterButtonDropDownStates, () => {
   checkedState.value = props.filters.some(obj => obj.inputType === 'single-checkbox' && queryFilterButtonDropDownStates.value[obj.esFieldName]?.includes('yes'))
 })
+
+//click outside setup
+const clickOutsideTarget = ref(null)
+onClickOutside(clickOutsideTarget, event => { openItemIndex.value = -1 })
 </script>
 
 <template>
-  <div class="search-generic-filters">
+  <div class="search-generic-filters" ref="clickOutsideTarget">
     <div
       v-if="filters.length > 0"
       class="container"

--- a/src/lib-components/SearchGenericFilters.vue
+++ b/src/lib-components/SearchGenericFilters.vue
@@ -117,7 +117,8 @@ watch(queryFilterButtonDropDownStates, () => {
 
 // click outside setup
 const clickOutsideTarget = ref(null)
-onClickOutside(clickOutsideTarget, () => { openItemIndex.value = -1 })
+onClickOutside(clickOutsideTarget,
+  () => { openItemIndex.value = -1 })
 </script>
 
 <template>

--- a/src/lib-components/SearchGenericFilters.vue
+++ b/src/lib-components/SearchGenericFilters.vue
@@ -115,13 +115,13 @@ watch(queryFilterButtonDropDownStates, () => {
   checkedState.value = props.filters.some(obj => obj.inputType === 'single-checkbox' && queryFilterButtonDropDownStates.value[obj.esFieldName]?.includes('yes'))
 })
 
-//click outside setup
+// click outside setup
 const clickOutsideTarget = ref(null)
-onClickOutside(clickOutsideTarget, event => { openItemIndex.value = -1 })
+onClickOutside(clickOutsideTarget, () => { openItemIndex.value = -1 })
 </script>
 
 <template>
-  <div class="search-generic-filters" ref="clickOutsideTarget">
+  <div ref="clickOutsideTarget" class="search-generic-filters">
     <div
       v-if="filters.length > 0"
       class="container"


### PR DESCRIPTION
Connected to [APPS-2265](https://jira.library.ucla.edu/browse/APPS-2265)

**Notes:**

Edited search generic filters to allow closing the filter dropdowns when clicking outside. The SearchGeneric storybook should now show the same behavior as the vue 2 version, where clicking outside the dropdowns automatically closes them https://ucla-library-storybook.netlify.app/?path=/story/search-generic--default

**Checklist:**

-   [X ] I checked that it is working locally in the dev server
-   [X ] I checked that it is working locally in the storybook
-   [X ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X ] I used a conventional commit message
-   [X ] I assigned myself to this PR


[APPS-2265]: https://uclalibrary.atlassian.net/browse/APPS-2265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ