### PR TITLE
fix: APP-2937 Remove gap between FTVA event cards

### DIFF
--- a/src/stories/SectionWrapper.stories.js
+++ b/src/stories/SectionWrapper.stories.js
@@ -286,3 +286,38 @@ export function FtvaExploreOtherSeries() {
   `,
   }
 }
+
+export function FtvaSeries2Cards() {
+  return {
+    data() {
+      return {
+        parsedFtvaEventSeries: mockFtvaSeries.slice(1)
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { SectionWrapper, SectionTeaserCard, SmartLink },
+    template: `
+      <SectionWrapper
+        section-title="Explore Other Series"
+        theme="white"
+      >
+        <template v-slot:top-right>
+          <smart-link
+            to="/somelink"
+          >
+            View All Series <span style="font-size:1.5em;"> &#8250;</span>
+          </smart-link>
+          
+        </template>
+        <SectionTeaserCard
+
+          :items="parsedFtvaEventSeries"
+        />
+      </SectionWrapper>
+  `,
+  }
+}

--- a/src/styles/ftva/_section-teaser-card.scss
+++ b/src/styles/ftva/_section-teaser-card.scss
@@ -2,26 +2,14 @@
     flex-wrap: nowrap;
     max-width: 100%; // 100% of the parent container
     align-items: flex-start;
-    justify-content: space-between;
     overflow-y: auto;
     padding-top: 25px;
     scrollbar-color: $grey-blue $white;
 
     .card {
-        width: calc((100% / 3) - 22px);
+        flex-basis: calc(33.3333333333% - 22px);
         min-width: 280px;
         margin-bottom: 15px;
-
-        @media #{$medium} {
-            flex-shrink: 0;
-
-            .section-teaser-card {
-                gap: var(--space-m);
-                overflow-x: auto;
-                overflow-y: visible;
-                flex-wrap: nowrap;
-            }
-        }
     }
 }
 

--- a/src/styles/ftva/_section-teaser-card.scss
+++ b/src/styles/ftva/_section-teaser-card.scss
@@ -7,7 +7,7 @@
     scrollbar-color: $grey-blue $white;
 
     .card {
-        flex-basis: calc(33.3333333333% - 22px);
+        flex-basis: calc((100% / 3) - 22px);
         min-width: 280px;
         margin-bottom: 15px;
     }

--- a/src/styles/ftva/_section-wrapper.scss
+++ b/src/styles/ftva/_section-wrapper.scss
@@ -8,11 +8,13 @@
 
         text-decoration: underline;
         text-decoration-thickness: 3px;
-        text-decoration-color: #{$grey-blue};
+        -webkit-text-decoration-color: #{$grey-blue};
+                text-decoration-color: #{$grey-blue};
         text-underline-offset: 4px;
 
         &:hover {
-            text-decoration-color: #{$bright-blue};
+            -webkit-text-decoration-color: #{$bright-blue};
+                    text-decoration-color: #{$bright-blue};
         }
     }
 


### PR DESCRIPTION
Connected to [APPS-2937](https://jira.library.ucla.edu/browse/APPS-2937)

**Component Updated:** _section-teaser-card.scss

https://deploy-preview-610--ucla-library-storybook.netlify.app/?path=/story/section-wrapper--ftva-series-2-cards

**Screenshots:**

![event-cards-spacing_before](https://github.com/user-attachments/assets/7fd4009f-7762-4c7e-ae33-bd5f73749210)

![event-cards-spacing_after](https://github.com/user-attachments/assets/30e793a1-f0c1-49c3-bf7c-0986daccc330)

**Checklist:**

-   ~~[ ] I checked that it is working locally in the dev server~~
-   [x] I checked that it is working locally in the storybook
-   ~~[ ] I checked that it is working locally in the 
library-website-nuxt dev server~~
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I requested a PR review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2937]: https://uclalibrary.atlassian.net/browse/APPS-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ