### PR TITLE
chore: refactor theme pattern to rescope styles, add deep() where needed

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,6 +24,7 @@ const config: StorybookConfig = {
                     scss: {
                         additionalData: `
                             @import "ucla-library-design-tokens/scss/fonts.scss";
+                            @import "ucla-library-design-tokens/scss/_tokens-ftva";
                             @import "ucla-library-design-tokens/scss/app.scss";
                         `,
                     },

--- a/src/lib-components/BlockCardWithImage.vue
+++ b/src/lib-components/BlockCardWithImage.vue
@@ -168,5 +168,7 @@ const parsedDateFormat = computed(() => {
   lang="scss"
   scoped
 >
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_block-card-with-image.scss";
+@import "@/styles/ftva/_block-card-with-image.scss";
 </style>

--- a/src/lib-components/BlockCardWithImage.vue
+++ b/src/lib-components/BlockCardWithImage.vue
@@ -168,7 +168,6 @@ const parsedDateFormat = computed(() => {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_block-card-with-image.scss";
 @import "@/styles/ftva/_block-card-with-image.scss";
 </style>

--- a/src/lib-components/BlockEventDetail.vue
+++ b/src/lib-components/BlockEventDetail.vue
@@ -91,5 +91,7 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_block-event-detail.scss";
+@import "@/styles/ftva/_block-event-detail.scss";
 </style>

--- a/src/lib-components/BlockEventDetail.vue
+++ b/src/lib-components/BlockEventDetail.vue
@@ -91,7 +91,6 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_block-event-detail.scss";
 @import "@/styles/ftva/_block-event-detail.scss";
 </style>

--- a/src/lib-components/BlockInfo.vue
+++ b/src/lib-components/BlockInfo.vue
@@ -73,5 +73,7 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_block-info.scss";
+@import "@/styles/ftva/_block-info.scss";
 </style>

--- a/src/lib-components/BlockInfo.vue
+++ b/src/lib-components/BlockInfo.vue
@@ -73,7 +73,6 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_block-info.scss";
 @import "@/styles/ftva/_block-info.scss";
 </style>

--- a/src/lib-components/BlockRemoveSearchFilter.vue
+++ b/src/lib-components/BlockRemoveSearchFilter.vue
@@ -73,7 +73,6 @@ function closeBlockFilter() {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_block-remove-search-filter.scss";
 @import "@/styles/ftva/_block-remove-search-filter.scss";
 </style>

--- a/src/lib-components/BlockRemoveSearchFilter.vue
+++ b/src/lib-components/BlockRemoveSearchFilter.vue
@@ -73,5 +73,7 @@ function closeBlockFilter() {
   lang="scss"
   scoped
 >
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_block-remove-search-filter.scss";
+@import "@/styles/ftva/_block-remove-search-filter.scss";
 </style>

--- a/src/lib-components/BlockScreeningDetail.vue
+++ b/src/lib-components/BlockScreeningDetail.vue
@@ -176,7 +176,6 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_block-screening-detail.scss";
 @import "@/styles/ftva/_block-screening-detail.scss";
 </style>

--- a/src/lib-components/BlockScreeningDetail.vue
+++ b/src/lib-components/BlockScreeningDetail.vue
@@ -176,5 +176,7 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_block-screening-detail.scss";
+@import "@/styles/ftva/_block-screening-detail.scss";
 </style>

--- a/src/lib-components/BlockTag.vue
+++ b/src/lib-components/BlockTag.vue
@@ -88,5 +88,7 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_block-tag.scss";
+@import "@/styles/ftva/_block-tag.scss";
 </style>

--- a/src/lib-components/BlockTag.vue
+++ b/src/lib-components/BlockTag.vue
@@ -88,7 +88,6 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_block-tag.scss";
 @import "@/styles/ftva/_block-tag.scss";
 </style>

--- a/src/lib-components/ButtonDropdown.vue
+++ b/src/lib-components/ButtonDropdown.vue
@@ -289,5 +289,7 @@ const parsedClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_button-dropdown.scss";
+@import "@/styles/ftva/_button-dropdown.scss";
 </style>

--- a/src/lib-components/ButtonDropdown.vue
+++ b/src/lib-components/ButtonDropdown.vue
@@ -294,7 +294,6 @@ const parsedClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_button-dropdown.scss";
 @import "@/styles/ftva/_button-dropdown.scss";
 </style>

--- a/src/lib-components/ButtonLink.vue
+++ b/src/lib-components/ButtonLink.vue
@@ -136,7 +136,6 @@ const parsedIconName = computed(() => {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_button-link.scss";
 @import "@/styles/ftva/_button-link.scss";
 </style>

--- a/src/lib-components/ButtonLink.vue
+++ b/src/lib-components/ButtonLink.vue
@@ -136,5 +136,7 @@ const parsedIconName = computed(() => {
   lang="scss"
   scoped
 >
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_button-link.scss";
+@import "@/styles/ftva/_button-link.scss";
 </style>

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -259,7 +259,6 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_card-meta.scss";
 @import "@/styles/ftva/_card-meta.scss";
 </style>

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -259,5 +259,7 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_card-meta.scss";
+@import "@/styles/ftva/_card-meta.scss";
 </style>

--- a/src/lib-components/DateFilter.vue
+++ b/src/lib-components/DateFilter.vue
@@ -302,8 +302,6 @@ watch(date, async (newDate, oldDate) => {
 </template>
 
 <style lang="scss" scoped>
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
-
 .date-filter {
   .dp__calendar_header_separator {
     display: none;

--- a/src/lib-components/DividerWayFinder.vue
+++ b/src/lib-components/DividerWayFinder.vue
@@ -50,6 +50,6 @@ onMounted(() => {
 </template>
 
 <style lang="scss" scoped>
-@import "@/styles/themes.scss";
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_divider-way-finder.scss";
+@import "@/styles/ftva/_divider-way-finder.scss";
 </style>

--- a/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -131,5 +131,6 @@ function setCurrentSlide(currentSlide: number) {
 </template>
 
 <style lang="scss" scoped>
-@import "@/styles/themes.scss";
+@import "@/styles/default/_new-lightbox.scss";
+@import "@/styles/ftva/_new-lightbox.scss";
 </style>

--- a/src/lib-components/FooterLinks.vue
+++ b/src/lib-components/FooterLinks.vue
@@ -53,7 +53,6 @@ const classes = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_footer-links.scss";
 @import "@/styles/ftva/_footer-links.scss";
 </style>

--- a/src/lib-components/FooterPrimary.vue
+++ b/src/lib-components/FooterPrimary.vue
@@ -261,7 +261,6 @@ function formatTarget(target: string) {
 </template>
 
 <style lang="scss" scoped>
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_footer-primary.scss";
 @import "@/styles/ftva/_footer-primary.scss";
 </style>

--- a/src/lib-components/FooterSock.vue
+++ b/src/lib-components/FooterSock.vue
@@ -55,7 +55,6 @@ const year = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_footer-sock.scss";
 @import "@/styles/ftva/_footer-sock.scss";
 </style>

--- a/src/lib-components/NavBreadcrumb.vue
+++ b/src/lib-components/NavBreadcrumb.vue
@@ -193,7 +193,6 @@ const parsedClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_nav-breadcrumb.scss";
 @import "@/styles/ftva/_nav-breadcrumb.scss";
 </style>

--- a/src/lib-components/NavBreadcrumb.vue
+++ b/src/lib-components/NavBreadcrumb.vue
@@ -193,5 +193,7 @@ const parsedClasses = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_nav-breadcrumb.scss";
+@import "@/styles/ftva/_nav-breadcrumb.scss";
 </style>

--- a/src/lib-components/NavSearch.vue
+++ b/src/lib-components/NavSearch.vue
@@ -78,5 +78,7 @@ function doSearch() {
   lang="scss"
   scoped
 >
-@import "@/styles/themes.scss";
+@import "ucla-library-design-tokens/scss/_tokens-ftva";
+@import "@/styles/default/_nav-search.scss";
+@import "@/styles/ftva/_nav-search.scss";
 </style>

--- a/src/lib-components/NavSearch.vue
+++ b/src/lib-components/NavSearch.vue
@@ -78,7 +78,6 @@ function doSearch() {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_nav-search.scss";
 @import "@/styles/ftva/_nav-search.scss";
 </style>

--- a/src/lib-components/SectionTeaserCard.vue
+++ b/src/lib-components/SectionTeaserCard.vue
@@ -59,7 +59,6 @@ const classes = computed(() => {
   lang="scss"
   scoped
 >
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
 @import "@/styles/default/_section-teaser-card.scss";
 @import "@/styles/ftva/_section-teaser-card.scss";
 </style>

--- a/src/styles/_ftva-theme.scss
+++ b/src/styles/_ftva-theme.scss
@@ -1,8 +1,3 @@
-// Need imports to access ftva tokens
-// can be removed if this file is included here by UX team, or if we import elsewhere
-// https://github.com/UCLALibrary/design-tokens/blob/main/scss/app.scss
-@import "ucla-library-design-tokens/scss/_tokens-ftva";
-
 @import "ftva/_block-event-detail";
 @import "ftva/_block-info";
 @import "ftva/_block-remove-search-filter";

--- a/src/styles/default/_block-info.scss
+++ b/src/styles/default/_block-info.scss
@@ -1,0 +1,4 @@
+.block-info {
+    display: flex;
+    flex-direction: column;
+}

--- a/src/styles/default/_block-screening-detail.scss
+++ b/src/styles/default/_block-screening-detail.scss
@@ -1,0 +1,5 @@
+.block-screening-detail {
+    .block-tags {
+        display: flex;
+    }
+}

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -13,7 +13,7 @@
         border-radius: 10px 10px 0 0;
     }
 
-    .card-meta {
+    :deep(.card-meta) {
         margin: 25px 10px 0;
         padding: 0px 10px 10px 10px;
 
@@ -35,9 +35,6 @@
     :deep(.date-time) {
         position: absolute;
         bottom: 0;
-    }
-
-    .only-date-time {
         display: flex;
         flex-direction: row;
 

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -34,11 +34,10 @@
 
     :deep(.date-time) {
         position: absolute;
-        bottom: 0;
+        bottom: var(--space-s);
         display: flex;
         flex-direction: row;
 
-        margin-bottom: 10px;
         @include ftva-emphasized-subtitle;
         color: $accent-blue;
         letter-spacing: .04px;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,3 +1,4 @@
+
 body {
   font-family: var(--font-primary);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
       scss: {
         additionalData: `
                   @import "ucla-library-design-tokens/scss/fonts.scss";
+                  @import "ucla-library-design-tokens/scss/_tokens-ftva";
                   @import "ucla-library-design-tokens/scss/app.scss";
                 `,
       },


### PR DESCRIPTION
Connected to [APPS-2867](https://jira.library.ucla.edu/browse/APPS-2867)

**Notes:**

When we implemented the theme pattern we introduced an anti-pattern that removed scoping (plus we are reloading the theme a lot which bloats the project). This has led to problems with styling, especially for the card-meta component which is reused as a child component in 4 other components (BlockCardWithImage, BlockClippedDate, BlockFloatingHighlight, SectionTeaserCard), in addition to being used directly on the page.

This PR:
- imports ONLY the components theme files, so that styles are once again scoped. 
- adds default theme files for a few components which didnt have them
- restores styles in SectionTeaserCard & BlockCardWithImage for ftva that were getting overwritten

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-2867]: https://uclalibrary.atlassian.net/browse/APPS-2867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ