### PR TITLE
fix: APPS-2847 NavBreadcrumb URI encoding

### DIFF
--- a/src/lib-components/NavBreadcrumb.vue
+++ b/src/lib-components/NavBreadcrumb.vue
@@ -35,7 +35,8 @@ const isMobile = computed(() => {
 
 // Split URI path; then remove empty string at start of the array
 const parsedBreadcrumbs = computed(() => {
-  const pagePathArray = route.path.split('/').slice(1)
+  const decodedRoutePath = decodeURI(route.path)
+  const pagePathArray = decodedRoutePath.split('/').slice(1)
 
   return pagePathArray
 })

--- a/src/lib-components/SectionTeaserCard.vue
+++ b/src/lib-components/SectionTeaserCard.vue
@@ -26,13 +26,17 @@ const titleClasses = computed(() => {
 </script>
 
 <template>
-  <div v-if="sectionTitle" :class="titleClasses"> {{ sectionTitle }} </div>
+  <div v-if="sectionTitle" :class="titleClasses">
+    {{ sectionTitle }}
+  </div>
   <ul :class="classes" :data-header="sectionTitle ? sectionTitle : null">
-    <BlockCardWithImage v-for="(item, index) in items" :key="`Card${index}`" :image="item.image" :to="item.to"
+    <BlockCardWithImage
+      v-for="(item, index) in items" :key="`Card${index}`" :image="item.image" :to="item.to"
       :category="item.category" :title="item.title" :alternative-full-name="item.alternativeFullName"
       :language="item.language" :start-date="item.startDate" :end-date="item.endDate" :text="item.text"
       :image-aspect-ratio="60" :is-vertical="true" :byline-one="item.bylineOne" :byline-two="item.bylineTwo"
-      :section-handle="item.sectionHandle" :ongoing="item.ongoing" class="card" />
+      :section-handle="item.sectionHandle" :ongoing="item.ongoing" class="card"
+    />
   </ul>
 </template>
 

--- a/src/stories/NavBreadcrumb.stories.js
+++ b/src/stories/NavBreadcrumb.stories.js
@@ -53,7 +53,7 @@ Default.args = {
 
 export const MultipleNesting = Template.bind({})
 MultipleNesting.args = {
-  to: '/explore-collections/watch-and-listen-online/senator-john-f.-kennedy-gives-press-conference-in-los-angeles',
+  to: '/events/upcoming-events/la-région-centrale-03-08-24',
 }
 
 export const MultipleNestingCollapsed = Template.bind({})


### PR DESCRIPTION
Connected to [APPS-2847](https://jira.library.ucla.edu/browse/APPS-2847)

**Component Updated:** NavBreadcrumb}.vue

**Notes:**

URIs tested:
- `/events/la-r%C3%A9gion-centrale-03-08-24`
- `/events/la-région-centrale-03-08-24`

Browsers tested: 
- Chrome, Firefox, Edge, Safari

![navbreadcrumb-eincoding-fix](https://github.com/user-attachments/assets/6c6b1666-16e7-4f40-990e-d3905ff26ab3)

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   ~~[ ] I checked that it is working locally in the storybook~~
-   ~~[ ] I checked that it is working locally in the 
library-website-nuxt dev server~~
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I have requested a PR  review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2847]: https://uclalibrary.atlassian.net/browse/APPS-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ