### PR TITLE
fix: APPS-2843 Component BlockInfo Styling updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "sass": "^1.64.2",
         "storybook": "^7.4.1",
         "typescript": "^5.2.2",
-        "ucla-library-design-tokens": "^5.19.0",
+        "ucla-library-design-tokens": "^5.20.0",
         "video.js": "^8.5.2",
         "vite": "^5.3.1",
         "vite-svg-loader": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ devDependencies:
     specifier: ^5.2.2
     version: 5.5.3
   ucla-library-design-tokens:
-    specifier: ^5.19.0
-    version: 5.19.0
+    specifier: ^5.20.0
+    version: 5.20.0
   video.js:
     specifier: ^8.5.2
     version: 8.12.0
@@ -11298,8 +11298,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /ucla-library-design-tokens@5.19.0:
-    resolution: {integrity: sha512-kybTsDIiyGcg1xTJqPZWrkv1+NThfXj26oJYar/oeHN9MqR36qO6B0M9JYNcWEp6AvrgrX0aH2wilstlndj0fw==}
+  /ucla-library-design-tokens@5.20.0:
+    resolution: {integrity: sha512-dQv1OVx8RBSep08AvCI3Tu6F73iuPk98bYrjYnmJh22dOTj9zpF4b7e/iuPLr7413egZjGJ5jzLb9WbR8DjZOw==}
     dev: true
 
   /ufo@1.5.3:

--- a/src/lib-components/SectionTeaserCard.vue
+++ b/src/lib-components/SectionTeaserCard.vue
@@ -26,13 +26,17 @@ const titleClasses = computed(() => {
 </script>
 
 <template>
-  <div v-if="sectionTitle" :class="titleClasses"> {{ sectionTitle }} </div>
+  <div v-if="sectionTitle" :class="titleClasses">
+    {{ sectionTitle }}
+  </div>
   <ul :class="classes" :data-header="sectionTitle ? sectionTitle : null">
-    <BlockCardWithImage v-for="(item, index) in items" :key="`Card${index}`" :image="item.image" :to="item.to"
+    <BlockCardWithImage
+      v-for="(item, index) in items" :key="`Card${index}`" :image="item.image" :to="item.to"
       :category="item.category" :title="item.title" :alternative-full-name="item.alternativeFullName"
       :language="item.language" :start-date="item.startDate" :end-date="item.endDate" :text="item.text"
       :image-aspect-ratio="60" :is-vertical="true" :byline-one="item.bylineOne" :byline-two="item.bylineTwo"
-      :section-handle="item.sectionHandle" :ongoing="item.ongoing" class="card" />
+      :section-handle="item.sectionHandle" :ongoing="item.ongoing" class="card"
+    />
   </ul>
 </template>
 

--- a/src/styles/ftva/_block-info.scss
+++ b/src/styles/ftva/_block-info.scss
@@ -34,6 +34,7 @@
         width: -moz-max-content;
         width: max-content;
         margin: 0 auto;
+        margin-bottom: 10px;
     }
 
     @media (min-width: 1024px) {

--- a/src/styles/ftva/_block-info.scss
+++ b/src/styles/ftva/_block-info.scss
@@ -9,8 +9,8 @@
     .block-info-header {
         @include ftva-subtitle-1;
         text-align: center;
-        color: $medium-grey;
-        border-bottom: 1px solid $subtitle-grey;
+        color: $heading-grey;
+        border-bottom: 1px solid $grey-blue;
         padding: 8px 0;
     }
 
@@ -18,9 +18,12 @@
         padding: 16px 0 16px 20px;
     }
 
-    // ToDo: Add Proxima font when fixed in design tokens
     .block-info-list li {
         @include ftva-body-2;
+        color: $body-grey;
+    }
+
+    .block-info-list li::marker {
         color: $body-grey;
     }
 

--- a/src/styles/ftva/_block-info.scss
+++ b/src/styles/ftva/_block-info.scss
@@ -34,6 +34,7 @@
         width: -moz-max-content;
         width: max-content;
         margin: 0 auto;
+        margin-top: 10px;
         margin-bottom: 10px;
     }
 


### PR DESCRIPTION
Connected to [APPS-2843](https://uclalibrary.atlassian.net/browse/APPS-2843)

1. TICKET INFO: @include heading-grey;
2. the stroke under: @include grey-blue;
3. bullet points: @include body-grey;
4. bullet text: @include ftva-body-2;
5. add 10px margin below button
No changes were made to `src/lib-components/SectionTeaserCard.vue` it is just linting

[APPS-2843]: https://uclalibrary.atlassian.net/browse/APPS-2843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ