### PR TITLE
fix: APPS-2914 NavBreadcrumb hydration error

### DIFF
--- a/src/lib-components/DividerWayFinder.vue
+++ b/src/lib-components/DividerWayFinder.vue
@@ -35,7 +35,7 @@ watchEffect(() => {
 
 // Mounted
 onMounted(() => {
-  console.log('does this route exist?', route?.path)
+  // console.log('does this route exist?', route?.path)
   colorRoute.value = route?.path || ''
 })
 // console.log('section name computed', sectionName.value)

--- a/src/lib-components/NavBreadcrumb.vue
+++ b/src/lib-components/NavBreadcrumb.vue
@@ -2,8 +2,8 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import SvgIconCaretRight from 'ucla-library-design-tokens/assets/svgs/icon-caret-right.svg'
+import { useWindowSize } from '@vueuse/core'
 import { useTheme } from '@/composables/useTheme'
-import { useGlobalStore } from '@/stores/GlobalStore'
 
 // COMPONENTS
 import SmartLink from '@/lib-components/SmartLink.vue'
@@ -29,19 +29,16 @@ const { to, parentTitle, title } = defineProps({
 
 const route = useRoute()
 
-const isExpanded = ref(null)
-
-const globalStore = useGlobalStore()
-
-// const mobileWinWidth = computed(() => {
-//   return globalStore.winWidth <= 1200
-// })
+const isExpanded = ref(false)
 
 const isMobile = ref(false)
 
 onMounted(() => {
-  watch(() => globalStore.winWidth, (newVal) => {
-    isMobile.value = newVal
+  // Watch for changes in window width only after the component is mounted
+  const { width } = useWindowSize()
+  watch(width, (newWidth) => {
+    // console.log("window width changes on client side")
+    isMobile.value = newWidth <= 1200
   }, { immediate: true })
 })
 
@@ -62,7 +59,7 @@ const parsedBreadcrumbLinks = computed(() => {
   if (isMobile.value) {
     // return last 2 items
     const mobileBreadcrumb
-            = createBreadcrumbLinks(breadcrumbsList).slice(-2)
+      = createBreadcrumbLinks(breadcrumbsList).slice(-2)
 
     return mobileBreadcrumb.splice(0, 1)
   }
@@ -183,7 +180,10 @@ const parsedClasses = computed(() => {
         @click="toggleLinksExpansion()"
         v-text="linkObj.title"
       />
-      <SvgIconCaretRight v-if="!linkObj.isLastItem" aria-hidden="true" />
+      <SvgIconCaretRight
+        v-if="!linkObj.isLastItem"
+        aria-hidden="true"
+      />
       <!-- FTVA uses title field from Craft for the final breadcrumb -->
       <span
         v-if="linkObj.isLastItem && theme === 'ftva'"

--- a/src/lib-components/NavBreadcrumb.vue
+++ b/src/lib-components/NavBreadcrumb.vue
@@ -33,16 +33,16 @@ const isExpanded = ref(null)
 
 const globalStore = useGlobalStore()
 
-const mobileWinWidth = computed(() => {
-  return globalStore.winWidth <= 1200
-})
+// const mobileWinWidth = computed(() => {
+//   return globalStore.winWidth <= 1200
+// })
 
-const isMobile = ref()
+const isMobile = ref(false)
 
 onMounted(() => {
-  watch(() => mobileWinWidth.value, (newVal) => {
+  watch(() => globalStore.winWidth, (newVal) => {
     isMobile.value = newVal
-  })
+  }, { immediate: true })
 })
 
 // Split URI path; then remove empty string at start of the array

--- a/src/lib-components/NavBreadcrumb.vue
+++ b/src/lib-components/NavBreadcrumb.vue
@@ -40,8 +40,8 @@ const mobileWinWidth = computed(() => {
 const isMobile = ref()
 
 onMounted(() => {
-  watch(() => mobileWinWidth.value, (new_val) => {
-    isMobile.value = new_val
+  watch(() => mobileWinWidth.value, (newVal) => {
+    isMobile.value = newVal
   })
 })
 

--- a/src/lib-components/NavBreadcrumb.vue
+++ b/src/lib-components/NavBreadcrumb.vue
@@ -33,14 +33,14 @@ const isExpanded = ref(null)
 
 const globalStore = useGlobalStore()
 
-const isMobile1 = computed(() => {
+const mobileWinWidth = computed(() => {
   return globalStore.winWidth <= 1200
 })
 
 const isMobile = ref()
 
 onMounted(() => {
-  watch(() => isMobile1.value, (new_val) => {
+  watch(() => mobileWinWidth.value, (new_val) => {
     isMobile.value = new_val
   })
 })

--- a/src/lib-components/NavBreadcrumb.vue
+++ b/src/lib-components/NavBreadcrumb.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import SvgIconCaretRight from 'ucla-library-design-tokens/assets/svgs/icon-caret-right.svg'
 import { useTheme } from '@/composables/useTheme'
@@ -33,8 +33,16 @@ const isExpanded = ref(null)
 
 const globalStore = useGlobalStore()
 
-const isMobile = computed(() => {
+const isMobile1 = computed(() => {
   return globalStore.winWidth <= 1200
+})
+
+const isMobile = ref()
+
+onMounted(() => {
+  watch(() => isMobile1.value, (new_val) => {
+    isMobile.value = new_val
+  })
 })
 
 // Split URI path; then remove empty string at start of the array

--- a/src/stories/NavBreadcrumb.stories.js
+++ b/src/stories/NavBreadcrumb.stories.js
@@ -1,7 +1,6 @@
-import { computed, onBeforeUnmount, onMounted } from 'vue'
+import { computed } from 'vue'
 import router from '@/router'
 import NavBreadcrumb from '@/lib-components/NavBreadcrumb'
-import { useGlobalStore } from '@/stores/GlobalStore'
 
 // Storybook default settings
 export default {
@@ -19,24 +18,6 @@ function Template(args) {
   router.push(args.to)
   return {
     setup() {
-      onMounted(() => {
-        const globalStore = useGlobalStore()
-
-        const updateWinWidth = () => {
-          globalStore.winWidth = window.innerWidth
-        }
-
-        // Set initial winWidth
-        updateWinWidth()
-
-        window.addEventListener('resize', updateWinWidth)
-
-        // Clean up
-        onBeforeUnmount(() => {
-          window.removeEventListener('resize', updateWinWidth)
-        })
-      })
-
       return { args }
     },
     components: { NavBreadcrumb },
@@ -73,21 +54,6 @@ function TemplateFTVA(args) {
       }
     },
     setup() {
-      onMounted(() => {
-        const globalStore = useGlobalStore()
-
-        const updateWinWidth = () => {
-          globalStore.winWidth = window.innerWidth
-        }
-
-        updateWinWidth()
-
-        window.addEventListener('resize', updateWinWidth)
-
-        onBeforeUnmount(() => {
-          window.removeEventListener('resize', updateWinWidth)
-        })
-      })
       return { args }
     },
     components: { NavBreadcrumb },


### PR DESCRIPTION
Connected to [APPS-2914](https://jira.library.ucla.edu/browse/APPS-2914)

**Component Updated:** NavBreadcrumb.vue

**Notes:**
- 

![hydration-error](https://github.com/user-attachments/assets/0b7b342b-70c3-4a0c-903c-c34653a3346b)

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~[ ] UX has reviewed and approved this~
-   [x] I requested a PR review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2914]: https://uclalibrary.atlassian.net/browse/APPS-2914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ