### PR TITLE
fix: APPS-2889 styles for screening text

### DIFF
--- a/src/styles/ftva/_block-screening-detail.scss
+++ b/src/styles/ftva/_block-screening-detail.scss
@@ -1,6 +1,9 @@
 .ftva.block-screening-detail {
   .count {
     @include ftva-subtitle-1;
+    text-transform: none;
+    font-size: 18px;
+    font-weight: 400;
     color: $subtitle-grey;
   }
 


### PR DESCRIPTION
Connected to [APPS-2889](https://jira.library.ucla.edu/browse/APPS-2889)

**Component Styles Updated:** /ftva/_block-screening-detail.scss

**Notes:**

Some of the styles were missed on the first pass through, we are updating them to match the mockups https://www.figma.com/design/L8e1czKo8a8px368ayyPZ4/%5BFTVA%5D-Final-Design-with-Annotations?node-id=1422-31472&node-type=frame&t=FWW5UFCw30U3kQwl-0


Before:

<img width="574" alt="Screenshot 2024-10-24 at 10 59 35 AM" src="https://github.com/user-attachments/assets/1c039fb6-aaa2-4e19-8a0b-97a4f2e58d51">

After:
<img width="574" alt="Screenshot 2024-10-24 at 10 59 27 AM" src="https://github.com/user-attachments/assets/4428faec-06f3-4195-90fb-9d65f9e0415b">


**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-2889]: https://uclalibrary.atlassian.net/browse/APPS-2889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ