### PR TITLE
feat: Add trailing slash for internal links for percy to not create new snapshots

### DIFF
--- a/src/lib-components/SmartLink.vue
+++ b/src/lib-components/SmartLink.vue
@@ -29,10 +29,10 @@ export default {
     },
     parsedTo() {
       if (this.isRelative && !this.isDownload && !this.parsedTarget) {
-        if (this.to !== '/' && !this.to.endsWith('/') && !this.to.includes("q=") && !this.to.includes("&filters=")) {
+        if (this.to !== '/' && !this.to.endsWith('/') && !this.to.includes('q=') && !this.to.includes('&filters='))
 
           return `${this.to}/`
-        }
+
         return this.to
       }
       return this.to

--- a/src/lib-components/SmartLink.vue
+++ b/src/lib-components/SmartLink.vue
@@ -27,6 +27,16 @@ export default {
     isRelative() {
       return !!isRelativeLink(this.to)
     },
+    parsedTo() {
+      if (this.isRelative && !this.isDownload && !this.parsedTarget) {
+        if (this.to !== '/' && !this.to.endsWith('/') && !this.to.includes("q=") && !this.to.includes("&filters=")) {
+
+          return `${this.to}/`
+        }
+        return this.to
+      }
+      return this.to
+    }
   },
 }
 </script>
@@ -35,7 +45,7 @@ export default {
   <router-link
     v-if="isRelative && !isDownload && !parsedTarget"
     class="smart-link is-router-link"
-    :to="to"
+    :to="parsedTo"
   >
     <slot />
   </router-link>


### PR DESCRIPTION

Connected to [APPS-2811](https://jira.library.ucla.edu/browse/APPS-2811)

In Nuxt2 Percy snap shot baselines have a trailing slash, but in Nuxt3 Percy is creating snapshots with no trailing slash, so new snaps are created for the same URLs. To avoid this, Nuxt3 prefers to use NuxtLink with a trailing slash appended, but since we are using a component library we cannot use NuxtLink in this repo, hence the solution is to modify SmartLink component to append a trailing slash for the routes to be similar to nuxt2 for Percy final check, we can rethink about trailing slash for all the sites once website and Meap is migrated.

[APPS-2811]: https://uclalibrary.atlassian.net/browse/APPS-2811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ