### PR TITLE
fix: overflowing long text in ftva menu

### DIFF
--- a/src/stories/HeaderSticky.stories.js
+++ b/src/stories/HeaderSticky.stories.js
@@ -74,7 +74,7 @@ const FTVAprimaryItems = [
   },
   {
     ...API.primaryNavlinks[0],
-    name:'Really really long name',
+    name: 'Really really long name',
   },
 ]
 

--- a/src/stories/HeaderSticky.stories.js
+++ b/src/stories/HeaderSticky.stories.js
@@ -60,6 +60,24 @@ export function Default() {
   }
 }
 
+const FTVAprimaryItems = [
+  { ...API.primaryNavlinks[0] },
+  {
+    ...API.primaryNavlinks[0],
+    name: 'Visit',
+    url: '/visit/',
+  },
+  {
+    ...API.primaryNavlinks[0],
+    name: 'About',
+    url: '/about/',
+  },
+  {
+    ...API.primaryNavlinks[0],
+    name:'Really really long name',
+  },
+]
+
 export function FTVAVersion() {
   return {
     setup() {
@@ -67,7 +85,6 @@ export function FTVAVersion() {
         const globalStore = useGlobalStore()
 
         const updateWinWidth = () => {
-          console.log(window.innerWidth)
           globalStore.winWidth = window.innerWidth
         }
 
@@ -84,7 +101,7 @@ export function FTVAVersion() {
     },
     data() {
       return {
-        primaryItems,
+        FTVAprimaryItems,
       }
     },
     provide() {
@@ -95,7 +112,7 @@ export function FTVAVersion() {
     components: { HeaderSticky },
     template: `
         <header-sticky
-            :primary-items="primaryItems"
+            :primary-items="FTVAprimaryItems"
         />
     `,
   }

--- a/src/styles/ftva/_header-sticky.scss
+++ b/src/styles/ftva/_header-sticky.scss
@@ -24,6 +24,7 @@
             color: white;
             font-size: 20px;
             font-weight: 500;
+            line-height: normal;
         }
     }
 }


### PR DESCRIPTION
Connected to [APPS-](https://jira.library.ucla.edu/browse/APPS-)

**Notes:**

Prevents long menu items from overflowing the container. 
Discussed with UX here: https://uclalibrary.slack.com/archives/C014BPS0YBX/p1726169734734269

UX would like to make further changes to header styles, we need to make time next week or following. This is merely a quickfix to prevent the current 'broken' look.


<img width="1270" alt="Screenshot 2024-09-12 at 12 31 48 PM" src="https://github.com/user-attachments/assets/0fa1d627-eaf3-41f8-9a23-021279715b16">
<img width="1268" alt="Screenshot 2024-09-12 at 12 33 46 PM" src="https://github.com/user-attachments/assets/cf9194af-4784-493e-9bfc-8f936faf926d">

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR
