### PR TITLE
fix: APPS-2675 fix BlockStaffDetail.vue image type

### DIFF
--- a/src/lib-components/BlockStaffDetail.vue
+++ b/src/lib-components/BlockStaffDetail.vue
@@ -20,8 +20,8 @@ import IconWithLink from '@/lib-components/IconWithLink.vue'
 // PROPS & DATA
 const props = defineProps({
   image: {
-    type: Array as PropType<MediaItemType[]>,
-    default: () => [],
+    type: Object as PropType<MediaItemType>,
+    default: () => {},
   },
   to: {
     type: String,
@@ -92,10 +92,6 @@ const props = defineProps({
   }
 })
 
-const parsedImage = computed(() => {
-  return props.image.length ? props.image[0].src : {}
-})
-
 const parsedPronouns = computed(() => {
   return `Pronouns: ${props.pronouns}`
 })
@@ -152,8 +148,8 @@ const mergeSortTopics = computed(() => {
     <div class="section-staff-bio">
       <div :class="image ? 'body-contact' : 'body-contact no-image'">
         <ResponsiveImage
-          v-if="props.image.length"
-          :media="parsedImage"
+          v-if="image"
+          :media="image"
           :aspect-ratio="100"
           class="image"
         />

--- a/src/stories/BlockStaffDetail.stories.js
+++ b/src/stories/BlockStaffDetail.stories.js
@@ -13,7 +13,7 @@ const mockDefault = {
   slug: 'test-subject-librarian',
   uri: 'about/staff/test-subject-librarian',
   title: 'TEST - Subject Librarian',
-  image: [{ src: API.image_people }],
+  image: API.image_people,
   to: 'test-subject-librarian',
   nameFirst: 'TEST - Subject',
   nameLast: 'Librarian',
@@ -82,7 +82,7 @@ const mockAlternativeName = {
   slug: 'test-phyllis-blackshear',
   uri: 'about/staff/test-phyllis-blackshear',
   title: 'Test Alternative Name Phyllis Blackshear',
-  image: [{ src: API.image_people }],
+  image: API.image_people,
   to: 'test-phyllis-blackshear',
   nameFirst: 'test_Phyllis',
   nameLast: 'Blackshear',
@@ -155,7 +155,7 @@ const mockNoImageOneLocation = {
   slug: 'sylvia-page',
   uri: 'about/staff/sylvia-page',
   title: 'Test  NO IMAGE Penelope Pitstop',
-  image: [],
+  // image: {},
   to: 'sylvia-page',
   nameFirst: 'Test  NO IMAGE Penelope',
   nameLast: 'Pitstop',
@@ -234,7 +234,7 @@ const mockNoImageOrBio = {
   slug: 'sylvia-page',
   uri: 'about/staff/sylvia-page',
   title: 'Test  NO IMAGE Penelope Pitstop',
-  image: [],
+  image: {},
   to: 'sylvia-page',
   nameFirst: 'Test  NO IMAGE Penelope',
   nameLast: 'Pitstop',
@@ -377,7 +377,7 @@ export function NoImageOrBio() {
   }
 }
 
-export function AskMeAboutAndAcademicDeaprtments() {
+export function AskMeAboutAndAcademicDepartments() {
   return {
     data() {
       return {


### PR DESCRIPTION
Connected to [APPS-2675](https://jira.library.ucla.edu/browse/APPS-2675)

**Component Edited:** BlockStaffDetail.vue

**Stories Edited:** ~/stories/BlockStaffDetail.stories.js


**Notes:**

images won't display because our mock storybook data is bugged, it has the entire image object being passed as the src argument for the responsiveImage child component, this means the responsiveImage component in BlockStaffDetail.vue never renders with actual data, and throws errors about getting a string when it expects an object

**Checklist:**

-   [X ] I checked that it is working locally in the dev server
-   [X ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X ] I used a conventional commit message
-   [X ] I assigned myself to this PR


[APPS-2675]: https://uclalibrary.atlassian.net/browse/APPS-2675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ