### PR TITLE
fix: APPS-3030 Adjust TwoColumn component spacing

### DIFF
--- a/src/lib-components/TwoColLayoutWStickySideBar.vue
+++ b/src/lib-components/TwoColLayoutWStickySideBar.vue
@@ -134,7 +134,6 @@ onMounted(() => {
   }
 }
 
-
 // MOBILE STYLES
 @media (max-width: 899px) {
   .two-column {

--- a/src/lib-components/TwoColLayoutWStickySideBar.vue
+++ b/src/lib-components/TwoColLayoutWStickySideBar.vue
@@ -16,7 +16,7 @@ function setMainMinHeight() {
 onMounted(() => {
   const { width } = useWindowSize()
   watch([width, sidebar], ([newWidth]) => {
-    isMobile.value = newWidth <= 750
+    isMobile.value = newWidth <= 899
 
     if (isMobile.value === true)
       primaryCol.value!.style!.minHeight = 'auto' // on mobile, reset height
@@ -97,9 +97,9 @@ onMounted(() => {
       top: 85px;
       will-change: top;
 
-     :deep(.block-call-to-action.slim-left-align) {
-        border-radius: 10px;
-      }
+    :deep(.block-call-to-action.slim-left-align) {
+      border-radius: 10px;
+    }
 
       >* {
         margin-bottom: 30px;
@@ -113,6 +113,14 @@ onMounted(() => {
 }
 
 // MEDIUM DEVICE STYLES
+@media (min-width: 900px) and (max-width: 1200px){
+  .two-column {
+    .sidebar-column {
+      margin-right: var(--unit-gutter);
+    }
+  }
+}
+
 @media (max-width: 1200px) {
   .two-column {
     padding-right: var(--unit-gutter);
@@ -123,15 +131,12 @@ onMounted(() => {
         padding-left: var(--unit-gutter);
       }
     }
-
-    .sidebar-column {
-      padding-right: 0;
-    }
   }
 }
 
+
 // MOBILE STYLES
-@media #{$small} {
+@media (max-width: 899px) {
   .two-column {
     display: grid;
     grid-template-columns: 1fr;


### PR DESCRIPTION
Connected to [APPS-3030](https://jira.library.ucla.edu/browse/APPS-3030)

**Component Updated:** TwoColLayoutWStickySidebar.vue

**Notes:**
- Added space/margin to the right of the sidebar column at tablet resolution
- Shifted the component to one-column at earlier breakpoint 

https://deploy-preview-644--ucla-library-storybook.netlify.app/?path=/story/layout-2-column-layout-with-sticky-sidebar--event-series

![sidebar-col-spacing-fixed](https://github.com/user-attachments/assets/f4e2ab93-d080-4519-a221-e4e4715a9c0b)

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3030]: https://uclalibrary.atlassian.net/browse/APPS-3030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ