### PR TITLE
fix: APPS-3046 Remove excess content spacing in SlimBlockCTA

### DIFF
--- a/src/styles/default/_block-call-to-action.scss
+++ b/src/styles/default/_block-call-to-action.scss
@@ -102,6 +102,7 @@
 
     .parsed-content {
       color: unset; 
+      margin-bottom: 0;
     }
   }
 


### PR DESCRIPTION
Connected to [APPS-3046](https://jira.library.ucla.edu/browse/APPS-3046)

**Component Updated:** BlockCallToAction.vue

**Notes:**
- Removed excess spacing below SlimCTA text content--coming from RichText component's `parsed-content` class
- Setting `parsed-content`'s margin-bottom to 0 in the default file does not affect spacing in the default component; `text` div that is parent to `parsed-content` already has a margin-bottom value of 32px (which takes precedence over `parsed-content`'s 28px value)

https://deploy-preview-648--ucla-library-storybook.netlify.app/?path=/story/block-call-to-action--ftva-slim-cta-titled

*Before*
![slim-cta-spacing-before](https://github.com/user-attachments/assets/561fbf1c-99d5-4679-aa47-5d33a501b5e5)

*After*
![slim-cta-spacing-after](https://github.com/user-attachments/assets/72e867e1-6f1a-4af6-a09a-3446e02a0f78)

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3046]: https://uclalibrary.atlassian.net/browse/APPS-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ