### PR TITLE
chore: APPS-2557 carryover improvements from nuxt2 branch

### DIFF
--- a/src/stories/CardMeta.stories.js
+++ b/src/stories/CardMeta.stories.js
@@ -14,7 +14,7 @@ const mock = {
   language: 'zh',
   startDate: '2022-03-31T07:00:00+00:00',
   endDate: '2021-11-26T11:00:00-08:00',
-  text: '<p>In Greek literature (which is where the phrase entered Western literature), the Seven Seas were the <strong>Aegean</strong>, <em>Adriatic</em>, Mediterranean, Black, Red, and Caspian seas, with the Persian Gulf.</p> <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>',
+  text: '<p>In Greek literature (which is where the phrase entered Western literature), the Seven Seas were the <strong>Aegean</strong>, <em>Adriatic</em>, Mediterranean, Black, Red, and Caspian seas, with the Persian Gulf. <a href="https://www.scotchandscones.com/shortbread-history/">Test Link.</a></p> <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>',
   locations: [
     { title: 'Powellarium', to: '/location/bar' },
     { title: 'Research Library (Charles E. Young)', to: '/location/baz' },


### PR DESCRIPTION
Connected to [APPS-2557](https://jira.library.ucla.edu/browse/APPS-2557)

**Stories Edited:** ~/stories/CardMeta.stories.js

**Notes:**

I verified that these 2 changes were present in the branch:

Change 1: Highlight Text prop should be displayed using RichText component that can handle `<a>` tags, test data should test for `<a> `tags
[fix: APPS-2493 Hyperlink styling needed in FPB Highlight summary field by jendiamond · Pull Request #443 · UCLALibrary/ucla-library-website-components](https://github.com/UCLALibrary/ucla-library-website-components/pull/443) 

Solution:
As BlockHighlight.vue no longer exists, we needed to check that the components it was split into (BlockCardWithImage, BlockFloatingHighlight, BlockClippedDate) all had this behavior.

Luckily, all 3 components use CardMeta to display the text prop, so I needed to check that it was using the RichText component. It was already using RichText, so I added `<a>` tags to the test data. 

Change 2: Update search results on input clear
[fix: update search when clearing search bar by sourcefilter · Pull Request #435 · UCLALibrary/ucla-library-website-components](https://github.com/UCLALibrary/ucla-library-website-components/pull/435) 

Solution: No work needed, I had already made this fix as part of https://uclalibrary.atlassian.net/browse/APPS-2665

**Checklist:**

-   [X ] I checked that it is working locally in the dev server
-   [ X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X ] I used a conventional commit message
-   [ X] I assigned myself to this PR


[APPS-2557]: https://uclalibrary.atlassian.net/browse/APPS-2557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ