### PR TITLE
feat: APPS-2943 Add initialTab setting option to TabToggle

### DIFF
--- a/src/lib-components/TabItem.vue
+++ b/src/lib-components/TabItem.vue
@@ -19,7 +19,7 @@ const { content, icon, title } = defineProps({
   },
 })
 
-const activeTab = inject('activeTab')
+const activeTabTitle = inject('activeTabTitle')
 
 const theme = useTheme()
 
@@ -29,7 +29,7 @@ const classes = computed(() => {
 </script>
 
 <template>
-  <div v-show="title === activeTab" :class="classes">
+  <div v-show="title === activeTabTitle" :class="classes">
     <div
       v-text="content"
     />

--- a/src/lib-components/TabList.vue
+++ b/src/lib-components/TabList.vue
@@ -57,18 +57,19 @@ onMounted(() => {
   const activeTabElem = tabRefs.value[initialTab]
 
   /* @argument {boolean} hasInitialWidth */
-  // Boolean flag to disable glider's default full width,
-  // and set glider's starting position to align with
-  // initial tab
+  // Boolean flag to disable glider's default
+  // full width, and set glider's starting
+  // position to align with initial tab.
   animateTabGlider(activeTabElem, false)
 
   const { width } = useWindowSize()
   watch(width, (_newWidth) => {
-    // The glider width and animation/travel distance depend on
-    // the width and position of the tab buttons; when the window
-    // resizes these button values change, so the animation method
-    // needs to be called again to update the glider logic using
-    // the new button values
+    // The glider width and animation/travel distance
+    // depend on the width and position of the tab
+    // buttons; when the window resizes, these button
+    // values change. The animation method needs to be
+    // called again to update the glider logic using the
+    // new button values.
     const activeTabElem = tabRefs.value[activeTabIndex.value]
     animateTabGlider(activeTabElem, true)
   })
@@ -147,9 +148,9 @@ function switchTab(tabName: string) {
 function animateTabGlider(elem: HTMLElement, hasInitialWidth: boolean) {
   const tabGlider = tabGliderRef.value
 
-  // Positional values of tab button
+  // Get positional values of tab button
+  // and set glider height to match tab button
   const tabBtn = elem.getBoundingClientRect()
-  // Set glider height to match tab button
   tabGlider.style.height = `${tabBtn.height}px`
 
   if (!hasInitialWidth) {
@@ -159,11 +160,11 @@ function animateTabGlider(elem: HTMLElement, hasInitialWidth: boolean) {
     // Set glider width to match tab button
     tabGlider.style.width = `${tabBtn.width}px`
 
-    // Remove tab btn background; display glider background instead
+    // Remove tab button background; display glider background instead
     elem.style.background = 'none'
   }
 
-  // Calculate and set distance (CSS variable) to animate
+  // Calculate and set distance (CSS variable) to animate glider
   tabGlider.style.setProperty('--move_glider', `${elem.offsetLeft}px`)
 }
 </script>

--- a/src/lib-components/TabList.vue
+++ b/src/lib-components/TabList.vue
@@ -49,8 +49,12 @@ const iconMapping = {
 }
 
 onMounted(() => {
-  if (initialTab <= tabItems.value.length)
-    activeTab.value = tabItems.value[initialTab]?.title
+  activeTab.value = tabItems.value[initialTab]?.title
+
+  const tabElem = tabRefs.value[initialTab]
+
+  // Boolean flag to disable initial width glider
+  animateTabGlider(tabElem, false)
 })
 
 // Computed
@@ -74,40 +78,6 @@ function setTabId(tabName: string) {
 function setTabAriaControl(tabName: string) {
   const tabTitle = hyphenateTabName(tabName)
   return `panel-${tabTitle}`
-}
-
-function switchTab(tabName: string) {
-  activeTab.value = tabName
-
-  const tabIndex = tabItems.value!.findIndex(tab => tab?.title === tabName)
-
-  const tabElem: HTMLElement = tabRefs.value[tabIndex]
-
-  if (tabElem)
-    tabElem.focus()
-
-  if (!tabElem.classList.contains('active'))
-    animateTabGlider(tabElem)
-}
-
-function animateTabGlider(elem: HTMLElement) {
-  const tabGlider = tabGliderRef.value
-
-  const scaleGliderWidth = elem.offsetWidth / tabGlider.offsetWidth
-
-  // Calculate width to scale animated glider
-  // Use variable in CSS
-  tabGlider.style.setProperty('--scale_glider_width', scaleGliderWidth)
-
-  // Calculate and set distance to animate
-  // Use variable in CSS
-  tabGlider.style.setProperty('--translate_glider_left', `${elem.offsetLeft}px`)
-
-  // Object with positional values of tab button
-  const tabBtn = elem.getBoundingClientRect()
-
-  // Set glider to same height as tab button
-  tabGlider.style.height = `${tabBtn.height}px`
 }
 
 function hyphenateTabName(str: string) {
@@ -140,6 +110,42 @@ function keydownHandler(e: KeyboardEvent) {
       break
     default:
   }
+}
+
+function switchTab(tabName: string) {
+  activeTab.value = tabName
+
+  const tabIndex = tabItems.value!.findIndex(tab => tab?.title === tabName)
+
+  const tabElem: HTMLElement = tabRefs.value[tabIndex]
+
+  if (tabElem)
+    tabElem.focus()
+
+  if (!tabElem.classList.contains('active'))
+    animateTabGlider(tabElem, true)
+}
+
+function animateTabGlider(elem: HTMLElement, hasInitialWidth: boolean) {
+  const tabGlider = tabGliderRef.value
+
+  // Positional values of tab button
+  const tabBtn = elem.getBoundingClientRect()
+
+  if (!hasInitialWidth) {
+    tabGlider.style.width = '0'
+    tabGlider.style.setProperty('--translate_glider_left', `${elem.offsetLeft}px`)
+  }
+  else {
+    // Set glider width to match tab button
+    tabGlider.style.width = `${tabBtn.width}px`
+
+    // Note
+    tabGlider.style.setProperty('--translate_glider_left', `${elem.offsetLeft - 12}px`)
+  }
+
+  // Set glider height to match tab button
+  tabGlider.style.height = `${tabBtn.height}px`
 }
 </script>
 

--- a/src/lib-components/TabList.vue
+++ b/src/lib-components/TabList.vue
@@ -53,7 +53,10 @@ onMounted(() => {
 
   const tabElem = tabRefs.value[initialTab]
 
-  // Boolean flag to disable initial width glider
+  /* @argument {boolean} hasInitialWidth */
+  // Boolean flag to disable glider's default full width,
+  // and set glider's starting position to align with
+  // initial tab
   animateTabGlider(tabElem, false)
 })
 
@@ -134,15 +137,17 @@ function animateTabGlider(elem: HTMLElement, hasInitialWidth: boolean) {
 
   if (!hasInitialWidth) {
     tabGlider.style.width = '0'
-    tabGlider.style.setProperty('--translate_glider_left', `${elem.offsetLeft}px`)
   }
   else {
     // Set glider width to match tab button
     tabGlider.style.width = `${tabBtn.width}px`
 
-    // Note
-    tabGlider.style.setProperty('--translate_glider_left', `${elem.offsetLeft - 12}px`)
+    // Remove tab btn background; display glider background instead
+    elem.style.background = 'none'
   }
+
+  // Calculate and set distance to animate
+  tabGlider.style.setProperty('--move_glider', `${elem.offsetLeft}px`)
 
   // Set glider height to match tab button
   tabGlider.style.height = `${tabBtn.height}px`

--- a/src/lib-components/TabList.vue
+++ b/src/lib-components/TabList.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, provide, ref, useSlots } from 'vue'
+import { computed, defineAsyncComponent, onMounted, provide, ref, useSlots } from 'vue'
 import { useTheme } from '@/composables/useTheme'
 
-const { alignment } = defineProps({
+const { alignment, initialTab } = defineProps({
   alignment: {
     type: String,
     default: 'left',
   },
+  initialTab: {
+    type: Number,
+    default: 0
+  }
 })
 
 const SvgIconCalendar = defineAsyncComponent(() =>
@@ -43,6 +47,11 @@ const iconMapping = {
     label: 'List'
   },
 }
+
+onMounted(() => {
+  if (initialTab <= tabItems.value.length)
+    activeTab.value = tabItems.value[initialTab]?.title
+})
 
 // Computed
 const parsedAriaLabel = computed(() => {

--- a/src/stories/TabToggle.stories.js
+++ b/src/stories/TabToggle.stories.js
@@ -94,6 +94,29 @@ export function Default() {
   }
 }
 
+export function SetInitialTab() {
+  return {
+    data() {
+      return { ...mockContent }
+    },
+    components: { TabItem, TabList },
+    template: `<div class="wrapper">
+      <tab-list :initial-tab="1">
+        
+        <tab-item title="Label 1" icon="icon-calendar" :content="text1">
+        </tab-item>
+
+        <tab-item title="Label 2" icon="icon-list" :content="text2">
+        </tab-item>
+
+        <tab-item title="Label 3" :content="text3">
+        </tab-item>
+      
+      </tab-list>
+    </div>`
+  }
+}
+
 export function FTVACentered() {
   return {
     data() {

--- a/src/styles/default/_tab-list.scss
+++ b/src/styles/default/_tab-list.scss
@@ -31,22 +31,19 @@
     left: 0;
     right: 0;
     bottom: 0;
-    margin: 8px 12px;
+    margin: 8px 0;
     min-height: 40px;
     height: 100%;
     border-radius: .25rem;
     background-color: $white;
     box-shadow: 0 1px 4px 0 rgba(0, 0, 0, .25);
-    translate: var(--translate_glider_left, 0) 0;
+    translate: var(--move_glider, 0) 0;
     transform-origin: left;
     transition: scale 300ms ease-out, translate 300ms ease-out;
   }
 
   .tab-glider ~ .tab-list-item.active {
     background: $white;
-    // Delay background to allow glider
-    // animation to complete
-    transition: background-color 900ms;
   }
 
   .tab-list-item {

--- a/src/styles/default/_tab-list.scss
+++ b/src/styles/default/_tab-list.scss
@@ -31,21 +31,22 @@
     left: 0;
     right: 0;
     bottom: 0;
-    margin: 8px 0;
+    margin: 8px 12px;
+    min-height: 40px;
+    height: 100%;
     border-radius: .25rem;
     background-color: $white;
     box-shadow: 0 1px 4px 0 rgba(0, 0, 0, .25);
-    scale: var(--scale_glider_width, .125) 1;
     translate: var(--translate_glider_left, 0) 0;
     transform-origin: left;
     transition: scale 300ms ease-out, translate 300ms ease-out;
   }
 
-  // Set background of initial active tab
-  // .tab-glider ~ .tab-list-item:nth-of-type(1).active
   .tab-glider ~ .tab-list-item.active {
     background: $white;
-    transition: background-color 3000ms;
+    // Delay background to allow glider
+    // animation to complete
+    transition: background-color 900ms;
   }
 
   .tab-list-item {

--- a/src/styles/default/_tab-list.scss
+++ b/src/styles/default/_tab-list.scss
@@ -42,7 +42,8 @@
   }
 
   // Set background of initial active tab
-  .tab-glider ~ .tab-list-item:nth-of-type(1).active {
+  // .tab-glider ~ .tab-list-item:nth-of-type(1).active
+  .tab-glider ~ .tab-list-item.active {
     background: $white;
     transition: background-color 3000ms;
   }

--- a/src/styles/default/_tab-list.scss
+++ b/src/styles/default/_tab-list.scss
@@ -32,8 +32,7 @@
     right: 0;
     bottom: 0;
     margin: 8px 0;
-    min-height: 40px;
-    height: 100%;
+    height: auto;
     border-radius: .25rem;
     background-color: $white;
     box-shadow: 0 1px 4px 0 rgba(0, 0, 0, .25);


### PR DESCRIPTION
Connected to [APPS-2943](https://jira.library.ucla.edu/browse/APPS-2943)

**Component Updated:** TabList.vue

**Preview:** https://deploy-preview-611--ucla-library-storybook.netlify.app/?path=/story/tab-toggle--set-initial-tab

**Notes:**
- Added prop to allow initial active tab to be set
- Added extra story to demonstrate feature
- Updated/refactored tab glider animation

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   ~~[ ] I added a screenshot of it working~~
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I requested a PR review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2943]: https://uclalibrary.atlassian.net/browse/APPS-2943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ