### PR TITLE
feat: APPS-2959 FlexibleMediaGallery FTVA variant

### DIFF
--- a/src/lib-components/Flexible/MediaGallery.vue
+++ b/src/lib-components/Flexible/MediaGallery.vue
@@ -12,10 +12,16 @@ import FlexibleMediaGalleryThumbnailCard from '@/lib-components/Flexible/MediaGa
 import type { FlexibleMediaGallery } from '@/types/flexible_types'
 import { useTheme } from '@/composables/useTheme'
 
-const { block } = defineProps({
+const { block, inline } = defineProps({
   block: {
     type: Object as PropType<FlexibleMediaGallery>,
     required: true,
+  },
+
+  // Triggers Lightbox to be overlaid (default) or inline
+  inline: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -73,6 +79,7 @@ function selectItem(itemIndex: number) {
       :items="block.mediaGallery"
       :selected-item="selectionIndex"
       tabindex="0"
+      :inline="inline"
       @close-modal="hideLightboxModal"
       @keydown.esc="hideLightboxModal"
     />

--- a/src/lib-components/Flexible/MediaGallery.vue
+++ b/src/lib-components/Flexible/MediaGallery.vue
@@ -37,14 +37,22 @@ const galleryTitle = computed(() => {
   return block.sectionTitle
 })
 
-const halfWidthTitle = computed(() => {
+const fullWidthGallery = computed(() => {
+  return block.mediaGalleryStyle === 'fullWidth'
+})
+
+const halfWidthGallery = computed(() => {
   return block.mediaGalleryStyle === 'halfWidth'
+})
+
+const halfWidthTitle = computed(() => {
+  return halfWidthGallery.value
     ? block.sectionTitle
     : ''
 })
 
 const halfWidthSummary = computed(() => {
-  return block.mediaGalleryStyle === 'halfWidth'
+  return halfWidthGallery.value
     ? block.richTextSimplified
     : ''
 })
@@ -84,7 +92,7 @@ function selectItem(itemIndex: number) {
       @keydown.esc="hideLightboxModal"
     />
 
-    <section v-if="theme" class="gallery-header">
+    <section v-if="theme && fullWidthGallery" class="gallery-header">
       <h2 class="gallery-title">
         {{ galleryTitle }}
       </h2>

--- a/src/lib-components/Flexible/MediaGallery.vue
+++ b/src/lib-components/Flexible/MediaGallery.vue
@@ -10,6 +10,7 @@ import FlexibleMediaGalleryNewLightbox from '@/lib-components/Flexible/MediaGall
 import FlexibleMediaGalleryThumbnailCard from '@/lib-components/Flexible/MediaGallery/ThumbnailCard.vue'
 
 import type { FlexibleMediaGallery } from '@/types/flexible_types'
+import { useTheme } from '@/composables/useTheme'
 
 const { block } = defineProps({
   block: {
@@ -26,6 +27,10 @@ const nItems = computed(() => {
   return block.mediaGallery.length
 })
 
+const galleryTitle = computed(() => {
+  return block.sectionTitle
+})
+
 const halfWidthTitle = computed(() => {
   return block.mediaGalleryStyle === 'halfWidth'
     ? block.sectionTitle
@@ -36,6 +41,11 @@ const halfWidthSummary = computed(() => {
   return block.mediaGalleryStyle === 'halfWidth'
     ? block.richTextSimplified
     : ''
+})
+
+const theme = useTheme()
+const parsedClasses = computed(() => {
+  return ['media-gallery', theme?.value || '']
 })
 
 // methods:
@@ -54,10 +64,9 @@ function selectItem(itemIndex: number) {
 </script>
 
 <template>
-  <!-- <section class="media-gallery"> -->
   <section
     v-if="block.mediaGallery && block.mediaGallery.length > 0"
-    class="media-gallery"
+    :class="parsedClasses"
   >
     <FlexibleMediaGalleryNewLightbox
       v-if="showLightboxModal"
@@ -67,6 +76,18 @@ function selectItem(itemIndex: number) {
       @close-modal="hideLightboxModal"
       @keydown.esc="hideLightboxModal"
     />
+
+    <section v-if="theme" class="gallery-header">
+      <h2 class="gallery-title">
+        {{ galleryTitle }}
+      </h2>
+      <h3 class="selected-image-title">
+        {{ block.mediaGallery[selectionIndex].captionTitle }}
+      </h3>
+      <p class="selected-image-caption">
+        {{ block.mediaGallery[selectionIndex].captionText }}
+      </p>
+    </section>
 
     <FlexibleMediaGalleryBannerImage
       v-if="block.mediaGallery && block.mediaGallery[selectionIndex].item"
@@ -99,17 +120,6 @@ function selectItem(itemIndex: number) {
   lang="scss"
   scoped
 >
-.media-gallery {
-  background-color: var(--color-theme, var(--color-white));
-
-  .thumbnails {
-    width: 100%;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(292px, 1fr));
-    column-gap: var(--space-m);
-    row-gap: var(--space-xl);
-    padding-top: var(--space-xl);
-    list-style-type: none;
-  }
-}
+@import "@/styles/default/_media-gallery.scss";
+@import "@/styles/ftva/_media-gallery.scss";
 </style>

--- a/src/lib-components/Flexible/MediaGallery.vue
+++ b/src/lib-components/Flexible/MediaGallery.vue
@@ -92,7 +92,7 @@ function selectItem(itemIndex: number) {
       @keydown.esc="hideLightboxModal"
     />
 
-    <section v-if="theme && fullWidthGallery" class="gallery-header">
+    <section v-if="theme === 'ftva' && fullWidthGallery" class="gallery-header">
       <h2 class="gallery-title">
         {{ galleryTitle }}
       </h2>

--- a/src/lib-components/Flexible/MediaGallery/BannerImage.vue
+++ b/src/lib-components/Flexible/MediaGallery/BannerImage.vue
@@ -77,7 +77,7 @@ const classes = computed(() => {
         />
       </div>
       <MediaBadge v-if="nItems > 1" :is-expanded="expanded">
-        <span v-if="theme">
+        <span v-if="theme === 'ftva'">
           <span v-if="expanded">Collapse Gallery</span>
           <span v-else>View all {{ nItems }} images</span>
         </span>
@@ -87,7 +87,7 @@ const classes = computed(() => {
         </span>
 
         <!-- Toggle Icons -->
-        <SvgIconFtvaDropTriangle v-if="theme" class="drop-triangle" :class="{ 'is-expanded': expanded }" />
+        <SvgIconFtvaDropTriangle v-if="theme === 'ftva'" class="drop-triangle" :class="{ 'is-expanded': expanded }" />
         <svg v-else class="glyph-expand">
           <line
             x1="20%"

--- a/src/lib-components/Flexible/MediaGallery/BannerImage.vue
+++ b/src/lib-components/Flexible/MediaGallery/BannerImage.vue
@@ -78,7 +78,8 @@ const classes = computed(() => {
       </div>
       <MediaBadge v-if="nItems > 1" :is-expanded="expanded">
         <span v-if="theme">
-          View all {{ nItems }} images
+          <span v-if="expanded">Collapse Gallery</span>
+          <span v-else>View all {{ nItems }} images</span>
         </span>
         <span v-else>
           {{ nItems }}
@@ -86,7 +87,7 @@ const classes = computed(() => {
         </span>
 
         <!-- Toggle Icons -->
-        <SvgIconFtvaDropTriangle v-if="theme" class="drop-triangle" />
+        <SvgIconFtvaDropTriangle v-if="theme" class="drop-triangle" :class="{ 'is-expanded': expanded }" />
         <svg v-else class="glyph-expand">
           <line
             x1="20%"

--- a/src/lib-components/Flexible/MediaGallery/BannerImage.vue
+++ b/src/lib-components/Flexible/MediaGallery/BannerImage.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import type { PropType } from 'vue'
 
 import SvgMoleculeImageStack from 'ucla-library-design-tokens/assets/svgs/molecule-image-stack.svg'
+import SvgIconImageStack from 'ucla-library-design-tokens/assets/svgs/icon-image-stack.svg'
 import SvgIconFtvaDropTriangle from 'ucla-library-design-tokens/assets/svgs/icon-ftva-drop-triangle.svg'
 import MediaItem from '@/lib-components/Media/Item.vue'
 import MediaBadge from '@/lib-components/MediaBadge.vue'
@@ -71,7 +72,14 @@ const classes = computed(() => {
     >
       <div v-if="nItems > 1 && !expanded">
         <div class="gradient" />
+        <div v-if="theme === 'ftva'" class="ftva-image-stack-bckgrd">
+          <SvgIconImageStack
+            class="molecule-image-stack"
+            aria-hidden="true"
+          />
+        </div>
         <SvgMoleculeImageStack
+          v-else
           class="molecule-image-stack"
           aria-hidden="true"
         />

--- a/src/lib-components/Flexible/MediaGallery/BannerImage.vue
+++ b/src/lib-components/Flexible/MediaGallery/BannerImage.vue
@@ -3,10 +3,13 @@ import { computed } from 'vue'
 import type { PropType } from 'vue'
 
 import SvgMoleculeImageStack from 'ucla-library-design-tokens/assets/svgs/molecule-image-stack.svg'
+import SvgIconFtvaDropTriangle from 'ucla-library-design-tokens/assets/svgs/icon-ftva-drop-triangle.svg'
 import MediaItem from '@/lib-components/Media/Item.vue'
 import MediaBadge from '@/lib-components/MediaBadge.vue'
 import RichText from '@/lib-components/RichText.vue'
 import type { MediaItemType } from '@/types/types'
+
+import { useTheme } from '@/composables/useTheme'
 
 const props = defineProps({
   item: {
@@ -45,9 +48,11 @@ const props = defineProps({
 
 const emit = defineEmits(['toggleThumbnails'])
 
+const theme = useTheme()
+
 const classes = computed(() => {
   return [
-    'banner-image',
+    'banner-image', theme?.value || '',
     props.isHalfWidth === 'halfWidth' ? 'half-width-media-item' : '',
   ]
 })
@@ -72,9 +77,17 @@ const classes = computed(() => {
         />
       </div>
       <MediaBadge v-if="nItems > 1" :is-expanded="expanded">
-        {{ nItems }}
-        images
-        <svg class="glyph-expand">
+        <span v-if="theme">
+          View all {{ nItems }} images
+        </span>
+        <span v-else>
+          {{ nItems }}
+          images
+        </span>
+
+        <!-- Toggle Icons -->
+        <SvgIconFtvaDropTriangle v-if="theme" class="drop-triangle" />
+        <svg v-else class="glyph-expand">
           <line
             x1="20%"
             y1="50%"
@@ -94,6 +107,7 @@ const classes = computed(() => {
       </MediaBadge>
     </MediaItem>
 
+    <!-- Half-Width Gallery -->
     <div v-if="isHalfWidth" class="text-wrapper">
       <h3 v-if="sectionTitle" class="title" v-text="sectionTitle" />
 
@@ -107,122 +121,6 @@ const classes = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-.banner-image {
-  // cursor: pointer;
-  .gradient {
-      display: none;
-      background: var(--gradient-radial);
-      background-size: cover;
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      cursor: pointer;
-  }
-
-  .svg__molecule-image-stack {
-      --width: calc(min(128px, 30%));
-      width: var(--width);
-      height: var(--width);
-      position: absolute;
-      left: calc(50% - var(--width) / 2);
-      top: calc((50% - var(--width) / 2) - 16px);
-
-      .svg__fill--primary-blue-03 {
-          fill: var(--color-primary-blue-03);
-      }
-  }
-
-  .glyph-expand {
-      display: inline-block;
-      width: 24px;
-      height: 24px;
-      margin-left: 8px;
-
-      border-radius: 12px;
-      background: #ffffff;
-  }
-}
-
-.half-width-media-item {
-  display: flex;
-  flex-direction: row;
-  gap: var(--space-xl);
-
-  .media-item {
-      width: calc((100% - 16px) / 2);
-      cursor: pointer;
-  }
-
-  .text-wrapper {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      max-width: calc((100% - 16px) / 2);
-
-      .title {
-          @include step-3;
-          color: var(--color-primary-blue-03);
-          margin-bottom: var(--space-l);
-          text-align: left;
-          width: 100%;
-      }
-      .summary {
-          @include step-0;
-          align-items: center;
-          text-align: left;
-          width: 100%;
-      }
-      .rich-text {
-          padding-right: 0;
-          :deep(p:not(:last-child)) {
-              margin-bottom: var(--space-m);
-          }
-      }
-  }
-
-  // Breakpoints
-  @media #{$medium} {
-      flex-direction: row;
-      gap: var(--space-xl);
-      .media-item {
-          width: calc((100% - 16px) / 2);
-          cursor: pointer;
-      }
-      .text-wrapper {
-          width: calc((100% - 16px) / 2);
-      }
-  }
-
-  @media #{$small} {
-      flex-direction: column;
-      flex-wrap: wrap;
-      .media-item {
-          width: 100%;
-      }
-      .text-wrapper {
-          min-width: 100%;
-          display: flex;
-          flex-direction: column;
-          margin-bottom: 15px;
-      }
-  }
-}
-
-// Hovers
-@media #{$has-hover} {
-  .media-item:hover {
-      .gradient {
-          display: block;
-      }
-
-      .svg__molecule-image-stack {
-          .svg__fill--primary-blue-03 {
-              fill: var(--color-primary-blue-05);
-          }
-      }
-  }
-}
+@import "@/styles/default/_media-gallery-banner-image.scss";
+@import "@/styles/ftva/_media-gallery-banner-image.scss";
 </style>

--- a/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -14,16 +14,23 @@ import MediaItem from '@/lib-components/Media/Item.vue'
 
 import { useTheme } from '@/composables/useTheme'
 
-const { items, selectedItem } = defineProps({
+const { items, selectedItem, inline } = defineProps({
   items: {
     type: Array as PropType<MediaGalleryItemType[]>,
     default: () => [],
     required: true,
   },
+
   selectedItem: {
     type: Number,
     default: 0,
   },
+
+  // Triggers Lightbox to be overlaid (default) or inline
+  inline: {
+    type: Boolean,
+    default: false
+  }
 })
 
 const emit = defineEmits<{
@@ -47,7 +54,7 @@ const captionText = computed(() => {
   return items.map(item => item.captionText)
 })
 const classes = computed(() => {
-  return ['lightbox', theme?.value || '']
+  return ['lightbox', theme?.value || '', inline ? 'inline' : '']
 })
 // if ftva, pass cover as object fit, otherwise contain
 const parsedObjectFit = computed(() => {

--- a/src/lib-components/Flexible/MediaGallery/ThumbnailCard.vue
+++ b/src/lib-components/Flexible/MediaGallery/ThumbnailCard.vue
@@ -10,6 +10,7 @@ import MediaItem from '@/lib-components/Media/Item.vue'
 
 import type { MediaItemType } from '@/types/types'
 import removeHtmlTruncate from '@/utils/removeHtmlTruncate'
+import { useTheme } from '@/composables/useTheme'
 
 const props = defineProps({
   item: {
@@ -56,10 +57,15 @@ const thumbnailImage = computed(() => {
 const parsedText = computed(() => {
   return removeHtmlTruncate(props.captionText || props.credit || '')
 })
+
+const theme = useTheme()
+const parsedClasses = computed(() => {
+  return ['thumbnail-card', theme?.value || '']
+})
 </script>
 
 <template>
-  <SectionWrapper class="thumbnail-card" :no-margins="true">
+  <SectionWrapper :class="parsedClasses" :no-margins="true">
     <MediaItem
       :item="thumbnailImage"
       :aspect-ratio="60"
@@ -82,36 +88,6 @@ const parsedText = computed(() => {
 </template>
 
 <style lang="scss" scoped>
-.thumbnail-card {
-  width: 100%;
-
-  .image {
-      margin-bottom: var(--space-s);
-  }
-
-  .caption-title {
-      @include step-1;
-      color: #{$black};
-      margin-bottom: var(--space-xs);
-  }
-
-  .caption-text {
-      @include step-0;
-      color: #{$secondary-grey-05};
-      @include truncate($lines: 4);
-  }
-
-  .caption-link {
-      @include button;
-      margin-top: 10px;
-      padding: 0;
-
-      // /* identical to box height, or 22px */
-      display: flex;
-      align-items: center;
-
-      // /* primary/blue-03 */
-      color: $primary-blue-03;
-  }
-}
+@import "@/styles/default/_media-gallery-thumbnail-card.scss";
+@import "@/styles/ftva/_media-gallery-thumbnail-card.scss";
 </style>

--- a/src/lib-components/MediaBadge.vue
+++ b/src/lib-components/MediaBadge.vue
@@ -1,12 +1,17 @@
-<script>
-export default {
-  name: 'MediaBadge',
-}
+<script setup>
+import { computed } from 'vue'
+import { useTheme } from '@/composables/useTheme'
+
+const theme = useTheme()
+
+const parsedClasses = computed(() => {
+  return ['media-badge', theme?.value || '']
+})
 </script>
 
 <template>
-  <div class="media-badge">
-    <div class="floating-highlight" />
+  <div :class="parsedClasses">
+    <div v-if="theme !== 'ftva'" class="floating-highlight" />
     <div class="badge-content">
       <slot class="badge-content-item" />
     </div>
@@ -14,74 +19,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-.media-badge {
-  --badge-width: 264px;
-  --badge-height: 64px;
-  --accent-slope: 2.35;
-  --background-color: var(--color-theme, var(--color-white));
-  --accent-color: var(--color-visit-fushia-03);
-
-  position: absolute;
-  width: var(--badge-width);
-  height: var(--badge-height);
-  right: -1px;
-  bottom: -1px;
-  cursor: pointer;
-
-  .badge-content {
-      @include button;
-
-      width: 100%;
-      height: 100%;
-
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      justify-content: center;
-
-      --color: var(--color-primary-blue-03);
-      color: var(--color);
-      stroke: var(--color);
-      background-color: var(--background-color);
-
-      --diagonal-width: calc(var(--badge-height) / var(--accent-slope));
-      clip-path: polygon(
-          0% 100%,
-          var(--diagonal-width) 0%,
-          100% 0%,
-          100% 100%,
-          0% 100%
-      );
-  }
-
-  .floating-highlight {
-      position: absolute;
-      width: var(--badge-width);
-      height: var(--badge-height);
-      top: -6px;
-      left: -8px;
-
-      background: var(--accent-color);
-
-      --diagonal-width: calc(var(--badge-height) / var(--accent-slope));
-      clip-path: polygon(
-          0% 100%,
-          0% calc(100% - 1.5px),
-          var(--diagonal-width) 0%,
-          100% 0%,
-          100% 1.5px,
-          calc(var(--diagonal-width) + 1px) 1.5px,
-          1px 100%
-      );
-  }
-}
-
-// Breakpoints
-
-@media #{$small} {
-  .media-badge {
-      --badge-width: 212px;
-      --badge-height: 44px;
-  }
-}
+@import "@/styles/default/_media-badge.scss";
+@import "@/styles/ftva/_media-badge.scss";
 </style>

--- a/src/stories/Flexible_MediaGallery.stories.js
+++ b/src/stories/Flexible_MediaGallery.stories.js
@@ -1,4 +1,6 @@
+import { computed } from 'vue'
 import * as API from './mock/Media'
+import * as FTVAGallery from './mock/FTVAMedia'
 import FlexibleMediaGallery from '@/lib-components/Flexible/MediaGallery'
 
 export default {
@@ -17,6 +19,26 @@ export function Default() {
       }
     },
 
+    components: { FlexibleMediaGallery },
+    template: '<flexible-media-gallery :block="block"/>',
+  }
+}
+
+export function FTVA() {
+  return {
+    data() {
+      return {
+        block: {
+          ...FTVAGallery.Gallery,
+          mediaGalleryStyle: 'fullWidth',
+        },
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
     components: { FlexibleMediaGallery },
     template: '<flexible-media-gallery :block="block"/>',
   }

--- a/src/stories/Flexible_MediaGallery.stories.js
+++ b/src/stories/Flexible_MediaGallery.stories.js
@@ -61,3 +61,26 @@ export function WithHalfWidth() {
     template: '<flexible-media-gallery :block="block"/>',
   }
 }
+
+export function FTVAHalfWidth() {
+  return {
+    data() {
+      return {
+        block: {
+          ...FTVAGallery.Gallery,
+          mediaGalleryStyle: 'halfWidth',
+          sectionTitle: 'FTVA Half Width Gallery',
+          richTextSimplified:
+                    'Sensors indicate no shuttle or other ships in this sector. According to coordinates, we have travelled 7,000 light years and are located near the system J-25. Tractor beam released, sir. Force field maintaining our hull integrity. Damage report? Sections 27, 28 and 29 on decks four, five and six destroyed. Without our shields, at this range it is probable a photon detonation could destroy the Enterprise.',
+        },
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { FlexibleMediaGallery },
+    template: '<flexible-media-gallery :block="block"/>',
+  }
+}

--- a/src/stories/MediaBadge.stories.js
+++ b/src/stories/MediaBadge.stories.js
@@ -1,4 +1,5 @@
-// Import mock api data
+import { computed } from 'vue'
+
 import * as API from '@/stories/mock-api.json'
 import MediaBadge from '@/lib-components/MediaBadge'
 import ResponsiveImage from '@/lib-components/ResponsiveImage.vue'
@@ -35,6 +36,34 @@ export function Default() {
 </svg>
         </media-badge>
       </responsive-image>
+  `,
+  }
+}
+
+export function FTVA() {
+  return {
+    data() {
+      return {
+        ...mock,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: {
+      ResponsiveImage,
+      MediaBadge,
+    },
+    template: `
+    <responsive-image :media="image">
+      <media-badge
+          :image="image"
+          :image-aspect-ratio="60">
+        5 Images
+      </media-badge>
+    </responsive-image>
   `,
   }
 }

--- a/src/stories/MediaGallery_BannerImage.stories.js
+++ b/src/stories/MediaGallery_BannerImage.stories.js
@@ -1,4 +1,5 @@
-// Import mock api data
+import { computed } from 'vue'
+
 import FlexibleMediaGalleryBannerImage from '@/lib-components/Flexible/MediaGallery/BannerImage.vue'
 
 import * as MEDIA from '@/stories/mock/Media'
@@ -29,12 +30,61 @@ export function Default() {
   }
 }
 
+export function FTVA() {
+  return {
+    data() {
+      return {
+        item: MEDIA.ImageFile,
+        nItems: 5,
+        expanded: false,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { FlexibleMediaGalleryBannerImage },
+    template: `
+      <flexible-media-gallery-banner-image
+        :item="item"
+        :n-items="nItems"
+        :expanded="expanded"
+    />
+  `,
+  }
+}
+
 export function Expanded() {
   return {
     data() {
       return {
         item: MEDIA.ImageFile,
         expanded: true,
+      }
+    },
+    components: { FlexibleMediaGalleryBannerImage },
+    template: `
+      <flexible-media-gallery-banner-image
+        :item="item"
+        n-items=5
+        :expanded="expanded"
+    />
+  `,
+  }
+}
+
+export function ExpandedFTVA() {
+  return {
+    data() {
+      return {
+        item: MEDIA.ImageFile,
+        expanded: true,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
       }
     },
     components: { FlexibleMediaGalleryBannerImage },

--- a/src/stories/MediaGallery_BannerImage.stories.js
+++ b/src/stories/MediaGallery_BannerImage.stories.js
@@ -1,7 +1,7 @@
 import { computed } from 'vue'
 
+import * as FTVAMedia from './mock/FTVAMedia'
 import FlexibleMediaGalleryBannerImage from '@/lib-components/Flexible/MediaGallery/BannerImage.vue'
-
 import * as MEDIA from '@/stories/mock/Media'
 
 // Storybook default settings
@@ -34,8 +34,8 @@ export function FTVA() {
   return {
     data() {
       return {
-        item: MEDIA.ImageFile,
-        nItems: 5,
+        item: FTVAMedia.ImageFile,
+        nItems: 4,
         expanded: false,
       }
     },
@@ -78,7 +78,8 @@ export function ExpandedFTVA() {
   return {
     data() {
       return {
-        item: MEDIA.ImageFile,
+        item: FTVAMedia.ImageFile,
+        nItems: 4,
         expanded: true,
       }
     },
@@ -91,7 +92,7 @@ export function ExpandedFTVA() {
     template: `
       <flexible-media-gallery-banner-image
         :item="item"
-        n-items=5
+        :n-items="nItems"
         :expanded="expanded"
     />
   `,

--- a/src/stories/MediaGallery_NewLightbox.stories.js
+++ b/src/stories/MediaGallery_NewLightbox.stories.js
@@ -1,4 +1,5 @@
 import { computed } from 'vue'
+import * as FTVAMedia from './mock/FTVAMedia'
 import FlexibleMediaGalleryNewLightbox from '@/lib-components/Flexible/MediaGallery/NewLightbox.vue'
 import BlockTag from '@/lib-components/BlockTag.vue'
 import { Gallery as MEDIA_GALLERY_MOCK } from '@/stories/mock/Media'
@@ -64,7 +65,7 @@ export function FTVA_DefaultLightbox() {
   return {
     data() {
       return {
-        items: mockFTVAGalleryComputedData,
+        items: FTVAMedia.Gallery.mediaGallery
       }
     },
     provide() {

--- a/src/stories/MediaGallery_NewLightbox.stories.js
+++ b/src/stories/MediaGallery_NewLightbox.stories.js
@@ -60,6 +60,23 @@ const mockFTVAGalleryComputedData = computed(() => {
   })
 })
 
+export function FTVA_DefaultLightbox() {
+  return {
+    data() {
+      return {
+        items: mockFTVAGalleryComputedData,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { FlexibleMediaGalleryNewLightbox },
+    template: '<flexible-media-gallery-new-lightbox :items="items"/>',
+  }
+}
+
 export function FTVA_EventDetailCarousel() {
   return {
     data() {
@@ -73,7 +90,7 @@ export function FTVA_EventDetailCarousel() {
       }
     },
     components: { FlexibleMediaGalleryNewLightbox },
-    template: '<flexible-media-gallery-new-lightbox :items="items" />',
+    template: '<flexible-media-gallery-new-lightbox :items="items" :inline=true />',
   }
 }
 
@@ -99,6 +116,6 @@ export function FTVA_Homepage() {
       }
     },
     components: { FlexibleMediaGalleryNewLightbox, BlockTag },
-    template: '<flexible-media-gallery-new-lightbox class="homepage" :items="items"><template v-slot="slotProps"><BlockTag :label="mockTags[slotProps.selectionIndex]" /></template></ flexible-media-gallery-new-lightbox>',
+    template: '<flexible-media-gallery-new-lightbox class="homepage" :items="items" :inline=true><template v-slot="slotProps"><BlockTag :label="mockTags[slotProps.selectionIndex]" /></template></ flexible-media-gallery-new-lightbox>',
   }
 }

--- a/src/stories/MediaGallery_ThumbnailCard.stories.js
+++ b/src/stories/MediaGallery_ThumbnailCard.stories.js
@@ -1,4 +1,4 @@
-// Import mock api data
+import { computed } from 'vue'
 import * as API from '@/stories/mock/Media'
 import FlexibleMediaGalleryThumbnailCard from '@/lib-components/Flexible/MediaGallery/ThumbnailCard.vue'
 
@@ -9,6 +9,26 @@ export default {
 }
 
 const mock = API.Gallery.mediaGallery[0]
+
+const mockFTVA = {
+  id: '46452',
+  captionTitle: 'Preservation and Access Initiative, Free Screening for the General Public: Tom Reed’s “For Members Only”: Black Perspectives on Local L.A. TV',
+  captionText: 'I\'m baby meh bicycle rights activated charcoal cronut you probably haven\'t heard of them distillery flannel cliche woke. Raclette sustainable vape salvia direct trade hashtag street art.',
+  sortOrder: 2,
+  item: [{
+    id: '3156835',
+    src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/TomReed_MalcolmX.webp',
+    height: 1813,
+    width: 2560,
+    srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 2560w',
+    alt: 'Tom Reed hosting an episode exploring the teachings of Malcolm X',
+    focalPoint: [
+      0.5,
+      0.5
+    ],
+    kind: 'image',
+  }],
+}
 
 const mockFocalPoint = {
   id: '43141',
@@ -43,6 +63,27 @@ export function Default() {
     template: `
     <div style="max-width: 400px">
       <flexible-media-gallery-thumbnail-card v-bind=mock level=3 />
+    </div>
+  `,
+  }
+}
+
+export function FTVA() {
+  return {
+    data() {
+      return {
+        mock: mockFTVA,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { FlexibleMediaGalleryThumbnailCard },
+    template: `
+    <div style="max-width: 400px">
+      <flexible-media-gallery-thumbnail-card v-bind=mock />
     </div>
   `,
   }

--- a/src/stories/mock/FTVAMedia.js
+++ b/src/stories/mock/FTVAMedia.js
@@ -73,3 +73,19 @@ export const Gallery = {
     },
   ]
 }
+
+export const ImageFile = [{
+  dataId: '3266312',
+  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Recurrent-nova_0-1.jpg',
+  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 2560w',
+  height: 1946,
+  width: 2560,
+  title: 'Recurrent nova 0 1',
+  focalPoint: [
+    0.5,
+    0.5
+  ],
+  kind: 'image',
+  type: 'image/jpeg',
+  alt: null
+}]

--- a/src/stories/mock/FTVAMedia.js
+++ b/src/stories/mock/FTVAMedia.js
@@ -1,113 +1,75 @@
-const ImageFile1 = [
-  {
-    id: '46054',
-    src: 'https://static.library.ucla.edu/craftassetstest/images/pine-needles_2022-10-18-005212_jcjf.jpg',
-    srcset:
-      'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 2560w',
-    height: 1918,
-    width: 2560,
-    title: 'Pine needles',
-    focalPoint: [0.5, 0.5],
-    kind: 'image',
-    type: 'image/jpeg',
-    alt: 'image alt text',
-  },
-]
-
-const ImageFile2 = [{
-  id: '3156835',
-  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/TomReed_MalcolmX.webp',
-  height: 1813,
-  width: 2560,
-  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 2560w',
-  alt: 'Tom Reed hosting an episode exploring the teachings of Malcolm X',
-  focalPoint: [
-    0.5,
-    0.5
-  ],
-  kind: 'image',
-  type: 'image/jpeg',
-}]
-
-const ImageFile3 = [{
-  dataId: '3201291',
-  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg',
-  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 2560w',
-  height: 1075,
-  width: 2560,
-  title: 'Michael Snow Walking Woman city resize crop 1000 420 90 c1',
-  focalPoint: [
-    0.5,
-    0.5
-  ],
-  kind: 'image',
-  type: 'image/jpeg',
-  alt: null
-}]
-
-const ImageFile4 = [{
-  dataId: '3264676',
-  src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/T-Coronae-Borealis-nova.jpg',
-  srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 2560w',
-  height: 1075,
-  width: 2560,
-  title: 'Michael Snow Walking Woman city resize crop 1000 420 90 c1',
-  focalPoint: [
-    0.5,
-    0.5
-  ],
-  kind: 'image',
-  type: 'image/jpeg',
-  alt: null
-}]
-
 export const Gallery = {
-  id: '46450',
   typeHandle: 'mediaGallery',
-  sectionTitle: 'Pine Needles are Awesome',
-  richTextSimplified: null,
-  mediaGalleryStyle: 'fullWidth',
+  dataId: '3266536',
+  sectionTitle: 'Once every 80 years',
+  sectionSummary: '<p><em>If predictions are correct, a key outburst star could put on a show in early 2024.</em></p>',
   mediaGallery: [
+    {
+      dataId: '3266537',
+      captionTitle: 'Recurrent Nova',
+      captionText: 'If predictions are correct, a key outburst star could put on a show in early 2024.',
+      sortOrder: 1,
+      item: [
+        {
+          dataId: '3266312',
+          src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Recurrent-nova_0-1.jpg',
+          srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Recurrent-nova_0-1.jpg 2560w',
+          height: 1946,
+          width: 2560,
+          title: 'Recurrent nova 0 1',
+          focalPoint: [
+            0.5,
+            0.5
+          ],
+          kind: 'image',
+          type: 'image/jpeg',
+          alt: null
+        }
+      ]
+    },
     {
       id: '46451',
       captionTitle: 'Cat Ipsum: Just saw other new cats inside the house snacking and playing nobody asked before using my litter box so mad meow kittycat',
-      captionText: 'Chase dog then run away sleep on keyboard kitty run to human with blood on mouth from frenzied attack on poor innocent mouse, don\'t i look cute?',
-      sortOrder: 1,
-      item: ImageFile1,
-      coverImage: ImageFile1,
-      credit: 'photo by someone',
-      linkUrl: null,
-      linkText: null,
-    },
-    {
-      id: '46452',
-      captionTitle: 'Tom Reed’s “For Members Only”: Black Perspectives on Local L.A. TV',
-      captionText: 'I\'m baby meh bicycle rights activated charcoal cronut you probably haven\'t heard of them distillery flannel cliche woke. Raclette sustainable vape salvia direct trade hashtag street art.',
-      credit: null,
+      captionText: 'Cat ipsum dolor sit amet, the cat was chasing the mouse. What the heck just happened, something feels fishy going to catch the red dot today going to catch the red dot today yet disappear for four days and return home with an expensive injury.',
       sortOrder: 2,
-      item: ImageFile2,
-      coverImage: ImageFile2,
-      embedCode: null,
-      linkUrl: null,
-      linkText: null,
+      item: [
+        {
+          id: '46054',
+          src: 'https://static.library.ucla.edu/craftassetstest/images/pine-needles_2022-10-18-005212_jcjf.jpg',
+          srcset:
+      'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 2560w',
+          height: 1918,
+          width: 2560,
+          title: 'Pine needles',
+          focalPoint: [0.5, 0.5],
+          kind: 'image',
+          type: 'image/jpeg',
+          alt: 'image alt text',
+        }
+      ],
     },
     {
-      id: '46453',
-      captionTitle: 'Walking Woman',
-      captionText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation',
+      dataId: '3266538',
+      captionTitle: null,
+      captionText: 'This finder chart covers about as much sky as the field of view in a typical pair of 7-power binoculars',
       sortOrder: 3,
-      item: ImageFile3,
-      coverImage: ImageFile3,
-      embedCode: null,
+      item: [
+        {
+          dataId: '3266330',
+          src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/T-CrB-finder-ST-larger.jpg',
+          srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/T-CrB-finder-ST-larger.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/T-CrB-finder-ST-larger.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/T-CrB-finder-ST-larger.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/T-CrB-finder-ST-larger.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/T-CrB-finder-ST-larger.jpg 2560w',
+          height: 2301,
+          width: 2560,
+          title: 'T Cr B finder ST larger',
+          focalPoint: [
+            0.5,
+            0.5
+          ],
+          kind: 'image',
+          type: 'image/jpeg',
+          alt: null
+        }
+      ]
     },
-    {
-      id: '46576',
-      captionTitle: 'Coronae Borealis Nova',
-      captionText: 'Doggo ipsum very good spot waggy wags thicc heckin angery woofer, ur givin me a spook borking doggo. Wow very biscit very jealous pupper heckin angery woofer sub woofer pupper, snoot noodle horse fat boi.',
-      sortOrder: 4,
-      item: ImageFile4,
-      coverImage: ImageFile4,
-      embedCode: null,
-    },
-  ],
+  ]
 }

--- a/src/stories/mock/FTVAMedia.js
+++ b/src/stories/mock/FTVAMedia.js
@@ -1,0 +1,113 @@
+const ImageFile1 = [
+  {
+    id: '46054',
+    src: 'https://static.library.ucla.edu/craftassetstest/images/pine-needles_2022-10-18-005212_jcjf.jpg',
+    srcset:
+      'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 2560w',
+    height: 1918,
+    width: 2560,
+    title: 'Pine needles',
+    focalPoint: [0.5, 0.5],
+    kind: 'image',
+    type: 'image/jpeg',
+    alt: 'image alt text',
+  },
+]
+
+const ImageFile2 = [{
+  id: '3156835',
+  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/TomReed_MalcolmX.webp',
+  height: 1813,
+  width: 2560,
+  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 2560w',
+  alt: 'Tom Reed hosting an episode exploring the teachings of Malcolm X',
+  focalPoint: [
+    0.5,
+    0.5
+  ],
+  kind: 'image',
+  type: 'image/jpeg',
+}]
+
+const ImageFile3 = [{
+  dataId: '3201291',
+  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg',
+  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Michael-Snow-Walking-Woman-city-resize-crop_1000_420_90_c1.jpg 2560w',
+  height: 1075,
+  width: 2560,
+  title: 'Michael Snow Walking Woman city resize crop 1000 420 90 c1',
+  focalPoint: [
+    0.5,
+    0.5
+  ],
+  kind: 'image',
+  type: 'image/jpeg',
+  alt: null
+}]
+
+const ImageFile4 = [{
+  dataId: '3264676',
+  src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/T-Coronae-Borealis-nova.jpg',
+  srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/T-Coronae-Borealis-nova.jpg 2560w',
+  height: 1075,
+  width: 2560,
+  title: 'Michael Snow Walking Woman city resize crop 1000 420 90 c1',
+  focalPoint: [
+    0.5,
+    0.5
+  ],
+  kind: 'image',
+  type: 'image/jpeg',
+  alt: null
+}]
+
+export const Gallery = {
+  id: '46450',
+  typeHandle: 'mediaGallery',
+  sectionTitle: 'Pine Needles are Awesome',
+  richTextSimplified: null,
+  mediaGalleryStyle: 'fullWidth',
+  mediaGallery: [
+    {
+      id: '46451',
+      captionTitle: 'Cat Ipsum: Just saw other new cats inside the house snacking and playing nobody asked before using my litter box so mad meow kittycat',
+      captionText: 'Chase dog then run away sleep on keyboard kitty run to human with blood on mouth from frenzied attack on poor innocent mouse, don\'t i look cute?',
+      sortOrder: 1,
+      item: ImageFile1,
+      coverImage: ImageFile1,
+      credit: 'photo by someone',
+      linkUrl: null,
+      linkText: null,
+    },
+    {
+      id: '46452',
+      captionTitle: 'Tom Reed’s “For Members Only”: Black Perspectives on Local L.A. TV',
+      captionText: 'I\'m baby meh bicycle rights activated charcoal cronut you probably haven\'t heard of them distillery flannel cliche woke. Raclette sustainable vape salvia direct trade hashtag street art.',
+      credit: null,
+      sortOrder: 2,
+      item: ImageFile2,
+      coverImage: ImageFile2,
+      embedCode: null,
+      linkUrl: null,
+      linkText: null,
+    },
+    {
+      id: '46453',
+      captionTitle: 'Walking Woman',
+      captionText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation',
+      sortOrder: 3,
+      item: ImageFile3,
+      coverImage: ImageFile3,
+      embedCode: null,
+    },
+    {
+      id: '46576',
+      captionTitle: 'Coronae Borealis Nova',
+      captionText: 'Doggo ipsum very good spot waggy wags thicc heckin angery woofer, ur givin me a spook borking doggo. Wow very biscit very jealous pupper heckin angery woofer sub woofer pupper, snoot noodle horse fat boi.',
+      sortOrder: 4,
+      item: ImageFile4,
+      coverImage: ImageFile4,
+      embedCode: null,
+    },
+  ],
+}

--- a/src/styles/default/_media-badge.scss
+++ b/src/styles/default/_media-badge.scss
@@ -1,0 +1,86 @@
+.media-badge {
+  --badge-width: 264px;
+  --badge-height: 64px;
+  --accent-slope: 2.35;
+  --background-color: var(--color-theme, var(--color-white));
+  --accent-color: var(--color-visit-fushia-03);
+
+  position: absolute;
+  width: var(--badge-width);
+  height: var(--badge-height);
+  right: -1px;
+  bottom: -1px;
+  cursor: pointer;
+
+  .badge-content {
+      @include button;
+
+      width: 100%;
+      height: 100%;
+
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+
+      --color: var(--color-primary-blue-03);
+      color: var(--color);
+      stroke: var(--color);
+      background-color: var(--background-color);
+
+      --diagonal-width: calc(var(--badge-height) / var(--accent-slope));
+      -webkit-clip-path: polygon(
+          0% 100%,
+          var(--diagonal-width) 0%,
+          100% 0%,
+          100% 100%,
+          0% 100%
+      );
+              clip-path: polygon(
+          0% 100%,
+          var(--diagonal-width) 0%,
+          100% 0%,
+          100% 100%,
+          0% 100%
+      );
+  }
+
+  .floating-highlight {
+      position: absolute;
+      width: var(--badge-width);
+      height: var(--badge-height);
+      top: -6px;
+      left: -8px;
+
+      background: var(--accent-color);
+
+      --diagonal-width: calc(var(--badge-height) / var(--accent-slope));
+      -webkit-clip-path: polygon(
+          0% 100%,
+          0% calc(100% - 1.5px),
+          var(--diagonal-width) 0%,
+          100% 0%,
+          100% 1.5px,
+          calc(var(--diagonal-width) + 1px) 1.5px,
+          1px 100%
+      );
+              clip-path: polygon(
+          0% 100%,
+          0% calc(100% - 1.5px),
+          var(--diagonal-width) 0%,
+          100% 0%,
+          100% 1.5px,
+          calc(var(--diagonal-width) + 1px) 1.5px,
+          1px 100%
+      );
+  }
+}
+
+// Breakpoints
+
+@media #{$small} {
+  .media-badge {
+      --badge-width: 212px;
+      --badge-height: 44px;
+  }
+}

--- a/src/styles/default/_media-gallery-banner-image.scss
+++ b/src/styles/default/_media-gallery-banner-image.scss
@@ -1,0 +1,118 @@
+.banner-image {
+  // cursor: pointer;
+  .gradient {
+      display: none;
+      background: var(--gradient-radial);
+      background-size: cover;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      cursor: pointer;
+  }
+
+  .svg__molecule-image-stack {
+      --width: calc(min(128px, 30%));
+      width: var(--width);
+      height: var(--width);
+      position: absolute;
+      left: calc(50% - var(--width) / 2);
+      top: calc((50% - var(--width) / 2) - 16px);
+
+      .svg__fill--primary-blue-03 {
+          fill: var(--color-primary-blue-03);
+      }
+  }
+
+  .glyph-expand {
+      display: inline-block;
+      width: 24px;
+      height: 24px;
+      margin-left: 8px;
+
+      border-radius: 12px;
+      background: #ffffff;
+  }
+}
+
+.half-width-media-item {
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-xl);
+
+  .media-item {
+      width: calc((100% - 16px) / 2);
+      cursor: pointer;
+  }
+
+  .text-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      max-width: calc((100% - 16px) / 2);
+
+      .title {
+          @include step-3;
+          color: var(--color-primary-blue-03);
+          margin-bottom: var(--space-l);
+          text-align: left;
+          width: 100%;
+      }
+      .summary {
+          @include step-0;
+          align-items: center;
+          text-align: left;
+          width: 100%;
+      }
+      .rich-text {
+          padding-right: 0;
+          :deep(p:not(:last-child)) {
+              margin-bottom: var(--space-m);
+          }
+      }
+  }
+
+  // Breakpoints
+  @media #{$medium} {
+      flex-direction: row;
+      gap: var(--space-xl);
+      .media-item {
+          width: calc((100% - 16px) / 2);
+          cursor: pointer;
+      }
+      .text-wrapper {
+          width: calc((100% - 16px) / 2);
+      }
+  }
+
+  @media #{$small} {
+      flex-direction: column;
+      flex-wrap: wrap;
+      .media-item {
+          width: 100%;
+      }
+      .text-wrapper {
+          min-width: 100%;
+          display: flex;
+          flex-direction: column;
+          margin-bottom: 15px;
+      }
+  }
+}
+
+// Hovers
+@media #{$has-hover} {
+  .media-item:hover {
+      .gradient {
+          display: block;
+      }
+
+      .svg__molecule-image-stack {
+          .svg__fill--primary-blue-03 {
+              fill: var(--color-primary-blue-05);
+          }
+      }
+  }
+}

--- a/src/styles/default/_media-gallery-thumbnail-card.scss
+++ b/src/styles/default/_media-gallery-thumbnail-card.scss
@@ -1,0 +1,32 @@
+.thumbnail-card {
+  width: 100%;
+
+  .image {
+      margin-bottom: var(--space-s);
+  }
+
+  .caption-title {
+      @include step-1;
+      color: #{$black};
+      margin-bottom: var(--space-xs);
+  }
+
+  .caption-text {
+      @include step-0;
+      color: #{$secondary-grey-05};
+      @include truncate($lines: 4);
+  }
+
+  .caption-link {
+      @include button;
+      margin-top: 10px;
+      padding: 0;
+
+      // /* identical to box height, or 22px */
+      display: flex;
+      align-items: center;
+
+      // /* primary/blue-03 */
+      color: $primary-blue-03;
+  }
+}

--- a/src/styles/default/_media-gallery.scss
+++ b/src/styles/default/_media-gallery.scss
@@ -1,0 +1,14 @@
+.media-gallery {
+  background-color: var(--color-theme, var(--color-white));
+
+  .thumbnails {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(292px, 1fr));
+    -moz-column-gap: var(--space-m);
+         column-gap: var(--space-m);
+    row-gap: var(--space-xl);
+    padding-top: var(--space-xl);
+    list-style-type: none;
+  }
+}

--- a/src/styles/ftva/_media-badge.scss
+++ b/src/styles/ftva/_media-badge.scss
@@ -1,0 +1,14 @@
+.ftva.media-badge {
+
+  position: relative;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+
+  .badge-content {
+              -webkit-clip-path: unset;
+                      clip-path: unset;
+      ;
+  }
+
+}

--- a/src/styles/ftva/_media-badge.scss
+++ b/src/styles/ftva/_media-badge.scss
@@ -1,14 +1,16 @@
 .ftva.media-badge {
-
   position: relative;
   right: 0;
   bottom: 0;
   z-index: 1;
 
   .badge-content {
-              -webkit-clip-path: unset;
-                      clip-path: unset;
-      ;
+    justify-content: flex-end;
+    padding-right: 24px;
+    -webkit-clip-path: unset;
+            clip-path: unset;
+  text-transform: uppercase;
+  color: $subtitle-grey;
   }
 
 }

--- a/src/styles/ftva/_media-badge.scss
+++ b/src/styles/ftva/_media-badge.scss
@@ -1,5 +1,6 @@
 .ftva.media-badge {
   position: relative;
+  // 
   right: 0;
   bottom: 0;
   z-index: 1;
@@ -22,5 +23,12 @@
         -webkit-text-decoration-color: #{$bright-blue};
         text-decoration-color: #{$bright-blue};
     }
+  }
+
+  // Breakpoints
+
+  @media #{$small} {
+    // position: absolute;
+    --badge-width: 250px;
   }
 }

--- a/src/styles/ftva/_media-badge.scss
+++ b/src/styles/ftva/_media-badge.scss
@@ -9,8 +9,18 @@
     padding-right: 24px;
     -webkit-clip-path: unset;
             clip-path: unset;
-  text-transform: uppercase;
-  color: $subtitle-grey;
-  }
+    @include ftva-button-link;
+    color: $subtitle-grey;
+    text-transform: uppercase;
+    text-decoration: underline;
+    text-decoration-thickness: 3px;
+    -webkit-text-decoration-color: #{$grey-blue};
+    text-decoration-color: #{$grey-blue};
+    text-underline-offset: 4px;
 
+    &:hover {
+        -webkit-text-decoration-color: #{$bright-blue};
+        text-decoration-color: #{$bright-blue};
+    }
+  }
 }

--- a/src/styles/ftva/_media-gallery-banner-image.scss
+++ b/src/styles/ftva/_media-gallery-banner-image.scss
@@ -5,12 +5,13 @@
   }
 
   .drop-triangle {
+    position: relative;
     margin-left: 8px;
+    bottom: 1px;
   }
 
-  .expanded .drop-triangle {
+  .is-expanded.drop-triangle {
     transform: rotate(180deg);
-    position: relative;
   }
 }
 

--- a/src/styles/ftva/_media-gallery-banner-image.scss
+++ b/src/styles/ftva/_media-gallery-banner-image.scss
@@ -1,11 +1,30 @@
 .ftva.banner-image {
-  .svg__molecule-image-stack {
+
+  .ftva-image-stack-bckgrd {
     --width: calc(min(80px, 30%));
     width: var(--width);
     height: var(--width);
+    background-color: $accent-blue;
+    position: absolute;
+    left: calc(50% - var(--width) / 2);
+    top: calc(50% - var(--width) / 2);
+    border-radius: 50%;
+  }
 
-    :deep(.svg__fill--primary-blue-03) {
-        fill: $accent-blue;
+  .svg__icon-image-stack {
+    --width: calc(min(48px, 100%));
+    width: var(--width);
+    height: var(--width);
+    position: absolute;
+    left: calc(50% - var(--width) / 2);
+    top: calc(50% - var(--width) / 2);
+
+    :deep(.svg__stroke--primary-blue-03) {
+      stroke: $white;
+    }
+
+    :deep(.svg__stroke--default-cyan-03) {
+      display: none;
     }
   }
 

--- a/src/styles/ftva/_media-gallery-banner-image.scss
+++ b/src/styles/ftva/_media-gallery-banner-image.scss
@@ -1,5 +1,4 @@
 .ftva.banner-image {
-  
   .svg__molecule-image-stack {
     --width: calc(min(80px, 30%));
     width: var(--width);
@@ -8,7 +7,7 @@
     :deep(.svg__fill--primary-blue-03) {
         fill: $accent-blue;
     }
-}
+  }
 
   .media-badge {
     float: right;
@@ -30,4 +29,10 @@
   content: "";
   clear: both;
   display: table;
+}
+
+.ftva.half-width-media-item {
+  .media-badge {
+    position: absolute;
+  }
 }

--- a/src/styles/ftva/_media-gallery-banner-image.scss
+++ b/src/styles/ftva/_media-gallery-banner-image.scss
@@ -1,0 +1,22 @@
+.ftva.banner-image {
+  
+  .media-badge {
+    float: right;
+  }
+
+  .drop-triangle {
+    margin-left: 8px;
+  }
+
+  .expanded .drop-triangle {
+    transform: rotate(180deg);
+    position: relative;
+  }
+}
+
+// To clear floated MediaBadge
+.ftva.banner-image::after {
+  content: "";
+  clear: both;
+  display: table;
+}

--- a/src/styles/ftva/_media-gallery-banner-image.scss
+++ b/src/styles/ftva/_media-gallery-banner-image.scss
@@ -1,5 +1,15 @@
 .ftva.banner-image {
   
+  .svg__molecule-image-stack {
+    --width: calc(min(80px, 30%));
+    width: var(--width);
+    height: var(--width);
+
+    :deep(.svg__fill--primary-blue-03) {
+        fill: $accent-blue;
+    }
+}
+
   .media-badge {
     float: right;
   }

--- a/src/styles/ftva/_media-gallery-thumbnail-card.scss
+++ b/src/styles/ftva/_media-gallery-thumbnail-card.scss
@@ -1,0 +1,15 @@
+.ftva.thumbnail-card {
+
+  .caption-title {
+    @include truncate($lines: 3);
+    @include ftva-card-title-2;
+    color: $heading-grey;
+      margin-bottom: var(--space-s);
+  }
+
+  .caption-text {
+    @include truncate($lines: 2);
+    @include ftva-body-2;
+    color: $subtitle-grey;
+  }
+}

--- a/src/styles/ftva/_media-gallery.scss
+++ b/src/styles/ftva/_media-gallery.scss
@@ -1,0 +1,35 @@
+.ftva.media-gallery {
+
+  .gallery-header {
+    margin-bottom: 20px;
+  }
+
+  .gallery-title {
+    @include ftva-h5;
+    color: $accent-blue;
+    margin-bottom: 12px;
+  }
+
+  .selected-image-title {
+    @include ftva-subtitle-1;
+    color: $heading-grey;
+    margin-bottom: 4px;
+  }
+
+
+  .selected-image-caption {
+    @include ftva-body-2;
+    color: $subtitle-grey;
+  }
+
+  .thumbnails {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(292px, 1fr));
+    -moz-column-gap: var(--space-m);
+         column-gap: var(--space-m);
+    row-gap: var(--space-xl);
+    padding-top: var(--space-xl);
+    list-style-type: none;
+  }
+}

--- a/src/styles/ftva/_new-lightbox.scss
+++ b/src/styles/ftva/_new-lightbox.scss
@@ -1,123 +1,158 @@
 .ftva.lightbox {
-    // does not act like a lightbox, displays inline
-    position: relative;
-    z-index: auto;
-    grid-template-columns: [col] var(--media-width);
-    grid-gap: 0px;
 
-    .media-container {
-        grid-column: col 1 / span 3;
-        // todo make these styles a mixin?
-        .credit-text {
-            display: inline-block;
-            position: absolute;
-            font-family: var(--font-secondary);
-            bottom: 0;
-            right: 0;
-            color: var(--color-white);
-            font-size: 16px;
-            max-width: 100%;
-            overflow: hidden;
-            text-overflow: ellipsis;
-    
-            span {
-                background-color: rgba(0, 0, 0, 0.64);
-                padding: 4px 23px 4px 18px;
-                // enforce 1 line, 50 char limit
-                height: 32px;
-                max-width: 385px;
-                white-space: pre;
-            }
-        }
+  background: $navy-blue;
+
+  .button-prev, .button-next {
+    top: 50%;
+    transform: translateY(-50%);
+    width: 43px;
+    background-color: $navy-blue;
+    border: 1px solid $grey-blue;
+    border-radius: 8px;
+    padding: 2px 0px;
+  
+    :deep(.svg__fill--primary-blue-03) {
+      fill: $grey-blue;
     }
+  
+    :deep(.svg__stroke--primary-blue-03) {
+      stroke: $grey-blue;
+    }
+  }
 
-    .caption-block {
-      position: absolute;
+  .button-prev {
+    svg {
+      margin-left: -4px;  
+    }
+  }
+  
+  .button-next {
+    svg {
+      margin-left: -2px;
+    }
+  }
+} 
+
+ // Does not act like a Lightbox (overlaid); displays inline
+.ftva.inline.lightbox {      
+  position: relative;
+  z-index: auto;
+  grid-template-columns: [col] var(--media-width);
+  grid-gap: 0px;
+
+  .media-container {
+      grid-column: col 1 / span 3;
+      // todo make these styles a mixin?
+      .credit-text {
+          display: inline-block;
+          position: absolute;
+          font-family: var(--font-secondary);
+          bottom: 0;
+          right: 0;
+          color: var(--color-white);
+          font-size: 16px;
+          max-width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+  
+          span {
+              background-color: rgba(0, 0, 0, 0.64);
+              padding: 4px 23px 4px 18px;
+              // enforce 1 line, 50 char limit
+              height: 32px;
+              max-width: 385px;
+              white-space: pre;
+          }
+      }
+  }
+
+  .caption-block {
+    position: absolute;
+    // unset grid positioning from default theme
+    grid-row: unset;
+    grid-column: unset;
+
+    bottom: 0px;
+    left: 50%;
+    transform: translateX(-50%);
+    .media-counter {
+      background-color: $heading-grey;
+      border-radius: 20px;
+      padding: 0px 15px;
+      .media-counter-item {
+        padding: 1px;
+        margin: 0 -5px;
+        svg {
+          height: 22px;
+          width: 27px;
+        }
+      }
+    }
+  }
+
+    // hide captions beneath images and close button
+    .caption-content, .button-close {
+      display: none;
+    } 
+    .button-prev, .button-next {
+      top: 50%;
+      transform: translateY(-50%);
+      width: 43px;
+
+      background-color: $navy-blue;
+      border: 1px solid $grey-blue;
+      border-radius: 8px;
+      padding: 2px 0px;
       // unset grid positioning from default theme
       grid-row: unset;
       grid-column: unset;
-
-      bottom: 0px;
-      left: 50%;
-      transform: translateX(-50%);
-      .media-counter {
-        background-color: $heading-grey;
-        border-radius: 20px;
-        padding: 0px 15px;
-        .media-counter-item {
-          padding: 1px;
-          margin: 0 -5px;
-          svg {
-            height: 22px;
-            width: 27px;
-          }
-        }
+      justify-self: auto;
+      :deep(.svg__fill--primary-blue-03) {
+        fill: $grey-blue;
+      }
+      :deep(.svg__stroke--primary-blue-03) {
+        stroke: $grey-blue;
+      }
+    }
+    .button-prev {
+      left: 30px;
+      svg {
+        margin-left: -4px;  
+      }
+    }
+    .button-next {
+      right: 35px;
+      svg {
+        margin-left: -2px;
       }
     }
 
-      // hide captions beneath images and close button
-      .caption-content, .button-close {
-        display: none;
-      } 
-      .button-prev, .button-next {
-        top: 50%;
-        transform: translateY(-50%);
-        width: 43px;
+  // Homepage Lightbox Theme
+    &.homepage {
+      .caption-block {
+            display: flex;
+            flex-direction: column-reverse;
+            align-items: center;
+  
+            div.media-counter {
+                display: inline-flex;
+            }
+            div.caption-content {
+                display: block;
+            }
+      }
 
-        background-color: $navy-blue;
-        border: 1px solid $grey-blue;
-        border-radius: 8px;
-        padding: 2px 0px;
-        // unset grid positioning from default theme
-        grid-row: unset;
-        grid-column: unset;
-        justify-self: auto;
-        :deep(.svg__fill--primary-blue-03) {
-          fill: $grey-blue;
-        }
-        :deep(.svg__stroke--primary-blue-03) {
-          stroke: $grey-blue;
+  
+      .media-container {
+        .credit-text {
+          display: none;
         }
       }
-      .button-prev {
-        left: 30px;
-        svg {
-          margin-left: -4px;  
-        }
-      }
+      .button-prev,
       .button-next {
-        right: 35px;
-        svg {
-          margin-left: -2px;
-        }
+        bottom: 25px;
+        top: unset;
+        transform: unset;
       }
-
-    // Homepage Lightbox Theme
-      &.homepage {
-        .caption-block {
-              display: flex;
-              flex-direction: column-reverse;
-              align-items: center;
-    
-              div.media-counter {
-                  display: inline-flex;
-              }
-              div.caption-content {
-                  display: block;
-              }
-        }
-
-    
-        .media-container {
-          .credit-text {
-            display: none;
-          }
-        }
-        .button-prev,
-        .button-next {
-          bottom: 25px;
-          top: unset;
-          transform: unset;
-        }
-     }
-    } 
+   }
+  } 


### PR DESCRIPTION
Connected to [APPS-2959](https://jira.library.ucla.edu/browse/APPS-2959)

**Components Updated:**
- MediaBadge.vue
- ~/Flexible/MediaGallery.vue
- ~/Flexible/MediaGallery/BannerImage.vue
- ~/Flexible/MediaGallery/NewLightbox.vue
- ~/Flexible/MediaGallery/ThumbnailCard.vue


**Stories:**
- ~/stories/MediaBadge.stories.js
- ~/stories/MediaGallery_BannerImage.stories.js
- ~/stories/MediaGallery_NewLightbox.stories.js
- ~/stories/MediaGallery_ThumbnailCard.stories.js
- ~/stories/Flexible_MediaGallery.stories.js

<br>

**Notes:**
- Updated multiple components that comprise the FlexibleMediaGallery with FTVA variants
- Added new prop `inline` to be used to set the Lightbox component to display as an inline component, preserving the default overlay behavior when needed
  - Any FTVA template currently using the Lightbox component inline should be updated with the prop 
  - Related: https://uclalibrary.atlassian.net/browse/APPS-2998
- Moved and updated CSS files
- Although not specified explicitly in the ticket or the design comps, I included a `halfWidth` gallery option/story for FTVA
  - If the gallery might be used on the FTVA site, it can be updated later with confirmed/theme specs

<br>

**StoryBook Previews:**
- MediaBadge
  - https://deploy-preview-626--ucla-library-storybook.netlify.app/?path=/story/media-badge--ftva

- Media Gallery BannerImage
  - https://deploy-preview-626--ucla-library-storybook.netlify.app/?path=/story/media-gallery-banner-image--ftva

- Media Gallery ThumbnailCard
  - https://deploy-preview-626--ucla-library-storybook.netlify.app/?path=/story/media-gallery-thumbnail-card--ftva

- NewLightbox (Default)
  - https://deploy-preview-626--ucla-library-storybook.netlify.app/?path=/story/media-gallery-new-lightbox--ftva-default-lightbox
  - Using `inline` prop set to `true`:
    - https://deploy-preview-626--ucla-library-storybook.netlify.app/?path=/story/media-gallery-new-lightbox--ftva-event-detail-carousel

- FlexibleMediaGallery (FullWidth)
  - https://deploy-preview-626--ucla-library-storybook.netlify.app/?path=/story/flexible-media-gallery--ftva

- FlexibleMediaGallery (HalfWidth)
  - https://deploy-preview-626--ucla-library-storybook.netlify.app/?path=/story/flexible-media-gallery--ftva-half-width

<br>

**Local Nuxt Previews (with craft data):**
- Collapsed/Default
![media-gallery1](https://github.com/user-attachments/assets/59be1814-ef05-4b76-85a1-c9a4d98709a3)

- Expanded
![media-gallery2](https://github.com/user-attachments/assets/9c2e478d-e5c6-4c41-9718-913bd9b33242)

- Lightbox
![media-gallery3](https://github.com/user-attachments/assets/d478ac14-5a6f-4fa3-863c-80b03afce914)

<br>

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I have requested a PR review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2959]: https://uclalibrary.atlassian.net/browse/APPS-2959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ