### PR TITLE
chore: APPS-2962 move styles from page to story

### DIFF
--- a/src/styles/ftva/_section-teaser-card.scss
+++ b/src/styles/ftva/_section-teaser-card.scss
@@ -4,10 +4,12 @@
     align-items: flex-start;
     overflow-y: auto;
     padding-top: 25px;
+    gap: var(--space-xl) 20px;
     scrollbar-color: $grey-blue $white;
     &:has(> :last-child:nth-child(3)) {
         /* if section has 3 elements */
         justify-content: space-between;
+        gap: var(--space-xl) 16px;
     }
 
     .card {

--- a/src/styles/ftva/_section-teaser-card.scss
+++ b/src/styles/ftva/_section-teaser-card.scss
@@ -5,6 +5,10 @@
     overflow-y: auto;
     padding-top: 25px;
     scrollbar-color: $grey-blue $white;
+    &:has(> :last-child:nth-child(3)) {
+        /* if section has 3 elements */
+        justify-content: space-between;
+    }
 
     .card {
         flex-basis: calc((100% / 3) - 22px);


### PR DESCRIPTION
Connected to [APPS-2962](https://jira.library.ucla.edu/browse/APPS-2962)

**Notes:**

When section teaser card has 3 cards we'd like the third card to align with the edge of the link.
When section teaser card has fewer cards, we'd like the cards to align one after another without big gaps in between. 

This PR adds styles for 3 cards to justify content to the edges, but will not change the styles for 2 cards. We do bump the gap for 2 cards to 20px minimum so that it will not ever look too different than the responsive gap between the 3 card layouts, regardless of screen size

<img width="998" alt="Screenshot 2024-09-25 at 2 01 58 PM" src="https://github.com/user-attachments/assets/cbe0a091-a748-4fd0-ac9b-018f70b995b7">

<img width="998" alt="Screenshot 2024-09-25 at 2 02 08 PM" src="https://github.com/user-attachments/assets/604e73df-fe75-4410-978f-46a8c58f4605">

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-2962]: https://uclalibrary.atlassian.net/browse/APPS-2962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ