### PR TITLE
fix: Add production url back for blockhours

### DIFF
--- a/src/lib-components/BlockHours.vue
+++ b/src/lib-components/BlockHours.vue
@@ -18,9 +18,9 @@ const trackHeight = ref(0)
 // Computed
 const parsedSrc = computed(() => {
   if (!props.isClicc)
-    return `/blockHours.html?lid=${props.lid}`
+    return `https://www.library.ucla.edu/blockHours.html?lid=${props.lid}`
   else
-    return '/blockCliccHours.html?lid=0'
+    return 'https://www.library.ucla.edu/blockCliccHours.html?lid=0'
 })
 // Function to adjust iframe height
 function adjustIframeHeight(data: number) {


### PR DESCRIPTION
Connected to [APPS-2852](https://jira.library.ucla.edu/browse/APPS-2852)

Using /blockHours.html is not working locally on Nuxt side in static mode

[APPS-2852]: https://uclalibrary.atlassian.net/browse/APPS-2852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ