### PR TITLE
fix: APPS-2926 VideoEmbed cover image sizing

### DIFF
--- a/src/lib-components/VideoEmbed.vue
+++ b/src/lib-components/VideoEmbed.vue
@@ -103,6 +103,8 @@ const parsedTrailer = computed(() => {
       cursor: pointer;
       width: 100%;
       height: 100%;
+      aspect-ratio: 16 / 9;
+      object-fit: cover;
     }
 
     .play-button {


### PR DESCRIPTION
Connected to [APPS-2926](https://jira.library.ucla.edu/browse/APPS-2926)

**Component Updated:** VideoEmbed.vue

**Local Nuxt screenshots:**

_Before_

![video-cover_before](https://github.com/user-attachments/assets/5a924428-ae1a-4c80-9080-df9d0fdd7542)

<br>

_After_

![video-cover_after](https://github.com/user-attachments/assets/5526006f-4446-40e5-a1e2-119e6bbd01c5)


**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I have requested a PR review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2926]: https://uclalibrary.atlassian.net/browse/APPS-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ