### PR TITLE
fix: APPS-2858 Remove Trailing Dates from NavBeadcrumbs

### DIFF
--- a/src/lib-components/NavBreadcrumb.vue
+++ b/src/lib-components/NavBreadcrumb.vue
@@ -36,7 +36,8 @@ const isMobile = computed(() => {
 // Split URI path; then remove empty string at start of the array
 const parsedBreadcrumbs = computed(() => {
   const decodedRoutePath = decodeURI(route.path)
-  const pagePathArray = decodedRoutePath.split('/').slice(1)
+  const pathWithNoTrailingDates = stripUrlDate(decodedRoutePath)
+  const pagePathArray = pathWithNoTrailingDates.split('/').slice(1)
 
   return pagePathArray
 })
@@ -120,6 +121,18 @@ function setLinkExpansion() {
 
 function toggleLinksExpansion() {
   isExpanded.value = !isExpanded.value
+}
+
+function stripUrlDate(str) {
+  // Find the last occurrence of date pattern 00-00-00 in a string
+  const pattern = /([0-9][0-9])-([0-9][0-9])-([0-9][0-9])(?!.\w)/
+
+  if (pattern.test(str)) {
+    const updateStr = str.replace(pattern, '')
+    return updateStr.trim()
+  }
+
+  return str
 }
 
 // THEME

--- a/src/stories/NavBreadcrumb.stories.js
+++ b/src/stories/NavBreadcrumb.stories.js
@@ -53,7 +53,7 @@ Default.args = {
 
 export const MultipleNesting = Template.bind({})
 MultipleNesting.args = {
-  to: '/events/upcoming-events/la-région-centrale-03-08-24',
+  to: '/events/upcoming-events/la-région-centrale-10-20-23-screening-03-08-24',
 }
 
 export const MultipleNestingCollapsed = Template.bind({})


### PR DESCRIPTION
Connected to [APPS-2858](https://jira.library.ucla.edu/browse/APPS-2858)

**Component Updated:** NavBreadcrumb.vue

**Stories:** ~/stories/NavBreadcrumb.stories.js

**Note:**
- Remove last occurrence of date pattern (00-00-00) in URL/route string parsed to create breadcrumbs
- Test Route: `'/events/upcoming-events/la-région-centrale-10-20-23-screening-03-08-24' `

![breadcrumb-no-trailing-dates](https://github.com/user-attachments/assets/39296410-0bda-4eab-81cd-74d88ed90e2c)

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   ~~[ ] I checked that it is working locally in the 
library-website-nuxt dev server~~
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I have requested a PR review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2858]: https://uclalibrary.atlassian.net/browse/APPS-2858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ