### PR TITLE
fix: APPS-2825 Fix MastheadSecondary Height

### DIFF
--- a/src/lib-components/MastheadSecondary.vue
+++ b/src/lib-components/MastheadSecondary.vue
@@ -106,7 +106,7 @@ const classes = computed(() => {
     }
 
     :deep(div) {
-      margin: 0;
+      margin-bottom: 0;
     }
   }
 

--- a/src/lib-components/MastheadSecondary.vue
+++ b/src/lib-components/MastheadSecondary.vue
@@ -104,6 +104,10 @@ const classes = computed(() => {
     :deep(div) {
       color: var(--color-white);
     }
+
+    :deep(div) {
+      margin: 0;
+    }
   }
 
   .container {


### PR DESCRIPTION
Connected to [APPS-2825](https://jira.library.ucla.edu/browse/APPS-2825)

**Component Updated:** MastheadSecondary.vue

**Notes:**

- Shifting layout of MastheadSecondary sections in Vue3 (compared to Vue2) was being caused by additional margin emanating from the RichText component used in the Masthead:
  - https://github.com/UCLALibrary/ucla-library-website-components/blob/1a3fe6d1255bf1e125fd629552c24d5a6d4721bd/src/lib-components/RichText.vue#L69

![masthead-height-shift](https://github.com/user-attachments/assets/d0d75e99-95ae-47da-b038-02a4215dbc89)

 - Reset `margin-bottom` of the embedded RichText to `0` 
- https://deploy-preview-581--ucla-library-storybook.netlify.app/?path=/story/masthead-secondary--default

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   ~~[ ] I checked that it is working locally in the 
library-website-nuxt dev server~~
-   ~~[ ] I added a screenshot of it working~~
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I have requested a PR review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2825]: https://uclalibrary.atlassian.net/browse/APPS-2825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ