### PR TITLE
fix: APPS-2984 Share/Calendar button dropdown behavior

### DIFF
--- a/src/lib-components/ButtonDropdown.vue
+++ b/src/lib-components/ButtonDropdown.vue
@@ -166,7 +166,7 @@ function formatEndTime(str) {
 const theme = useTheme()
 
 const parsedClasses = computed(() => {
-  return ['button-dropdown', theme?.value || '']
+  return ['button-dropdown', theme?.value || '', { 'is-expanded': isDropdownExpanded.value }]
 })
 </script>
 

--- a/src/styles/default/_button-dropdown.scss
+++ b/src/styles/default/_button-dropdown.scss
@@ -11,7 +11,7 @@
         border-radius: 8px;
         border: 1px solid #{$primary-blue-03};
         font-weight: 500;
-        font-size: 18px; // Update to token value: $font-size-18
+        font-size: 18px;
         background-color: $white;
         color: #{$primary-blue-03};
 
@@ -73,7 +73,7 @@
         :deep(.icon-with-link) .text {
             font-family: "Karbon", Helvetica, Arial, sans-serif;
             font-weight: 500;
-            color: #555555; // Update to token value: $medium-gray
+            color: $medium-grey;
         }
 
         :deep(.icon-with-link) .link,
@@ -81,8 +81,8 @@
             text-decoration: underline;
             text-decoration-thickness: 3px;
             text-underline-offset: 6px;
-            -webkit-text-decoration-color: #abbfd6;
-            text-decoration-color: #abbfd6; // Update to token value: $grey-blue
+            -webkit-text-decoration-color: $grey-blue;
+                    text-decoration-color: $grey-blue;
         }
 
         :deep(.icon-with-link.not-smart-link) {
@@ -99,7 +99,7 @@
 
     @media #{$has-hover} {
         .button:hover {
-            background-color: #f1f1f1; // Update to token value
+            background-color: #f1f1f1;
         }
 
         .svg__icon-close.svg-glyph-close:hover {
@@ -108,8 +108,8 @@
 
         :deep(.icon-with-link) .link:hover,
         :deep(.icon-with-link.not-smart-link):hover .text {
-            -webkit-text-decoration-color: #2c91ff;
-            text-decoration-color: #2c91ff; // Update to token value: $bright-blue
+            -webkit-text-decoration-color: #{$bright-blue};
+                    text-decoration-color: #{$bright-blue};
         }
 
         :deep(.icon-with-link) {
@@ -189,8 +189,7 @@
 
         :deep(.icon-with-link.is-link-copied) {
             width: 85%;
-            background-color: #e7edf2; // Update to token value
-
+            background-color: $page-blue;
             .text {
                 top: 3px;
             }
@@ -198,7 +197,7 @@
 
         .dropdown-modal-item {
             :deep(.icon-with-link):active {
-                background-color: #faf5f4; // Update to token value
+                background-color: #faf5f4;
                 width: 85%;
             }
         }
@@ -213,7 +212,7 @@
         height: 51px;
         padding: 0;
         font-family: inherit;
-        font-size: 18px; // Update to token value: $font-size-18
+        font-size: 18px;
         font-weight: 500;
         line-height: inherit;
         padding: 12px 16px 12px 20px;
@@ -244,6 +243,7 @@
     }
 
     add-to-calendar-button::part(atcb-list-wrapper) {
+        background: $white;
         width: 274px;
         min-width: 0;
         min-height: auto;
@@ -273,18 +273,22 @@
         padding: 0;
         font-family: "Karbon", Helvetica, Arial, sans-serif;
         font-weight: 500;
-        font-size: 18px; // update
+        font-size: 18px; 
         line-height: inherit;
-        color: #555555; // Update to token value: $medium-gray
+        color: $medium-grey;
         text-decoration: underline;
         text-decoration-thickness: 3px;
         text-underline-offset: 6px;
-        -webkit-text-decoration-color: #abbfd6;
-        text-decoration-color: #abbfd6; // Update to token value: $grey-blue
+        -webkit-text-decoration-color: $grey-blue;
+                text-decoration-color: $grey-blue;
     }
 
     add-to-calendar-button::part(atcb-list-item):hover {
-        -webkit-text-decoration-color: #2c91ff;
-        text-decoration-color: #2c91ff; // Update to token value: $bright-blue
+        -webkit-text-decoration-color: #{$bright-blue};
+                text-decoration-color: #{$bright-blue};
     }
 }
+
+// .button-dropdown.is-expanded {
+//     position: absolute;
+// }

--- a/src/styles/default/_button-dropdown.scss
+++ b/src/styles/default/_button-dropdown.scss
@@ -57,6 +57,12 @@
         background-color: $white;
     }
 
+    .button-dropdown-modal-wrapper.is-expanded {
+        position: absolute;
+        width: auto;
+        margin: 0 4px;
+    }
+
     .dropdown-modal-item {
         :deep(.icon-with-link) {
             .icon-with-link-container {
@@ -178,6 +184,8 @@
 
         .button-dropdown-modal-wrapper.is-expanded {
             width: 100%;
+            position: static;
+            margin: 0;
         }
 
         .svg__icon-close.svg-glyph-close {
@@ -248,15 +256,15 @@
         min-width: 0;
         min-height: auto;
         padding: 20px 20px 24px 20px;
-        margin: 0 auto;
+        margin: 0 4px;
         border-width: 0 1px 1px 1px;
         border-style: solid;
         border-color: #{$primary-blue-03};
         border-bottom-left-radius: 8px;
         border-bottom-right-radius: 8px;
-        position: relative;
-        top: 0;
-        left: 0;
+        position: absolute;
+        top: unset;
+        left: unset;
     }
 
     add-to-calendar-button::part(atcb-list) {
@@ -288,7 +296,3 @@
                 text-decoration-color: #{$bright-blue};
     }
 }
-
-// .button-dropdown.is-expanded {
-//     position: absolute;
-// }

--- a/src/styles/ftva/_button-dropdown.scss
+++ b/src/styles/ftva/_button-dropdown.scss
@@ -1,7 +1,7 @@
 .ftva.button-dropdown {
     .button {
-        border-color: #555555; // Update to: $medium-grey
-        color: #555555; // Update to: $medium-grey
+        border-color: $medium-grey;
+        color: $medium-grey;
 
         .button-svg {
             stroke: unset;
@@ -10,7 +10,7 @@
 
     .toggle-triangle-icon {
         :deep(.svg__fill--accent-blue) {
-            fill: #555555; // Update to: $medium-grey
+            fill: $medium-grey;
         }
     }
 
@@ -18,6 +18,6 @@
         border-left-width: 1px;
         border-right-width: 1px;
         border-bottom-width: 1px;
-        border-color: #555555; // Update to: $medium-grey
+        border-color: $medium-grey;
     }
 }


### PR DESCRIPTION
Connected to [APPS-2984](https://jira.library.ucla.edu/browse/APPS-)

**Component Updated:** ButtonDropdown.vue

**Notes:**
- Update component to make button drop down over content rather than shift content downwards


**Storybook Previews:**
- Calendar button
  - https://deploy-preview-631--ucla-library-storybook.netlify.app/?path=/story/layout-2-column-layout-with-sticky-sidebar--ftva-event-detail
- Share button
  - https://deploy-preview-631--ucla-library-storybook.netlify.app/?path=/story/layout-2-column-layout-with-sticky-sidebar--ftva-blog-detail

<br>

**Local Nuxt Previews:**

- *Calendar Dropdown*
![calendar-overlay](https://github.com/user-attachments/assets/880ad658-d665-4c5b-82a8-2bd2d9580d59)

- *Share Dropdown*

![share-overlay](https://github.com/user-attachments/assets/b7cfbad3-0ee7-41f3-8196-588909e17a04)

<br>

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [x] I requested a PR review from the dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR

[APPS-2984]: https://uclalibrary.atlassian.net/browse/APPS-2984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ