### PR TITLE
fix: APPS-2665 When user clicks the x on search keyword, the search is not triggered automatically

### DIFF
--- a/src/lib-components/SearchInput.vue
+++ b/src/lib-components/SearchInput.vue
@@ -35,8 +35,9 @@ const props = defineProps({
     default: true
   }
 })
-const emit = defineEmits(['update:modelValue'])
-console.log('modelValue', props.modelValue)
+//
+const emit = defineEmits(['update:modelValue', 'clear'])
+// console.log('modelValue', props.modelValue)
 const attrs = useAttrs()
 
 const hasFocus = ref(false)
@@ -94,6 +95,7 @@ function clear() {
   // console.log('in clear')
   searchInputModelValue.value = ''
   emit('update:modelValue', '')
+  emit('clear')
 }
 
 function onInput(e) {


### PR DESCRIPTION
Connected to [APPS-2665](https://jira.library.ucla.edu/browse/APPS-2665)

**Notes:**

Needed to add additional syntax to get the child component to emit the 'clear' event to its parent 

**Checklist:**

-   [X ] I checked that it is working locally in the dev server
-   [ X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X ] I used a conventional commit message
-   [X ] I assigned myself to this PR


[APPS-2665]: https://uclalibrary.atlassian.net/browse/APPS-2665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ