### PR TITLE
fix: APPS-2982 Remove excess padding values

### DIFF
--- a/src/lib-components/TwoColLayoutWStickySideBar.vue
+++ b/src/lib-components/TwoColLayoutWStickySideBar.vue
@@ -76,7 +76,7 @@ onMounted(() => {
     .primary-section-wrapper {
       padding-left: 0px;
       margin: var(--space-2xl) auto;
-      padding: 0 var(--unit-gutter);
+      padding: 0 var(--unit-gutter) 0 0;
     }
   }
 
@@ -89,7 +89,6 @@ onMounted(() => {
     right: 0;
     padding-top: var(--space-2xl);
     padding-bottom: 40px;
-    padding-right: var(--unit-gutter);
 
     .sidebar-content-wrapper {
       position: sticky;

--- a/src/lib-components/TwoColLayoutWStickySideBar.vue
+++ b/src/lib-components/TwoColLayoutWStickySideBar.vue
@@ -74,7 +74,6 @@ onMounted(() => {
     width: 67%;
 
     .primary-section-wrapper {
-      padding-left: 0px;
       margin: var(--space-2xl) auto;
       padding: 0 var(--unit-gutter) 0 0;
     }
@@ -110,10 +109,18 @@ onMounted(() => {
 @media (max-width: 1200px) {
   .two-column {
     padding-right: var(--unit-gutter);
-  }
 
-  .two-column>.primary-column {
-    width: 62%;
+    .primary-column {
+      width: 62%;
+
+      .primary-section-wrapper {
+        padding-left: var(--unit-gutter);
+      }
+    }
+
+    .sidebar-column {
+      padding-right: var(--unit-gutter);
+    }
   }
 }
 


### PR DESCRIPTION
Connected to [APPS-2982](https://jira.library.ucla.edu/browse/APPS-2982)

**Component Created:** TwoColLayoutWStickySideBar.vue

**Notes:**
- Removed padding to the left and right of the component.

**Before:**
![event-series-page-fixes](https://github.com/user-attachments/assets/fd76f97f-d02a-4e33-99bb-10e229d27513)


**After:**
![twoColStickySidebar-fixed-padding](https://github.com/user-attachments/assets/7f56fb91-eaf9-4116-9fa7-44f42c2ea62b)

![tablet-mob](https://github.com/user-attachments/assets/198241c6-8b46-4714-8b6e-fc70baf3abeb)


**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2982]: https://uclalibrary.atlassian.net/browse/APPS-2982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ