### PR TITLE
fix: APPS-2668 SearchHome.vue query param should be q

### DIFF
--- a/src/lib-components/SearchHome.vue
+++ b/src/lib-components/SearchHome.vue
@@ -86,7 +86,7 @@ function doSearch() {
   if (isSiteSearch.value) {
     router.push({
       path: actionUrl.value,
-      query: { [queryParam as any]: searchWords.value },
+      query: { [queryParam.value as string]: searchWords.value },
     })
   }
   else {

--- a/src/stories/SearchHome.spec.js
+++ b/src/stories/SearchHome.spec.js
@@ -7,4 +7,11 @@ describe('Search / Search Home', () => {
 
     cy.percySnapshot('Search / Home: Default')
   })
+  it('uses q for query parameter', () => {
+    cy.visit('/iframe.html?id=search-search-home--default&args=&viewMode=story')
+    // click the library search tab, then submit empty search
+    cy.contains('button', 'Site Search').click()
+    cy.get('button[class="button-submit"]').click()
+    cy.url().should('include', '?q=')
+  })
 })


### PR DESCRIPTION
Connected to [APPS-2668](https://jira.library.ucla.edu/browse/APPS-2668)

**Component Edited:** SearchHome.vue

**Spec Edited:** ~/stories/SearchHome.spec.js, added a story for this requirement

**Notes:**

Sneaky error where we were passing the entire ref object for queryParam, instead of just the queryParam.value as a simple string

**Checklist:**

-   [ X] I checked that it is working locally in the dev server
-   [ X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ X] I assigned this PR to someone on the dev team to review
-   [ X] I used a conventional commit message
-   [ X] I assigned myself to this PR


[APPS-2668]: https://uclalibrary.atlassian.net/browse/APPS-2668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ