### PR TITLE
feat: fix csbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "private": false,
     "version": "2.39.0-alpha.96",
-    "main": "dist/ucla-library-website-components.cjs.js",
+    "main": "dist/ucla-library-website-components.cjs",
     "module": "dist/ucla-library-website-components.es.js",
     "files": [
         "dist"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       name: 'ucla-library-website-components',
       formats: ['es', 'cjs'],
       fileName: format =>
-        `ucla-library-website-components.${format}.js`,
+        format === 'cjs' ? `ucla-library-website-components.${format}` : `ucla-library-website-components.${format}.js`,
     },
     rollupOptions: {
       external: ['vue', 'vue-router'],


### PR DESCRIPTION
fix following error on nuxt3 branch
```
ERROR  [nuxt] [request error] [unhandled] [500] exports is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and '/Users/parinitamulak/library-website-nuxt/node_modules/.pnpm/ucla-library-website-components@2.39.0-alpha.96_typescript@5.5.3_vue-router@4.4.0_vue@3.4.31/node_modules/ucla-library-website-components/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
  This file is being treated as an ES module because it has a '.js' file extension and './node_modules/.pnpm/ucla-library-website-components@2.39.0-alpha.96_typescript@5.5.3_vue-router@4.4.0_vue@3.4.31/node_modules/ucla-library-website-components/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.  
  at ./node_modules/.pnpm/ucla-library-website-components@2.39.0-alpha.96_typescript@5.5.3_vue-router@4.4.0_vue@3.4.31/node_modules/ucla-library-website-components/dist/ucla-library-website-components.cjs.js:1:207  
```