### PR TITLE
fix: APPS-2969 Add hover state to FTVA card-horizontal titles

### DIFF
--- a/src/lib-components/BlockCardThreeColumn.vue
+++ b/src/lib-components/BlockCardThreeColumn.vue
@@ -258,7 +258,8 @@ const parsedDateFormat = computed(() => {
       }
 
       &:hover>a.title {
-        text-decoration: none;
+        text-decoration-thickness: 3px;
+        text-underline-offset: 4px;
       }
     }
 

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -32,6 +32,10 @@
             margin-bottom: 10px;
         }
 
+        &:hover>a.title {
+            text-decoration: none;
+        }
+
         .byline-group {
             position: absolute;
             bottom: var(--space-s);

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -32,10 +32,6 @@
             margin-bottom: 10px;
         }
 
-        &:hover>a.title {
-            text-decoration: none;
-        }
-
         .byline-group {
             position: absolute;
             bottom: var(--space-s);
@@ -83,20 +79,6 @@
                 right: -30px;
                 top: -2px;
                 margin: 0px 10px;
-            }
-        }
-    }
-
-    // take the hover style off of the title
-    @media #{$has-hover} {
-        &:hover {
-            .title {
-                color: none;
-                text-decoration: none;
-                text-decoration-thickness: none;
-                -webkit-text-decoration-color: none;
-                        text-decoration-color: none;
-                text-underline-offset: none;
             }
         }
     }

--- a/src/styles/ftva/_rich-text.scss
+++ b/src/styles/ftva/_rich-text.scss
@@ -26,12 +26,14 @@
 
   :deep(a) {
     color: $body-grey;
-    text-decoration-color: $grey-blue;
+    -webkit-text-decoration-color: $grey-blue;
+            text-decoration-color: $grey-blue;
     text-decoration-thickness: 3px;
     text-underline-offset: 4px;
 
     &:hover {
-      text-decoration-color: $accent-blue;
+      -webkit-text-decoration-color: $bright-blue;
+              text-decoration-color: $bright-blue;
     }
   }
 
@@ -98,7 +100,8 @@
     background-size: cover;
     background-position: left;
     padding: .15rem;
-    filter: invert(98%) sepia(131%) saturate(1029%) hue-rotate(196deg) brightness(130%) contrast(68%);
+    -webkit-filter: invert(98%) sepia(131%) saturate(1029%) hue-rotate(196deg) brightness(130%) contrast(68%);
+            filter: invert(98%) sepia(131%) saturate(1029%) hue-rotate(196deg) brightness(130%) contrast(68%);
   }
 
   :deep(table) {


### PR DESCRIPTION
Connected to [APPS-2969](https://jira.library.ucla.edu/browse/APPS-2969)

**Components Updated:** 
- BlockCardThreeColumn.vue
- BlockCardWithImage.vue
- RichText.vue

**Notes:**
- updated CSS to add hover state to FTVA horizontal cards in BlockCardThreeColumn
- updated hover color for FTVA RichText to `$bright-blue` per UX (re [Slack thread](https://uclalibrary.slack.com/archives/C014BPS0YBX/p1729101841687409))
- removed redundant style rule in FTVA BlockCardWithImage

**Previews:**
- https://deploy-preview-633--ucla-library-storybook.netlify.app/?path=/story/global-rich-text--ftva-rich-text
- https://deploy-preview-633--ucla-library-storybook.netlify.app/?path=/story/section-teaser-list--dynamic-component

**Checklist:**
-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   ~~[ ] I checked that it is working locally in the library-website-nuxt dev server~~
-   ~~[ ] I added a screenshot of it working~~
-   [x] UX has reviewed and approved this
-   [x] I have requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2969]: https://uclalibrary.atlassian.net/browse/APPS-2969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ