### PR TITLE
feat: Create Component FTVA VideoEmbed

### DIFF
--- a/src/lib-components/ResponsiveVideo.vue
+++ b/src/lib-components/ResponsiveVideo.vue
@@ -302,5 +302,11 @@ function onPlaying() {
           opacity: 0;
       }
   }
+  :deep(.video-embed) {
+    position: absolute;
+    top:0;
+    left: 0;
+    width: 100%;
+  }
 }
 </style>

--- a/src/lib-components/VideoEmbed.vue
+++ b/src/lib-components/VideoEmbed.vue
@@ -1,112 +1,101 @@
-<!-- The VideoEmbed component creates an iframe with a youtube video embed using a custom play icon -->
-<!-- TODO maybe one day? : combine this component with Item.vue or VideoJs.vue, as there is a lot of functional overlap -->
+<!-- The VideoEmbed component creates an iframe with a youtube video embed
+ it has an optional custom posterImage and icon -->
 <script lang='ts' setup>
 import type { PropType } from 'vue'
+import SvgIconPlayFilled from 'ucla-library-design-tokens/assets/svgs/icon-ftva-playvideo.svg'
+import { computed, defineProps } from 'vue'
 import type { MediaItemType } from '@/types/types'
-import SvgIconPlayFilled from 'ucla-library-design-tokens/assets/svgs/icon-play-filled.svg';
-import { defineProps, computed, onMounted } from 'vue'
-const { trailer, posterImage } = defineProps({
-    trailer: {
-        type: String,
-        required: true
-    },
-    posterImage: {
-        type: Object as PropType<MediaItemType>, // todo pass whole image or just src?
-        required: false
-    }
-})
-// const displayIframe = computed(() => {
-//     return posterImage ? 'none' : 'block'
-// })
 
-// this component doesn't apply themes currently
+const { trailer, posterImage } = defineProps({
+  trailer: {
+    type: String,
+    required: true
+  },
+  posterImage: {
+    type: Object as PropType<MediaItemType>,
+    required: false
+  }
+})
+
+// this component doesn't have themes currently
 const classes = computed(() => {
-    return ['video-embed', posterImage ? 'has-poster' : 'no-poster']
+  const src = posterImage?.src
+  return ['video-embed', src ? 'has-poster' : 'no-poster']
 })
 const parsedTrailer = computed(() => {
-    return trailer.split('src=\"')[1].split('\"')[0]
+  return trailer.split('src=\"')[1].split('\"')[0]
 })
 </script>
+
 <template>
-    <div v-if="parsedTrailer" :class="classes">
-        <div class="cover-container" onclick="this.nextElementSibling.style.display='block'; this.style.display='none'">
-            <img v-if="posterImage?.src" :src="posterImage.src" class="cover" />
-            <SvgIconPlayFilled class="play-button" />
-        </div>
-        <div class="video-container"> <!-- :style="{ display: displayIframe } todo remove inline styles?  -->
-            <iframe :src="parsedTrailer" title="YouTube video player" class="responsive-iframe" frameborder="0"
-                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy"></iframe>
-        </div>
+  <div v-if="parsedTrailer" :class="classes">
+    <div class="cover-container" onclick="this.nextElementSibling.style.display='block'; this.style.display='none'">
+      <img v-if="posterImage?.src" :src="posterImage.src" class="cover">
+      <SvgIconPlayFilled class="play-button" />
     </div>
+    <div class="video-container">
+      <iframe
+        :src="parsedTrailer" title="YouTube video player" class="responsive-iframe" frameborder="0"
+        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy"
+      />
+    </div>
+  </div>
 </template>
+
 <style lang='scss' scoped>
-.cover-container {
-    position: relative;
-
-    // width: 560px;
-    // height: 315px;
-    &:hover .play-button {
-        // filter: drop-shadow(1px 1px 80px hsla(206.5, 0%, 10%, 50%));
-        transform: scale(1.8);
-    }
-}
-
-.cover {
-    cursor: pointer;
-    position: absolute;
-}
-
-.play-button {
-    width: 80px;
-    position: absolute;
-    left: 0;
-    right: 0;
-    transition: all 250ms ease-in-out;
-}
-
-.cover,
-.play-button {
-    top: 0;
-    bottom: 0;
-    margin: auto;
-}
-// to do ? 
 .video-embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    width: 100%;
-    height: 100%;
+    position: relative;
+    width: 793px;
+    height: 568px;
+
     &.has-poster {
         .video-container {
             display: none;
         }
     }
+
     &.no-poster {
         .cover-container {
             display: none;
         }
     }
-.video-container {
-    position: absolute;
+
+    .cover-container {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        display: grid;
+        grid-template: 1fr / 1fr;
+        place-items: center;
+
+        >* {
+            grid-column: 1 / 1;
+            grid-row: 1 / 1;
+        }
+
+        .cover {
+            cursor: pointer;
+            width: 100%;
+            height: 100%;
+        }
+
+        .play-button {
+            width: 55px;
+            height: 55px;
+            z-index: 5;
+            transition: all 250ms ease-in-out;
+        }
+    }
+
+    .video-container, .responsive-iframe {
+        position: absolute;
         top: 0;
         left: 0;
         bottom: 0;
         right: 0;
         width: 100%;
         height: 100%;
-}
- .responsive-iframe {
-        position: absolute;
-            top: 0;
-            left: 0;
-            bottom: 0;
-            right: 0;
-            width: 100%;
-            height: 100%;
- }
+    }
 }
 </style>

--- a/src/lib-components/VideoEmbed.vue
+++ b/src/lib-components/VideoEmbed.vue
@@ -1,0 +1,112 @@
+<!-- The VideoEmbed component creates an iframe with a youtube video embed using a custom play icon -->
+<!-- TODO maybe one day? : combine this component with Item.vue or VideoJs.vue, as there is a lot of functional overlap -->
+<script lang='ts' setup>
+import type { PropType } from 'vue'
+import type { MediaItemType } from '@/types/types'
+import SvgIconPlayFilled from 'ucla-library-design-tokens/assets/svgs/icon-play-filled.svg';
+import { defineProps, computed, onMounted } from 'vue'
+const { trailer, posterImage } = defineProps({
+    trailer: {
+        type: String,
+        required: true
+    },
+    posterImage: {
+        type: Object as PropType<MediaItemType>, // todo pass whole image or just src?
+        required: false
+    }
+})
+// const displayIframe = computed(() => {
+//     return posterImage ? 'none' : 'block'
+// })
+
+// this component doesn't apply themes currently
+const classes = computed(() => {
+    return ['video-embed', posterImage ? 'has-poster' : 'no-poster']
+})
+const parsedTrailer = computed(() => {
+    return trailer.split('src=\"')[1].split('\"')[0]
+})
+</script>
+<template>
+    <div v-if="parsedTrailer" :class="classes">
+        <div class="cover-container" onclick="this.nextElementSibling.style.display='block'; this.style.display='none'">
+            <img v-if="posterImage?.src" :src="posterImage.src" class="cover" />
+            <SvgIconPlayFilled class="play-button" />
+        </div>
+        <div class="video-container"> <!-- :style="{ display: displayIframe } todo remove inline styles?  -->
+            <iframe :src="parsedTrailer" title="YouTube video player" class="responsive-iframe" frameborder="0"
+                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                referrerpolicy="strict-origin-when-cross-origin" allowfullscreen loading="lazy"></iframe>
+        </div>
+    </div>
+</template>
+<style lang='scss' scoped>
+.cover-container {
+    position: relative;
+
+    // width: 560px;
+    // height: 315px;
+    &:hover .play-button {
+        // filter: drop-shadow(1px 1px 80px hsla(206.5, 0%, 10%, 50%));
+        transform: scale(1.8);
+    }
+}
+
+.cover {
+    cursor: pointer;
+    position: absolute;
+}
+
+.play-button {
+    width: 80px;
+    position: absolute;
+    left: 0;
+    right: 0;
+    transition: all 250ms ease-in-out;
+}
+
+.cover,
+.play-button {
+    top: 0;
+    bottom: 0;
+    margin: auto;
+}
+// to do ? 
+.video-embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    &.has-poster {
+        .video-container {
+            display: none;
+        }
+    }
+    &.no-poster {
+        .cover-container {
+            display: none;
+        }
+    }
+.video-container {
+    position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        width: 100%;
+        height: 100%;
+}
+ .responsive-iframe {
+        position: absolute;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            width: 100%;
+            height: 100%;
+ }
+}
+</style>

--- a/src/stories/ResponsiveVideo.stories.js
+++ b/src/stories/ResponsiveVideo.stories.js
@@ -1,4 +1,6 @@
 import ResponsiveVideo from '@/lib-components/ResponsiveVideo'
+import VideoEmbed from '@/lib-components/VideoEmbed'
+import { computed } from 'vue'
 
 // Import mock api data
 import * as API from '@/stories/mock-api.json'
@@ -29,5 +31,26 @@ export function VideoWithControls() {
     },
     components: { ResponsiveVideo },
     template: '<responsive-video :media="video" :controls="true"/>',
+  }
+}
+
+// Example using a slot to put a VideoEmbed iframe inside ResponsiveVideo
+const mockFTVAData = {
+  trailer: '<figure><iframe width="560" height="315" src="https://www.youtube.com/embed/uYr_SvIKKuI?si=ihenbmyE91KqyXK5" title="YouTube video player" frameborder="0"></iframe></figure>'
+}
+export function WithSlottedVideoEmbed() {
+  return {
+    setup() {
+      return {
+        mockFTVAData
+      }
+    },
+    data() {
+      return {
+        video: API.video,
+      }
+    },
+    components: { ResponsiveVideo, VideoEmbed },
+    template: '<responsive-video :aspect-ratio="56.9" :controls="true"><template v-slot><video-embed :trailer="mockFTVAData.trailer" /></template></responsive-video>',
   }
 }

--- a/src/stories/ResponsiveVideo.stories.js
+++ b/src/stories/ResponsiveVideo.stories.js
@@ -1,6 +1,5 @@
 import ResponsiveVideo from '@/lib-components/ResponsiveVideo'
 import VideoEmbed from '@/lib-components/VideoEmbed'
-import { computed } from 'vue'
 
 // Import mock api data
 import * as API from '@/stories/mock-api.json'

--- a/src/stories/VideoEmbed.spec.js
+++ b/src/stories/VideoEmbed.spec.js
@@ -1,0 +1,10 @@
+// describe('/ Story With Image', () => {
+//   it('Default', () => {
+//     cy.visit(
+//       '/iframe.html?id=impact-report-story-with-image--default&args=&viewMode=story'
+//     )
+//     cy.get('.story-with-image').should('exist')
+
+//     cy.percySnapshot('IMPACT REPORT / Story With Image: Default')
+//   })
+// })

--- a/src/stories/VideoEmbed.spec.js
+++ b/src/stories/VideoEmbed.spec.js
@@ -1,10 +1,10 @@
-// describe('/ Story With Image', () => {
-//   it('Default', () => {
-//     cy.visit(
-//       '/iframe.html?id=impact-report-story-with-image--default&args=&viewMode=story'
-//     )
-//     cy.get('.story-with-image').should('exist')
+describe('/ Video Embed', () => {
+  it('Default', () => {
+    cy.visit(
+      '/iframe.html?id=global-videoembed--default&args=&viewMode=story'
+    )
+    cy.get('.video-embed').should('exist')
 
-//     cy.percySnapshot('IMPACT REPORT / Story With Image: Default')
-//   })
-// })
+    cy.percySnapshot('VIDEO / Video Embed: Default')
+  })
+})

--- a/src/stories/VideoEmbed.stories.js
+++ b/src/stories/VideoEmbed.stories.js
@@ -8,7 +8,7 @@ export default {
 // Variations of stories below
 const mockTrailerData = {
   trailer: '<figure><iframe width="560" height="315" src="https://www.youtube.com/embed/uYr_SvIKKuI?si=ihenbmyE91KqyXK5" title="YouTube video player" frameborder="0"></iframe></figure>',
-  posterImage: { ...API.image, src: 'https://via.placeholder.com/960x540' }
+  posterImage: API.image
 }
 export function Default() {
   return {

--- a/src/stories/VideoEmbed.stories.js
+++ b/src/stories/VideoEmbed.stories.js
@@ -1,20 +1,35 @@
 import VideoEmbed from '@/lib-components/VideoEmbed'
-import { computed } from 'vue'
+import * as API from '@/stories/mock-api.json'
 
 export default {
   title: 'GLOBAL / VideoEmbed',
   component: VideoEmbed,
 }
 // Variations of stories below
-const mockTrailerData = `<figure><iframe width="560" height="315" src="https://www.youtube.com/embed/uYr_SvIKKuI?si=ihenbmyE91KqyXK5" title="YouTube video player" frameborder="0"></iframe></figure>`
+const mockTrailerData = {
+  trailer: '<figure><iframe width="560" height="315" src="https://www.youtube.com/embed/uYr_SvIKKuI?si=ihenbmyE91KqyXK5" title="YouTube video player" frameborder="0"></iframe></figure>',
+  posterImage: { ...API.image, src: 'https://via.placeholder.com/960x540' }
+}
 export function Default() {
-    return {
+  return {
     data() {
       return {
         mockTrailerData
       }
     },
     components: { VideoEmbed },
-    template: '<video-embed :trailer="mockTrailerData"/>',
+    template: '<video-embed :trailer="mockTrailerData.trailer"/>',
+  }
+}
+
+export function WithCustomImageandIcon() {
+  return {
+    data() {
+      return {
+        mockTrailerData
+      }
+    },
+    components: { VideoEmbed },
+    template: '<video-embed :trailer="mockTrailerData.trailer" :posterImage="mockTrailerData.posterImage"/>',
   }
 }

--- a/src/stories/VideoEmbed.stories.js
+++ b/src/stories/VideoEmbed.stories.js
@@ -1,0 +1,20 @@
+import VideoEmbed from '@/lib-components/VideoEmbed'
+import { computed } from 'vue'
+
+export default {
+  title: 'GLOBAL / VideoEmbed',
+  component: VideoEmbed,
+}
+// Variations of stories below
+const mockTrailerData = `<figure><iframe width="560" height="315" src="https://www.youtube.com/embed/uYr_SvIKKuI?si=ihenbmyE91KqyXK5" title="YouTube video player" frameborder="0"></iframe></figure>`
+export function Default() {
+    return {
+    data() {
+      return {
+        mockTrailerData
+      }
+    },
+    components: { VideoEmbed },
+    template: '<video-embed :trailer="mockTrailerData"/>',
+  }
+}


### PR DESCRIPTION
Connected to [APPS-2789](https://jira.library.ucla.edu/browse/APPS-2789) | [ISSUE-536](https://github.com/UCLALibrary/ucla-library-website-components/issues/536)

https://deploy-preview-563--ucla-library-storybook.netlify.app/?path=/story/global-videoembed--with-custom-imageand-icon

**Component Updated:** `ResponsiveVideo.vue`

**Stories:** `~/stories/ResponsiveVideo.stories.js`

**Notes:**

This component create a responsive iframe and places a custom poster image over it if one is supplied. It also replaces the default youtube play arrow. 

Based on this component request: https://github.com/UCLALibrary/ucla-library-website-components/issues/536

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-2789]: https://uclalibrary.atlassian.net/browse/APPS-2789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ