### PR TITLE
feat: APPS-2941 add enddate, ongoing props to blockeventdetail.vue

### DIFF
--- a/src/lib-components/BlockEventDetail.vue
+++ b/src/lib-components/BlockEventDetail.vue
@@ -21,14 +21,23 @@ interface BlockEventDetailLocation {
   uri?: string
 }
 
-const { startDate, time, locations } = defineProps({
+const { startDate, endDate, time, ongoing, locations } = defineProps({
   startDate: {
     type: String,
-    default: '',
+    required: false,
   },
+  endDate: {
+    type: String,
+    required: false,
+  },
+  // Implied this is the start time
   time: {
     type: String,
-    default: '',
+    required: false,
+  },
+  ongoing: {
+    type: Boolean,
+    default: false,
   },
   locations: {
     type: Array<BlockEventDetailLocation>,
@@ -53,17 +62,29 @@ const themeSettings = computed(() => {
       }
   }
 })
+
+// Display date based on which data is provided
+const parsedDateDisplay = computed(() => {
+  if (ongoing)
+    return 'Ongoing'
+  else if (endDate)
+    return formatDates(startDate, endDate, 'shortWithYear')
+  else if (startDate)
+    return formatDates(startDate, startDate)
+  else
+    return null
+})
 </script>
 
 <template>
   <div :class="classes">
     <div class="event-list date">
       <span>
-        <SvgIconCalendar class="row-icon" /> {{ formatDates(startDate, startDate) }}
+        <SvgIconCalendar v-if="startDate" class="row-icon" /> {{ parsedDateDisplay }}
       </span>
     </div>
 
-    <div class="event-list time">
+    <div v-if="time" class="event-list time">
       <span>
         <SvgIconClock class="row-icon" /> {{ formatTimes(time, time) }}
       </span>

--- a/src/stories/BlockEventDetail.stories.js
+++ b/src/stories/BlockEventDetail.stories.js
@@ -30,6 +30,29 @@ const mockEventDetailData = {
   ]
 }
 
+const mockEventSeriesData = {
+  id: '2847944',
+  typeHandle: 'ftvaEvent',
+  title: 'La Région Centrale 03-08-24',
+  startDateWithTime: '2024-03-09T03:30:00+00:00',
+  endDate: '2024-03-09',
+  ongoing: false, // true is also valid for event series
+  location: [
+    {
+      id: '195746',
+      title: 'Billy Wilder Theater',
+      url: 'https://test-craft.library.ucla.edu/locations/billy-wilder-theater',
+      uri: 'locations/billy-wilder-theater'
+    },
+    {
+      id: '195746',
+      title: 'Other Location',
+      url: 'https://test-craft.library.ucla.edu/locations/other-locations',
+      uri: 'locations/somelocation'
+    }
+  ]
+}
+
 export function Default() {
   return {
     data() {
@@ -112,6 +135,54 @@ export function FtvaNoLocation() {
       :startDate="data.startDateWithTime"
       :time="data.startDateWithTime"
       :locations=[]
+    />
+    `,
+  }
+}
+
+export function EventSeries() {
+  return {
+    data() {
+      return {
+        data: mockEventSeriesData,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { BlockEventDetail },
+    template: `
+    <block-event-detail
+      :startDate="data.startDateWithTime"
+      :endDate="data.endDate"
+      :ongoing="data.ongoing"
+      :locations="data.location"
+    />
+    `,
+  }
+}
+
+export function EventSeriesOngoing() {
+  return {
+    data() {
+      return {
+        data: mockEventSeriesData,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { BlockEventDetail },
+    template: `
+    <block-event-detail
+      :startDate="data.startDateWithTime"
+      :endDate="data.endDate"
+      :ongoing="true"
+      :locations="[data.location[0]]"
     />
     `,
   }

--- a/src/utils/formatEventDates.js
+++ b/src/utils/formatEventDates.js
@@ -5,6 +5,7 @@ import format from 'date-fns/format'
  *
  * @param {string} startDate
  * @param {string} endDate
+ * @param {string} dateFormat - 'long', 'short', or 'shortWithYear'
  * @returns {string}
  */
 
@@ -26,14 +27,20 @@ function formatDates(startDate = '', endDate = '', dateFormat = 'long') {
     output = start
   }
 
-  if (dateFormat === 'short') {
+  if (dateFormat === 'short' || dateFormat === 'shortWithYear') {
     // "Feb 11 2020"
     const day = output.slice(0, 3)
     const dateYear = output.split(' ').slice(1).join(' ')
     if (endDate && endDate !== startDate) {
       // Feb 11 – May 31
-      const shortFormatEndDate = format(new Date(endDate), 'MMM d')
       const shortFormatStartDate = format(new Date(startDate), 'MMM d')
+      const shortFormatEndDate = format(new Date(endDate), 'MMM d')
+      // if 'shortWithYear' is selected, add the year to the end date
+      // Feb 11 – May 31 2020
+      if (dateFormat === 'shortWithYear') {
+        const shortFormatEndDateYear = format(new Date(endDate), 'MMM d, Y')
+        return `${shortFormatStartDate} - ${shortFormatEndDateYear}`
+      }
       return `${shortFormatStartDate} - ${shortFormatEndDate}`
     }
     return `${day} ${dateYear}`


### PR DESCRIPTION
Connected to [APPS-2941](https://jira.library.ucla.edu/browse/APPS-2941)

**Component Updated:** BlockEventDetail.vue

**Stories:** ~/stories/BlockEventDetail.stories.js

Added 2 stories for EventSeries data, one with date range, one with ongoing

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-2941]: https://uclalibrary.atlassian.net/browse/APPS-2941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ