### PR TITLE
chore: APPS-2992 move min height styles to sectionTeaserCard

### DIFF
--- a/src/styles/ftva/_section-teaser-card.scss
+++ b/src/styles/ftva/_section-teaser-card.scss
@@ -16,6 +16,7 @@
         flex-basis: calc((100% / 3) - 22px);
         min-width: 280px;
         margin-bottom: 15px;
+        min-height: 350px;
     }
 }
 


### PR DESCRIPTION
Connected to [APPS-2687](https://jira.library.ucla.edu/browse/APPS-2687)

**Notes:**

Quick ticket to add styles to component for ftva that are currently duplicated on every page.

Ticket specifies .is-vertical class but SectionTeaserCard is set to always use is-vertical so this seemed redundant to me, so I just added it to the scoped styles for card inside section-teaser-card

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-2687]: https://uclalibrary.atlassian.net/browse/APPS-2687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ