### PR TITLE
fix: APPS-2879 - Update NavBreadcrumb to use Event Title

### DIFF
--- a/src/stories/NavBreadcrumb.stories.js
+++ b/src/stories/NavBreadcrumb.stories.js
@@ -44,18 +44,21 @@ function Template(args) {
   }
 }
 
+// Legacy breadcrumb (Values entered at page-level)
 export const Default = Template.bind({})
 Default.args = {
   to: '/about/news',
-  title: 'jane doe',
-  parentTitle: 'parent',
+  title: 'Jane Doe',
+  parentTitle: 'Parent',
 }
 
+// All breadcrumbs generated from route
 export const MultipleNesting = Template.bind({})
 MultipleNesting.args = {
   to: '/events/upcoming-events/la-région-centrale-10-20-23-screening-03-08-24',
 }
 
+// All breadcrumbs generated from route
 export const MultipleNestingCollapsed = Template.bind({})
 MultipleNestingCollapsed.args = {
   to: '/explore-collections/watch-and-listen-online/ktla-collection/national-and-local-politics/ktla-news-demo-article',
@@ -92,7 +95,10 @@ function TemplateFTVA(args) {
   }
 }
 
+// FTVA Event: Using title from Craft data
+// to generate final breadcrumb
 export const FTVA = TemplateFTVA.bind({})
 FTVA.args = {
   to: '/watch-and-listen-online/senator-john-f.-kennedy-gives-press-conference-in-los-angeles',
+  title: 'Senator John F. Kennedy: "Press Conference" in Los Angeles?'
 }

--- a/src/styles/default/_nav-breadcrumb.scss
+++ b/src/styles/default/_nav-breadcrumb.scss
@@ -41,6 +41,11 @@
         @include truncate(1);
     }
 
+    .parent-page-url,
+    .current-page-title {
+        text-transform: capitalize;
+    }
+
     @media #{$extra-large} {
         padding: 0;
     }


### PR DESCRIPTION
Connected to [APPS-2879](https://jira.library.ucla.edu/browse/APPS-2879)

**Component Updated:** NavBreadcrumb.vue

**Stories:** ~/stories/NavBreadcrumb.stories.js

**Notes:**
- Parent breadcrumbs are capitalized
- Final breadcrumb is coming from `title` field in Craft; all characters retained
- Code still contains logic to parse decoded characters and to strip dates from the url string, which was needed when the final breadcrumb was coming from the route; if the default behavior will be to use data from Craft for the final breacrumb, then the logic in the script and in the template can be removed

![nav-breadcrumb-from-event-title](https://github.com/user-attachments/assets/b9ded7d5-dc3b-4a5d-8bb9-f4b1352bbcec)


**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   ~~[ ] I checked that it is working locally in the 
library-website-nuxt dev server~~
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I have requested a PR review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR
