### PR TITLE
fix: add relative position to anchor link on card

### DIFF
--- a/src/lib-components/BlockCardThreeColumn.vue
+++ b/src/lib-components/BlockCardThreeColumn.vue
@@ -159,20 +159,11 @@ const parsedDateFormat = computed(() => {
   display: flex;
   flex-direction: row;
   align-items: stretch;
+  position: relative;
 
   font-family: var(--font-primary);
   $large-width: 284px;
   $large-height: 213px;
-
-  li {
-    list-style: none;
-    list-style-position: outside;
-    @include card-clickable-area;
-
-    &:hover {
-      cursor: pointer;
-    }
-  }
 
   .day-month-date {
     display: flex;


### PR DESCRIPTION
Connected to [APPS-3001](https://jira.library.ucla.edu/browse/APPS-3001)

**Notes:**

We add position:relative to force the link element onto the card it belongs to, instead of it floating on top of the top card in the list!

Also removed some extra li styles as directed in the ticket 

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-3001]: https://uclalibrary.atlassian.net/browse/APPS-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ