### PR TITLE
fix: APPS-2856 VideoEmbed Responsiveness

### DIFF
--- a/src/lib-components/VideoEmbed.vue
+++ b/src/lib-components/VideoEmbed.vue
@@ -46,6 +46,7 @@ const parsedTrailer = computed(() => {
       >
       <SvgIconPlayFilled class="play-button" />
     </div>
+
     <div
       v-if="parsedTrailer"
       class="video-container"
@@ -70,8 +71,8 @@ const parsedTrailer = computed(() => {
 >
 .video-embed {
   position: relative;
-  width: 793px;
-  height: 568px;
+  width: 100%;
+  aspect-ratio: 16/9;
 
   &.has-poster {
     .video-container {
@@ -86,7 +87,7 @@ const parsedTrailer = computed(() => {
   }
 
   .cover-container {
-    position: relative;
+    position: absolute;
     width: 100%;
     height: 100%;
     display: grid;
@@ -115,10 +116,6 @@ const parsedTrailer = computed(() => {
   .video-container,
   .responsive-iframe {
     position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
     width: 100%;
     height: 100%;
   }


### PR DESCRIPTION
Connected to [APPS-2856](https://jira.library.ucla.edu/browse/APPS-2856)


**Component Created:** VideoEmbed.vue


**Preview:**
- https://deploy-preview-578--ucla-library-storybook.netlify.app/?path=/story/global-videoembed--with-custom-imageand-icon
- https://deploy-preview-578--ucla-library-storybook.netlify.app/?path=/story/section-screening-details--multiple-screenings


**Screenshots:**

![poster](https://github.com/user-attachments/assets/6470db03-396b-44d3-a8ae-4339706b4d32)

![trailer](https://github.com/user-attachments/assets/88345e38-cbc9-4bc4-a9be-0b1b242c8243)


**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   ~~[ ] I checked that it is working locally in the 
library-website-nuxt dev server~~
-   [x] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2856]: https://uclalibrary.atlassian.net/browse/APPS-2856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ