### PR TITLE
feat: Add ftva theme to sectionwrapper and paleblue theme to scss file

### DIFF
--- a/src/lib-components/SectionWrapper.vue
+++ b/src/lib-components/SectionWrapper.vue
@@ -3,6 +3,7 @@ import { computed, inject, provide } from 'vue'
 import SectionHeader from '@/lib-components/SectionHeader.vue'
 import RichText from '@/lib-components/RichText.vue'
 import kebabCase from '@/utils/kebabCase'
+import { useTheme } from '@/composables/useTheme'
 
 const props = defineProps({
   sectionTitle: {
@@ -31,6 +32,9 @@ const parentLevel = inject('sectionLevel', 1)
 const ancestorSetMargins = inject('ancestorSetMargins', false)
 // console.log('ancestorSetMargins', ancestorSetMargins)
 
+// THEME
+const theme = useTheme()
+
 const levelComputed = computed(() => {
   // console.log('SectionWrapper levelComputed', Number(props.level || parentLevel + 1))
   return Number(props.level || parentLevel + 1)
@@ -49,6 +53,7 @@ const classes = computed(() => {
     `section-wrapper${levelComputed.value}`,
     `theme-${props.theme}`,
     { 'top-level': setMargins.value },
+    theme?.value || ''
   ]
 })
 

--- a/src/stories/SectionWrapper.stories.js
+++ b/src/stories/SectionWrapper.stories.js
@@ -1,9 +1,12 @@
+import { computed } from 'vue'
+
 // Import component
 import { mock as mockMediaWithText } from './mock/BlockMediaWithText'
 import SectionWrapper from '@/lib-components/SectionWrapper'
 
 import BlockMediaWithText from '@/lib-components/BlockMediaWithText'
 import DividerWayFinder from '@/lib-components/DividerWayFinder'
+import SectionTeaserCard from '@/lib-components/SectionTeaserCard'
 
 const propsForMediaWithText = {
   sectionHeader: mockMediaWithText.mediaWithText[0].titleLink,
@@ -117,6 +120,79 @@ export function Divider() {
       <block-media-with-text v-bind="propsForMediaWithText" />
     </section-wrapper>
     </div>
+  `,
+  }
+}
+const mockFtva = [
+  {
+    id: '2847944',
+    to: 'events/la-région-centrale-03-08-24',
+    title: 'TEST - La Région Centrale Screening',
+    startDate: '2027-03-31T07:00:00+00:00',
+    endDate: null,
+    image: {
+      id: '3131261',
+      src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/pinkcloud-crop.png',
+      height: 1920,
+      width: 2560,
+      srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/pinkcloud-crop.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/pinkcloud-crop.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/pinkcloud-crop.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/pinkcloud-crop.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/pinkcloud-crop.png 2560w',
+      alt: 'A woman writing on a window.',
+      focalPoint: [
+        0.5,
+        0.5
+      ]
+    }
+  },
+  {
+    id: '3145808',
+    to: 'events/step-up-3-07-19-25',
+    title: 'TEST - Step Up 3D (2010) Sequel to 2008\'s Step Up 2: The Streets and the third installment in the Step Up film series',
+    startDate: '2028-03-31T07:00:00+00:00',
+    image: null
+  },
+  {
+    id: '3145784',
+    to: 'events/step-up-2-07-07-25',
+    title: 'TEST - Step Up 2: The Streets (2008)',
+    startDate: '2026-03-31T07:00:00+00:00',
+    image: {
+      id: '3157357',
+      src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/step2.jpg',
+      height: 1705,
+      width: 2560,
+      srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/step2.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/step2.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/step2.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/step2.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/step2.jpg 2560w',
+      alt: null,
+      focalPoint: [
+        0.5,
+        0.5
+      ]
+    }
+  },
+]
+
+export function FtvaUpcomingEvents() {
+  return {
+    data() {
+      return {
+        parsedFtvaEventSeries: mockFtva
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { SectionWrapper, SectionTeaserCard },
+    template: `
+      <SectionWrapper
+        section-title="Upcoming events in this series"
+        theme="paleblue"
+      >
+        <SectionTeaserCard
+
+          :items="parsedFtvaEventSeries"
+        />
+      </SectionWrapper>
   `,
   }
 }

--- a/src/stories/SectionWrapper.stories.js
+++ b/src/stories/SectionWrapper.stories.js
@@ -196,3 +196,81 @@ export function FtvaUpcomingEvents() {
   `,
   }
 }
+
+const mockFtvaSeries = [
+  {
+    to: 'series/todd-solondz-series',
+    title: 'TEST - Todd Solondz Series',
+    startDate: '2025-11-06T08:00:00+00:00',
+    endDate: '2025-12-13T08:00:00+00:00',
+    ongoing: false,
+    image:
+      {
+        id: '3157237',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Todd-Solondz_2024-07-04-073854_jbqd.jpg',
+        height: 1734,
+        width: 2560,
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Todd-Solondz_2024-07-04-073854_jbqd.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Todd-Solondz_2024-07-04-073854_jbqd.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Todd-Solondz_2024-07-04-073854_jbqd.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Todd-Solondz_2024-07-04-073854_jbqd.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Todd-Solondz_2024-07-04-073854_jbqd.jpg 2560w',
+        alt: null,
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      },
+  },
+  {
+    to: 'series/step-up-series',
+    title: 'TEST Series: The Step Up Movie Series',
+    startDate: '2025-11-07T08:00:00+00:00',
+    endDate: '2025-12-20T08:00:00+00:00',
+    ongoing: false,
+    image:
+      {
+        id: '3203293',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/step-up-7_2024-08-29-024747_kgpd.jpg',
+        height: 1438,
+        width: 2560,
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/step-up-7_2024-08-29-024747_kgpd.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/step-up-7_2024-08-29-024747_kgpd.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/step-up-7_2024-08-29-024747_kgpd.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/step-up-7_2024-08-29-024747_kgpd.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/step-up-7_2024-08-29-024747_kgpd.jpg 2560w',
+        alt: null,
+        focalPoint: [
+          0.5,
+          0.5
+        ],
+      },
+  },
+  {
+    to: 'series/series-with-3-upcoming-events',
+    title: 'Series with 3 upcoming events',
+    startDate: '2026-01-01T08:00:00+00:00',
+    endDate: '2026-03-31T07:00:00+00:00',
+    ongoing: false,
+    image: null,
+  },
+]
+
+export function FtvaExploreOtherSeries() {
+  return {
+    data() {
+      return {
+        parsedFtvaEventSeries: mockFtvaSeries
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { SectionWrapper, SectionTeaserCard },
+    template: `
+      <SectionWrapper
+        section-title="Explore Other Series"
+        theme="white"
+      >
+        <SectionTeaserCard
+
+          :items="parsedFtvaEventSeries"
+        />
+      </SectionWrapper>
+  `,
+  }
+}

--- a/src/styles/ftva/_section-wrapper.scss
+++ b/src/styles/ftva/_section-wrapper.scss
@@ -10,6 +10,24 @@
             .section-featured-banner {
                 max-width: var(--ftva-container-max-width);
             }
+
+
+        }
+
+        &.theme-paleblue {
+            --color-theme: #{$page-blue};
+            --color-children-theme: var(--color-white);
+
+            background-color: var(--color-theme);
+
+
+            :deep(*) {
+                .card-meta {
+                    background-color: var(--color-children-theme);
+                }
+            }
+
+
         }
 
         // FTVA uses different page max-width

--- a/src/styles/ftva/_section-wrapper.scss
+++ b/src/styles/ftva/_section-wrapper.scss
@@ -11,6 +11,14 @@
                 max-width: var(--ftva-container-max-width);
             }
 
+            :deep(.section-teaser-card) {
+                --color-children-theme: #{$page-blue};
+
+                .card-meta {
+                    background-color: var(--color-children-theme);
+                }
+            }
+
 
         }
 


### PR DESCRIPTION
Connected to [APPS-2918](https://jira.library.ucla.edu/browse/APPS-2918)


**Notes:**

Adds support for ftva theme to sectionwrapper, also adds paleblue theme and white theme variation for the background color work.

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/e39db28c-7e2f-4b93-900f-40c2f8cbda1b">

<img width="1452" alt="image" src="https://github.com/user-attachments/assets/dcc16d7d-1648-4080-a8c4-5ea24b399b71">




[APPS-2918]: https://uclalibrary.atlassian.net/browse/APPS-2918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ