### PR TITLE
fix: APPS-2983 Add fixed-width value to sidebar column

### DIFF
--- a/src/lib-components/TwoColLayoutWStickySideBar.vue
+++ b/src/lib-components/TwoColLayoutWStickySideBar.vue
@@ -84,8 +84,7 @@ onMounted(() => {
   }
 
   .sidebar-column {
-    min-width: 314px;
-    width: 30%;
+    width: #{$sidebar-width}px;
     position: absolute;
     height: 100%;
     top: 0;
@@ -119,7 +118,6 @@ onMounted(() => {
     padding-right: var(--unit-gutter);
 
     .primary-column {
-      width: 62%;
 
       .primary-section-wrapper {
         padding-left: var(--unit-gutter);
@@ -127,7 +125,7 @@ onMounted(() => {
     }
 
     .sidebar-column {
-      padding-right: var(--unit-gutter);
+      padding-right: 0;
     }
   }
 }
@@ -137,6 +135,7 @@ onMounted(() => {
   .two-column {
     display: grid;
     grid-template-columns: 1fr;
+    padding-right: 0;
 
     .primary-column {
       width: auto;


### PR DESCRIPTION
Connected to [APPS-2983](https://jira.library.ucla.edu/browse/APPS-2983)

**Component Updated:** TwoColLayoutWithStickySidebar.vue

**Notes:**
- Set fixed width value for sidebar column in two-column layout component
- Removed excess padding on component

**Local Nuxt Previews:**

_Desktop_
![fixed-width-sidebar-1](https://github.com/user-attachments/assets/4211d0c7-bb72-4317-a435-974ab7aa7eda)
<br>

_Tablet_
![fixed-width-sidebar-2](https://github.com/user-attachments/assets/3c1de85e-f196-4b6a-bb25-20483a0153da)
<br>

_Mobile_
![fixed-width-sidebar-3](https://github.com/user-attachments/assets/6eed56f8-6cdc-4776-8c48-b2df6f9ce7b2)
<br>

_Fixed excess padding_
![fixed-width-sidebar-4](https://github.com/user-attachments/assets/1751b778-fbe3-40e8-865c-13c46df34ce8)

<br>

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2983]: https://uclalibrary.atlassian.net/browse/APPS-2983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ