### PR TITLE
feat: fix pnpm version in publish action

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -20,9 +20,9 @@ jobs:
         with:
           node-version: 20
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
       - name: Install dependencies
         run: pnpm install
       - name: Install semantic-release extra plugins


### PR DESCRIPTION
this fixes the following bug:
https://github.com/UCLALibrary/ucla-library-website-components/actions/runs/11694891777/job/32569373589
```
Run pnpm install
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/home/runner/work/ucla-library-website-components/ucla-library-website-components".

Expected version: ^9.12.1
Got: [8](https://github.com/UCLALibrary/ucla-library-website-components/actions/runs/11694891777/job/32569373589#step:5:9).15.9

This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.

To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".
Error: Process completed with exit code 1.
```
