### PR TITLE
fix: APPS-3007 Use RichText comp in BlockCTA comp

### DIFF
--- a/src/lib-components/BlockCallToAction.vue
+++ b/src/lib-components/BlockCallToAction.vue
@@ -72,6 +72,10 @@ const SvgCallToActionMoney = defineAsyncComponent(() =>
   import('ucla-library-design-tokens/assets/svgs/call-to-action-money.svg')
 )
 
+const SvgCallToActionFTVAExternalLinkDark = defineAsyncComponent(() =>
+  import('ucla-library-design-tokens/assets/svgs/icon-ftva-external-link-dark.svg')
+)
+
 const SvgCallToActionFTVAInfo = defineAsyncComponent(() =>
   import('ucla-library-design-tokens/assets/svgs/icon-ftva-info.svg')
 )
@@ -88,6 +92,10 @@ const iconMapping = {
   'svg-call-to-action-find': {
     icon: SvgCallToActionFind,
     label: 'CTA Find'
+  },
+  'svg-call-to-action-ftva-external-link-dark': {
+    icon: SvgCallToActionFTVAExternalLinkDark,
+    label: 'CTA FTVA External Link'
   },
   'svg-call-to-action-ftva-info': {
     icon: SvgCallToActionFTVAInfo,

--- a/src/lib-components/BlockCallToAction.vue
+++ b/src/lib-components/BlockCallToAction.vue
@@ -4,6 +4,7 @@ import { computed, defineAsyncComponent } from 'vue'
 import { useGlobalStore } from '@/stores/GlobalStore'
 
 import ButtonLink from '@/lib-components/ButtonLink.vue'
+import RichText from '@/lib-components/RichText.vue'
 
 import { useTheme } from '@/composables/useTheme'
 
@@ -195,11 +196,7 @@ const classes = computed(() => {
       >
         {{ parsedContent.title }}
       </h2>
-      <div
-        :class="{ 'ftva-global-data': props.useGlobalData && theme === 'ftva' }"
-        class="text"
-        v-html="parsedContent.text"
-      />
+      <RichText :class="{ 'ftva-global-data': props.useGlobalData && theme === 'ftva' }" class="text" :rich-text-content="parsedContent.text" />
     </div>
     <div v-if="theme !== 'ftva'">
       <ButtonLink

--- a/src/styles/default/_block-call-to-action.scss
+++ b/src/styles/default/_block-call-to-action.scss
@@ -97,6 +97,14 @@
     max-width: 640px;
   }
 
+  :deep(.rich-text) {
+    padding-right: 0;
+
+    .parsed-content {
+      color: unset; 
+    }
+  }
+
   .text {
     @include step-0;
     text-align: center;
@@ -104,6 +112,7 @@
     margin-bottom: 32px;
     max-width: 640px;
   }
+
 
   // Breakpoints
   @media #{$medium} {

--- a/src/styles/ftva/_block-call-to-action.scss
+++ b/src/styles/ftva/_block-call-to-action.scss
@@ -42,12 +42,16 @@
     margin-bottom: 4px;
   }
 
-  .text {
+
+  :deep(.rich-text.text) {
     @include ftva-body-2;
-    font-size: 16px;
     line-height: 1.5;
     max-width: 100%;
     position: relative;
+    
+    p {
+      font-size: 16px;
+    }
   }
 
   :deep(.text a) {
@@ -55,10 +59,8 @@
     text-decoration: underline;
   }
 
-  :deep(.text.ftva-global-data > p::after) {
+  :deep(.rich-text a[target="_blank"]::after) {
     content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-external-link-dark.svg');
-    position: absolute;
-    margin-left: 10px;
-    bottom: -1px;
+    scale: 1;
   }
 }

--- a/src/styles/ftva/_block-call-to-action.scss
+++ b/src/styles/ftva/_block-call-to-action.scss
@@ -54,11 +54,6 @@
     }
   }
 
-  :deep(.text a) {
-    color: $accent-blue;
-    text-decoration: underline;
-  }
-
   :deep(.rich-text a[target="_blank"]::after) {
     content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-external-link-dark.svg');
     scale: 1;


### PR DESCRIPTION
Connected to [APPS-3007](https://jira.library.ucla.edu/browse/APPS-3007)

**Component Created:** BlockCallToAction.vue

**Notes:**
- Replaced use of parsed-text-handlebar template with RichText component
- Updated CSS
  - [Update to FTVA variant of RichText](https://github.com/UCLALibrary/ucla-library-website-components/pull/633) should show linked text with thicker pale blue underline that turns bright blue on hover 

<br>

**Preview:**
- https://deploy-preview-634--ucla-library-storybook.netlify.app/?path=/story/block-call-to-action--ftva-slim-cta-titled

![default](https://github.com/user-attachments/assets/8c2a68b5-349c-43dc-a36e-613e5bd5ab90)

![hover](https://github.com/user-attachments/assets/f0742ec4-d5f7-4774-87bb-420fea38201c)

<br>

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I have requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3007]: https://uclalibrary.atlassian.net/browse/APPS-3007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ