### PR TITLE
fix: APPS-3041 Reset TwoCol component primary column width

### DIFF
--- a/src/lib-components/TwoColLayoutWStickySideBar.vue
+++ b/src/lib-components/TwoColLayoutWStickySideBar.vue
@@ -115,6 +115,11 @@ onMounted(() => {
 // MEDIUM DEVICE STYLES
 @media (min-width: 900px) and (max-width: 1200px){
   .two-column {
+    
+    .primary-column {
+      width: 62%;
+    }
+
     .sidebar-column {
       margin-right: var(--unit-gutter);
     }

--- a/src/lib-components/TwoColLayoutWStickySideBar.vue
+++ b/src/lib-components/TwoColLayoutWStickySideBar.vue
@@ -115,7 +115,7 @@ onMounted(() => {
 // MEDIUM DEVICE STYLES
 @media (min-width: 900px) and (max-width: 1200px){
   .two-column {
-    
+
     .primary-column {
       width: 62%;
     }


### PR DESCRIPTION
Connected to [APPS-3041](https://jira.library.ucla.edu/browse/APPS-3041)

**Component Created:** TwoColLayoutWStickySidebar.vue

**Notes:**
- Reset primary column width at updated tablet breakpoint range

![reset-primary-col-width](https://github.com/user-attachments/assets/c17b33dc-7bc3-4edc-b29a-e1ec1813d408)


**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I assigned this PR to someone on the dev team to review~~
-   [x] I used a conventional commit message~~
-   [x] I assigned myself to this PR~~


[APPS-3041]: https://uclalibrary.atlassian.net/browse/APPS-3041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ