### PR TITLE
fix: APPS-2871 Component CardMeta alternativeTitles lang attribute

### DIFF
--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -167,9 +167,9 @@ const classes = computed(() => {
     <h3
       v-else
       class="title-no-link"
-    >
-      {{ title }}
-    </h3>
+      v-html="title"
+    />
+
     <h4
       v-if="alternativeFullName && alternativeFullName !== null"
       class="alternate-title"

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -174,11 +174,10 @@ const classes = computed(() => {
       v-if="alternativeFullName && alternativeFullName !== null"
       class="alternate-title"
     >
-      {{ alternativeFullName }}
       <span
         v-if="alternativeFullName && (language && language !== null)"
         :lang="language"
-      />
+      >{{ alternativeFullName }}</span>
     </h4>
 
     <RichText

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -181,7 +181,6 @@ const classes = computed(() => {
       />
     </h4>
 
-
     <RichText
       v-if="guestSpeaker"
       class="guestSpeaker"

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -169,15 +169,12 @@ const classes = computed(() => {
       class="title-no-link"
       v-html="title"
     />
-
     <h4
       v-if="alternativeFullName && alternativeFullName !== null"
       class="alternate-title"
+      :lang="language"
     >
-      <span
-        v-if="alternativeFullName && (language && language !== null)"
-        :lang="language"
-      >{{ alternativeFullName }}</span>
+      {{ alternativeFullName }}
     </h4>
 
     <RichText

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -167,8 +167,20 @@ const classes = computed(() => {
     <h3
       v-else
       class="title-no-link"
-      v-html="title"
-    />
+    >
+      {{ title }}
+    </h3>
+    <h4
+      v-if="alternativeFullName && alternativeFullName !== null"
+      class="alternate-title"
+    >
+      {{ alternativeFullName }}
+      <span
+        v-if="alternativeFullName && (language && language !== null)"
+        :lang="language"
+      />
+    </h4>
+
 
     <RichText
       v-if="guestSpeaker"

--- a/src/stories/CardMeta.stories.js
+++ b/src/stories/CardMeta.stories.js
@@ -110,6 +110,44 @@ export function FtvaWithBlockTagsAndIntro() {
   }
 }
 
+export function FtvaWithAlternativeTitle() {
+  return {
+    data() {
+      return {
+        event: {
+          title: 'Step Up (2006)',
+          alternativeTitle: 'The Central Region',
+          language: 'en',
+          introduction: '<p><em>UCLA Film &amp; Television Archive</em> and the <strong>Hammer Museum</strong> are proud to introduce <em>Graeme Ferguson</em></p><p>Ferguson who not only is the inventor of the IMAX format but also made a name for himself as a young cinematographer. He was known for working in the cinéma vérité style when he was asked to direct a documentary about the Arctic and Antarctic for the Expo 67 world’s fair in Montreal. He traveled for a year filming the movie, which included footage of Inuit life and the aurora borealis. </p>',
+          tagLabels: [
+            { title: 'Guest speaker' }, { title: '35mm' }
+          ],
+          guestSpeaker: '<p><a href=\"https://en.wikipedia.org/wiki/Graeme_Ferguson_(filmmaker)\">Graeme Ferguson</a> Ivan <em>Graeme Ferguson</em> CM (October 7, 1929 – May 8, 2021) was a Canadian filmmaker and inventor who co-invented the IMAX film format.</p>',
+        },
+        series: {
+          title: 'The Step Up Movie Series'
+        }
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { CardMeta },
+    template: `
+      <card-meta
+        :category="series.title"
+        :title="event.title"
+        :alternativeFullName="event.alternativeTitle"
+        :guestSpeaker="event.guestSpeaker"
+        :tagLabels="event.tagLabels"
+        :introduction="event.introduction"
+      />
+  `,
+  }
+}
+
 export function FtvaOnlyCategoryAndTitle() {
   return {
     data() {

--- a/src/styles/ftva/_card-meta.scss
+++ b/src/styles/ftva/_card-meta.scss
@@ -20,9 +20,14 @@
   }
 
   .alternate-title {
-    @include ftva-h4;
-    color: $medium-grey;
+    @include ftva-card-title-1;
+    font-weight: $font-weight-regular;
+    color: $subtitle-grey;
     margin: 0 0 24px;
+  }
+
+  .title-no-link:has(+ .alternate-title) {
+    margin-bottom: 0;
   }
 
   .block-tags {

--- a/src/styles/ftva/_card-meta.scss
+++ b/src/styles/ftva/_card-meta.scss
@@ -19,6 +19,12 @@
     margin: 0 0 24px;
   }
 
+  .alternate-title {
+    @include ftva-h4;
+    color: $medium-grey;
+    margin: 0 0 24px;
+  }
+
   .block-tags {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Connected to [APPS-2871](https://jira.library.ucla.edu/browse/APPS-2871)

### Notes
This ticket is done but currently on hold.  
Axa realized that it might not even be necessary.  She is going to consult with Jen Rhee tomorrow(8-14-24).
The Title is something Jen Rhee makes up for the event. It's not really a title of the film so there may not be an Alternative title and currently there is actually no field for it. 
The field I was using which is called alternative title for homepage is something different that would be in the Carousel somehow.

If we do need this then we would have to
+ Add a new alternativeTitle field in craft for the eventTitle
+ Add  `alternativeTitle` to the EventDetail query in the [tva-website-nuxt](https://github.com/UCLALibrary/ftva-website-nuxt) site

### Locally in the dev server
![Screenshot 2024-08-13 at 8 57 55 AM](https://github.com/user-attachments/assets/ef4d7614-74d3-4e56-b78a-96ff5f6ca790)

### Locally in the storybook
<img width="730" alt="Screenshot 2024-08-13 at 8 50 02 AM" src="https://github.com/user-attachments/assets/269131f2-28e6-4dee-8d53-a207c65c7dcc">

### Locally in the library-website-nuxt dev server


**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [ ] I used a conventional commit message
-   [ ] I assigned myself to this PR


[APPS-2871]: https://uclalibrary.atlassian.net/browse/APPS-2871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ