### PR TITLE
feat: APPS-3045 refactor mobile drawer, datefilter mobile

### DIFF
--- a/src/lib-components/ButtonDropdown.vue
+++ b/src/lib-components/ButtonDropdown.vue
@@ -1,7 +1,5 @@
 <script setup>
 import { computed, ref } from 'vue'
-
-// import { vOnClickOutside } from '@vueuse/components'
 import { useRoute } from 'vue-router'
 import 'add-to-calendar-button'
 import format from 'date-fns/format'
@@ -13,7 +11,6 @@ import IconWithLink from './IconWithLink.vue'
 import MobileDrawer from './MobileDrawer.vue'
 import removeTags from '@/utils/removeTags'
 
-// import { useGlobalStore } from '@/stores/GlobalStore'
 import { useTheme } from '@/composables/useTheme'
 
 // DATA
@@ -63,26 +60,13 @@ const { title, eventDescription, startDateWithTime, endTime, location, isEvent, 
   },
 })
 
-// const globalStore = useGlobalStore()
-
 const route = useRoute()
 
-// const isDropdownExpanded = ref(false)
-
 const isLinkCopied = ref(false)
-
-// COMPUTED
-// const isMobile = computed(() => {
-//   return globalStore.winWidth <= 750
-// })
 
 const isLinkCopiedClass = computed(() => [
   { 'is-link-copied': isLinkCopied.value },
 ])
-
-// const isDropdownExpandedClass = computed(() => [
-//   { 'is-expanded': isDropdownExpanded.value },
-// ])
 
 // Event data computations
 const parsedLocation = computed(() => {
@@ -115,19 +99,6 @@ const parsedEventDescription = computed(() => {
 
   return ''
 })
-
-// METHODS
-// function handleDropdownExpansion() {
-//   return (isDropdownExpanded.value = !isDropdownExpanded.value)
-// }
-
-// function closeDropdownOnClickOutside() {
-//   isDropdownExpanded.value = false
-// }
-
-// function removeOverlay() {
-//   isDropdownExpanded.value = false
-// }
 
 /* Inject styles into ATCB ShadowDOM on button dropdown:
  - Remove border bottom radii on button
@@ -263,76 +234,6 @@ const parsedClasses = computed(() => {
         </div>
       </template>
     </MobileDrawer>
-
-    <!-- Generic Button -->
-    <!-- <div v-else v-on-click-outside="closeDropdownOnClickOutside">
-      <div class="dropdown-overlay" :class="isDropdownExpandedClass" /> -->
-    <!-- <button
-      class="button"
-      :class="isDropdownExpandedClass"
-      @click="handleDropdownExpansion">
-      <span class="button-inner-wrapper">
-        <span v-if="hasIcon">
-          <component :is="SvgIconFtvaShare" class="button-svg" aria-hidden="true" />
-        </span>
-
-        <span class="button-text">{{ buttonTitle }}</span>
-      </span>
-
-      <span
-        :class="isDropdownExpandedClass"
-        class="toggle-triangle-icon">
-        <SvgIconFtvaDropTriangle />
-      </span>
-    </button> -->
-
-    <!-- Dropdown ITEMS -->
-    <!-- <div v-if="isDropdownExpanded" class="button-dropdown-modal">
-      <SvgGlyphClose
-        v-if="isMobile"
-        class="svg-glyph-close"
-        @click="removeOverlay" />
-      <div
-        class="button-dropdown-modal-wrapper"
-        :class="isDropdownExpandedClass">
-        <div
-          v-for="item in dropdownList"
-          :key="item.dropdownItemTitle"
-          class="dropdown-modal-item">
-          <span v-if="item.dropdownItemTitle === 'Email'"><a
-              :href="`mailto:?&body=${route.fullPath}`"
-              class="email-icon">
-              <IconWithLink
-                :text="item.dropdownItemTitle"
-                :icon-name="item.iconName"
-                class="not-smart-link" />
-            </a></span>
-
-          <span
-            v-else-if="item.dropdownItemTitle === 'Copy Link'">
-            <IconWithLink
-              v-if="!isLinkCopied"
-              :text="item.dropdownItemTitle"
-              :icon-name="item.iconName"
-              class="not-smart-link"
-              @click="handleCopiedLink(route.fullPath)" />
-
-            <IconWithLink
-              v-else
-              text="Link Copied!"
-              :class="isLinkCopiedClass"
-              :icon-name="SvgIconFtvaSocialConfirm" />
-          </span>
-
-          <IconWithLink
-            v-else
-            :text="item.dropdownItemTitle"
-            :icon-name="item.iconName"
-            :to="`${item.dropdownItemUrl}${route.fullPath}`" />
-        </div>
-      </div>
-    </div> -->
-    <!-- </div> -->
   </div>
 </template>
 

--- a/src/lib-components/ButtonDropdown.vue
+++ b/src/lib-components/ButtonDropdown.vue
@@ -1,19 +1,19 @@
 <script setup>
 import { computed, ref } from 'vue'
-import { vOnClickOutside } from '@vueuse/components'
+
+// import { vOnClickOutside } from '@vueuse/components'
 import { useRoute } from 'vue-router'
 import 'add-to-calendar-button'
 import format from 'date-fns/format'
 
-import SvgIconFtvaDropTriangle from 'ucla-library-design-tokens/assets/svgs/icon-ftva-drop-triangle.svg'
 import SvgIconFtvaShare from 'ucla-library-design-tokens/assets/svgs/icon-ftva-share.svg'
 import SvgIconFtvaSocialConfirm from 'ucla-library-design-tokens/assets/svgs/icon-ftva-social_confirm.svg'
-import SvgGlyphClose from 'ucla-library-design-tokens/assets/svgs/icon-close.svg'
 
 import IconWithLink from './IconWithLink.vue'
+import MobileDrawer from './MobileDrawer.vue'
 import removeTags from '@/utils/removeTags'
 
-import { useGlobalStore } from '@/stores/GlobalStore'
+// import { useGlobalStore } from '@/stores/GlobalStore'
 import { useTheme } from '@/composables/useTheme'
 
 // DATA
@@ -63,26 +63,26 @@ const { title, eventDescription, startDateWithTime, endTime, location, isEvent, 
   },
 })
 
-const globalStore = useGlobalStore()
+// const globalStore = useGlobalStore()
 
 const route = useRoute()
 
-const isDropdownExpanded = ref(false)
+// const isDropdownExpanded = ref(false)
 
 const isLinkCopied = ref(false)
 
 // COMPUTED
-const isMobile = computed(() => {
-  return globalStore.winWidth <= 750
-})
+// const isMobile = computed(() => {
+//   return globalStore.winWidth <= 750
+// })
 
 const isLinkCopiedClass = computed(() => [
   { 'is-link-copied': isLinkCopied.value },
 ])
 
-const isDropdownExpandedClass = computed(() => [
-  { 'is-expanded': isDropdownExpanded.value },
-])
+// const isDropdownExpandedClass = computed(() => [
+//   { 'is-expanded': isDropdownExpanded.value },
+// ])
 
 // Event data computations
 const parsedLocation = computed(() => {
@@ -117,17 +117,17 @@ const parsedEventDescription = computed(() => {
 })
 
 // METHODS
-function handleDropdownExpansion() {
-  return (isDropdownExpanded.value = !isDropdownExpanded.value)
-}
+// function handleDropdownExpansion() {
+//   return (isDropdownExpanded.value = !isDropdownExpanded.value)
+// }
 
-function closeDropdownOnClickOutside() {
-  isDropdownExpanded.value = false
-}
+// function closeDropdownOnClickOutside() {
+//   isDropdownExpanded.value = false
+// }
 
-function removeOverlay() {
-  isDropdownExpanded.value = false
-}
+// function removeOverlay() {
+//   isDropdownExpanded.value = false
+// }
 
 /* Inject styles into ATCB ShadowDOM on button dropdown:
  - Remove border bottom radii on button
@@ -166,7 +166,7 @@ function formatEndTime(str) {
 const theme = useTheme()
 
 const parsedClasses = computed(() => {
-  return ['button-dropdown', theme?.value || '', { 'is-expanded': isDropdownExpanded.value }]
+  return ['button-dropdown', theme?.value || '']
 })
 </script>
 
@@ -200,96 +200,139 @@ const parsedClasses = computed(() => {
         hideIconButton="true"
         listStyle="dropdown-static"
         :debug="debugModeEnabled"
-        @click="handleActbExpandedStyle"
-></add-to-calendar-button>
+        @click="handleActbExpandedStyle"></add-to-calendar-button>
       <!-- eslint-enable -->
     </div>
 
     <!-- Generic Button -->
-    <div v-else v-on-click-outside="closeDropdownOnClickOutside">
-      <div class="dropdown-overlay" :class="isDropdownExpandedClass" />
-      <button
-        class="button"
-        :class="isDropdownExpandedClass"
-        @click="handleDropdownExpansion"
-      >
+    <MobileDrawer v-else>
+      <template #buttonLabel>
         <!-- Optional Button Icon -->
-        <span class="button-inner-wrapper">
-          <span v-if="hasIcon">
-            <component :is="SvgIconFtvaShare" class="button-svg" aria-hidden="true" />
-          </span>
-
-          <span class="button-text">{{ buttonTitle }}</span>
+        <span v-if="hasIcon" class="icon-svg">
+          <component :is="SvgIconFtvaShare" class="button-svg" aria-hidden="true" />
         </span>
 
-        <span
-          :class="isDropdownExpandedClass"
-          class="toggle-triangle-icon"
-        >
-          <SvgIconFtvaDropTriangle />
-        </span>
-      </button>
-
-      <!-- Dropdown Modal -->
-      <div v-if="isDropdownExpanded" class="button-dropdown-modal">
-        <SvgGlyphClose
-          v-if="isMobile"
-          class="svg-glyph-close"
-          @click="removeOverlay"
-        />
+        <span class="button-text">{{ buttonTitle }}</span>
+      </template>
+      <template #dropdownItems>
         <div
-          class="button-dropdown-modal-wrapper"
-          :class="isDropdownExpandedClass"
+          v-for="item in dropdownList"
+          :key="item.dropdownItemTitle"
+          class="dropdown-modal-item"
         >
-          <!-- Dropdown Items -->
-          <div
-            v-for="item in dropdownList"
-            :key="item.dropdownItemTitle"
-            class="dropdown-modal-item"
+          <!-- "Send to Email" -->
+          <span v-if="item.dropdownItemTitle === 'Email'"><a
+            :href="`mailto:?&body=${route.fullPath}`"
+            class="email-icon"
           >
-            <!-- "Send to Email" -->
-            <span v-if="item.dropdownItemTitle === 'Email'"><a
-              :href="`mailto:?&body=${route.fullPath}`"
-              class="email-icon"
-            >
-              <IconWithLink
-                :text="item.dropdownItemTitle"
-                :icon-name="item.iconName"
-                class="not-smart-link"
-              /></a></span>
-
-            <!-- "Copy URL/Link" -->
-            <span
-              v-else-if="item.dropdownItemTitle === 'Copy Link'"
-            >
-              <!-- Swap on click -->
-              <IconWithLink
-                v-if="!isLinkCopied"
-                :text="item.dropdownItemTitle"
-                :icon-name="item.iconName"
-                class="not-smart-link"
-                @click="handleCopiedLink(route.fullPath)"
-              />
-
-              <IconWithLink
-                v-else
-                text="Link Copied!"
-                :class="isLinkCopiedClass"
-                :icon-name="SvgIconFtvaSocialConfirm"
-              />
-            </span>
-
-            <!-- Generic Dropdown Items -->
             <IconWithLink
-              v-else
               :text="item.dropdownItemTitle"
               :icon-name="item.iconName"
-              :to="`${item.dropdownItemUrl}${route.fullPath}`"
+              class="not-smart-link"
             />
-          </div>
+          </a></span>
+
+          <!-- "Copy URL/Link" -->
+          <span
+            v-else-if="item.dropdownItemTitle === 'Copy Link'"
+          >
+            <!-- Swap on click -->
+            <IconWithLink
+              v-if="!isLinkCopied"
+              :text="item.dropdownItemTitle"
+              :icon-name="item.iconName"
+              class="not-smart-link"
+              @click="handleCopiedLink(route.fullPath)"
+            />
+
+            <IconWithLink
+              v-else
+              text="Link Copied!"
+              :class="isLinkCopiedClass"
+              :icon-name="SvgIconFtvaSocialConfirm"
+            />
+          </span>
+
+          <!-- Generic Dropdown Items -->
+          <IconWithLink
+            v-else
+            :text="item.dropdownItemTitle"
+            :icon-name="item.iconName"
+            :to="`${item.dropdownItemUrl}${route.fullPath}`"
+          />
+        </div>
+      </template>
+    </MobileDrawer>
+
+    <!-- Generic Button -->
+    <!-- <div v-else v-on-click-outside="closeDropdownOnClickOutside">
+      <div class="dropdown-overlay" :class="isDropdownExpandedClass" /> -->
+    <!-- <button
+      class="button"
+      :class="isDropdownExpandedClass"
+      @click="handleDropdownExpansion">
+      <span class="button-inner-wrapper">
+        <span v-if="hasIcon">
+          <component :is="SvgIconFtvaShare" class="button-svg" aria-hidden="true" />
+        </span>
+
+        <span class="button-text">{{ buttonTitle }}</span>
+      </span>
+
+      <span
+        :class="isDropdownExpandedClass"
+        class="toggle-triangle-icon">
+        <SvgIconFtvaDropTriangle />
+      </span>
+    </button> -->
+
+    <!-- Dropdown ITEMS -->
+    <!-- <div v-if="isDropdownExpanded" class="button-dropdown-modal">
+      <SvgGlyphClose
+        v-if="isMobile"
+        class="svg-glyph-close"
+        @click="removeOverlay" />
+      <div
+        class="button-dropdown-modal-wrapper"
+        :class="isDropdownExpandedClass">
+        <div
+          v-for="item in dropdownList"
+          :key="item.dropdownItemTitle"
+          class="dropdown-modal-item">
+          <span v-if="item.dropdownItemTitle === 'Email'"><a
+              :href="`mailto:?&body=${route.fullPath}`"
+              class="email-icon">
+              <IconWithLink
+                :text="item.dropdownItemTitle"
+                :icon-name="item.iconName"
+                class="not-smart-link" />
+            </a></span>
+
+          <span
+            v-else-if="item.dropdownItemTitle === 'Copy Link'">
+            <IconWithLink
+              v-if="!isLinkCopied"
+              :text="item.dropdownItemTitle"
+              :icon-name="item.iconName"
+              class="not-smart-link"
+              @click="handleCopiedLink(route.fullPath)" />
+
+            <IconWithLink
+              v-else
+              text="Link Copied!"
+              :class="isLinkCopiedClass"
+              :icon-name="SvgIconFtvaSocialConfirm" />
+          </span>
+
+          <IconWithLink
+            v-else
+            :text="item.dropdownItemTitle"
+            :icon-name="item.iconName"
+            :to="`${item.dropdownItemUrl}${route.fullPath}`" />
         </div>
       </div>
-    </div>
+    </div> -->
+    <!-- </div> -->
   </div>
 </template>
 

--- a/src/lib-components/DateFilter.vue
+++ b/src/lib-components/DateFilter.vue
@@ -84,7 +84,12 @@ function goToToday() {
     document?.activeElement?.blur()
   }
   else {
-    date.value = [new Date(), new Date()]
+    if (isMobile.value)
+      // mobile does allow range selection
+      date.value = new Date()
+    else
+      date.value = [new Date(), new Date()]
+
     todayBtnActive.value = true
   }
 }

--- a/src/lib-components/DateFilter.vue
+++ b/src/lib-components/DateFilter.vue
@@ -30,7 +30,8 @@ const { eventDates, initialDates, hideInput } = defineProps({
     type: Object as PropType<SelectedDates>,
     default: () => ({ startDate: null, endDate: null }),
   },
-  // if true, the datepicker will be shown in 'inline' mode
+  // if true, the datepicker will be shown in 'inline' mode all the time, event on desktop
+  // this option is not currently used on the ftva site
   // https://vue3datepicker.com/props/modes/#inline
   hideInput: {
     type: Boolean,
@@ -48,6 +49,7 @@ const date = ref<Date[] | Date>([])
 const datepicker = ref<DatePickerInstance | null>(null)
 const isSelecting = ref(false)
 const isOpen = ref(false)
+const isMobile = ref(false)
 const todayBtnActive = ref(false)
 const textConfig = ref({
   rangeSeparator: ' — ',
@@ -187,7 +189,6 @@ watch(date, async (newDate, oldDate) => {
   }
 })
 
-const isMobile = ref(false)
 onMounted(() => {
   const { width } = useWindowSize()
   watch(width, (newWidth) => {

--- a/src/lib-components/DateFilter.vue
+++ b/src/lib-components/DateFilter.vue
@@ -451,7 +451,7 @@ onMounted(() => {
     display: inline-flex;
     align-items: center;
     svg {
-      margin-right: 10px;
+      margin-right: 8px;
     }
     :deep(path.svg__fill--accent-blue) {
       fill: $medium-grey;
@@ -794,10 +794,32 @@ onMounted(() => {
 
   //mobile drawer styles for datefilter
   :deep(.mobile-drawer) {
+    // center datepicker within drawer
     .dp__main {
       margin: 0 auto;
       .dp__menu {
         border: none;
+      }
+    }
+    // styles for the drawer launch button
+    // these may be useful for filterdropdown as well
+    .mobile-button {
+      width: 166px;
+      padding: 6px;
+      border-radius: 4px;
+      &:active {
+        color: white;
+        background-color: $accent-blue;
+          path.svg__fill--accent-blue {
+            fill: white;
+        }
+      }
+      &.is-expanded {
+        color: $accent-blue;
+        border: 2px solid $accent-blue;
+        path.svg__fill--accent-blue {
+          fill: $accent-blue;
+        }
       }
     }
   }

--- a/src/lib-components/MobileDrawer.vue
+++ b/src/lib-components/MobileDrawer.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useWindowSize } from '@vueuse/core'
+import SvgIconFtvaDropTriangle from 'ucla-library-design-tokens/assets/svgs/icon-ftva-drop-triangle.svg'
+import SvgGlyphClose from 'ucla-library-design-tokens/assets/svgs/icon-close.svg'
+import { useTheme } from '@/composables/useTheme'
+
+// DATA
+const isDropdownExpanded = ref(false)
+const isMobile = ref(false)
+
+// FUNCTIONS
+// Computed Methods
+const isDropdownExpandedClass = computed(() => [
+  { 'is-expanded': isDropdownExpanded.value },
+])
+// Regular Methods
+function handleDropdownExpansion() {
+  return (isDropdownExpanded.value = !isDropdownExpanded.value)
+}
+
+function closeDropdownOnClickOutside() {
+  isDropdownExpanded.value = false
+}
+
+function removeOverlay() {
+  isDropdownExpanded.value = false
+}
+
+// THEME
+const theme = useTheme()
+const parsedClasses = computed(() => {
+  return ['mobile-drawer', 'button-dropdown', theme?.value || '', { 'is-expanded': isDropdownExpanded.value }]
+})
+
+onMounted(() => {
+  const { width } = useWindowSize()
+  watch(width, (newWidth) => {
+    isMobile.value = newWidth <= 750
+  }, { immediate: true })
+})
+</script>
+
+<template>
+  <div :class="parsedClasses">
+    <div v-on-click-outside="closeDropdownOnClickOutside">
+      <div class="dropdown-overlay" :class="isDropdownExpandedClass" />
+      <button
+        class="button"
+        :class="isDropdownExpandedClass"
+        @click="handleDropdownExpansion"
+      >
+        <!-- Drawer Button Label Here
+                 Note: icons can be included, clicking button will open drawer -->
+        <slot name="buttonLabel" />
+
+        <span
+          :class="isDropdownExpandedClass"
+          class="toggle-triangle-icon"
+        >
+          <SvgIconFtvaDropTriangle />
+        </span>
+      </button>
+
+      <div v-if="isDropdownExpanded" class="button-dropdown-modal">
+        <SvgGlyphClose
+          v-if="isMobile"
+          class="svg-glyph-close"
+          @click="removeOverlay"
+        />
+        <div
+          class="button-dropdown-modal-wrapper"
+          :class="isDropdownExpandedClass"
+        >
+          <!-- Dropdown Items slot in here
+                     Note: items should use class .dropdown-modal-item -->
+          <slot name="dropdownItems" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "@/styles/default/_mobile-drawer.scss";
+@import "@/styles/ftva/_mobile-drawer.scss";
+</style>

--- a/src/lib-components/MobileDrawer.vue
+++ b/src/lib-components/MobileDrawer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useWindowSize } from '@vueuse/core'
+import { vOnClickOutside } from '@vueuse/components'
 import SvgIconFtvaDropTriangle from 'ucla-library-design-tokens/assets/svgs/icon-ftva-drop-triangle.svg'
 import SvgGlyphClose from 'ucla-library-design-tokens/assets/svgs/icon-close.svg'
 import { useTheme } from '@/composables/useTheme'

--- a/src/lib-components/MobileDrawer.vue
+++ b/src/lib-components/MobileDrawer.vue
@@ -52,7 +52,7 @@ onMounted(() => {
         @click="handleDropdownExpansion"
       >
         <!-- Drawer Button Label Here
-                 Note: icons can be included, clicking button will open drawer -->
+          Note: icons can be included, clicking button will open drawer -->
         <span class="button-inner-wrapper">
           <slot name="buttonLabel" />
         </span>
@@ -76,7 +76,7 @@ onMounted(() => {
           :class="isDropdownExpandedClass"
         >
           <!-- Dropdown Items slot in here -->
-          <slot name="dropdownItems" />
+          <slot name="dropdownItems" :remove-overlay="removeOverlay" />
         </div>
       </div>
     </div>

--- a/src/lib-components/MobileDrawer.vue
+++ b/src/lib-components/MobileDrawer.vue
@@ -30,7 +30,7 @@ function removeOverlay() {
 // THEME
 const theme = useTheme()
 const parsedClasses = computed(() => {
-  return ['mobile-drawer', 'button-dropdown', theme?.value || '', { 'is-expanded': isDropdownExpanded.value }]
+  return ['mobile-drawer', theme?.value || '', { 'is-expanded': isDropdownExpanded.value }]
 })
 
 onMounted(() => {
@@ -46,13 +46,15 @@ onMounted(() => {
     <div v-on-click-outside="closeDropdownOnClickOutside">
       <div class="dropdown-overlay" :class="isDropdownExpandedClass" />
       <button
-        class="button"
+        class="mobile-button"
         :class="isDropdownExpandedClass"
         @click="handleDropdownExpansion"
       >
         <!-- Drawer Button Label Here
                  Note: icons can be included, clicking button will open drawer -->
-        <slot name="buttonLabel" />
+        <span class="button-inner-wrapper">
+          <slot name="buttonLabel" />
+        </span>
 
         <span
           :class="isDropdownExpandedClass"
@@ -72,8 +74,7 @@ onMounted(() => {
           class="button-dropdown-modal-wrapper"
           :class="isDropdownExpandedClass"
         >
-          <!-- Dropdown Items slot in here
-                     Note: items should use class .dropdown-modal-item -->
+          <!-- Dropdown Items slot in here -->
           <slot name="dropdownItems" />
         </div>
       </div>

--- a/src/stories/DateFilter.stories.js
+++ b/src/stories/DateFilter.stories.js
@@ -7,7 +7,6 @@ export default {
 }
 
 const mock = {
-  hideInput: false,
   eventDates: ['2/29/2024', '2/29/2024', '2/29/2024', '2/29/2024', '3/1/2024', '3/2/2024', '3/2/2024', '3/4/2024', '3/6/2024', '3/8/2024', '3/19/2024', '3/19/2024', '3/19/2024', '3/19/2024', '3/19/2024', '3/19/2024',],
 }
 
@@ -19,10 +18,11 @@ export function Default() {
       }
     },
     components: { DateFilter },
-    template: '<div style="height:509px"><date-filter :eventDates="eventDates" :hideInput="hideInput"/></div>',
+    template: '<div style="height:509px"><date-filter :eventDates="eventDates" /></div>',
   }
 }
-
+/* hideInput prop is not currently used anywhere in the app,
+input is hidden automatically on mobile */
 const mockNoInput = {
   hideInput: true,
   eventDates: ['2/29/2024', '2/29/2024', '2/29/2024', '2/29/2024', '3/1/2024', '3/2/2024', '3/2/2024', '3/4/2024', '3/6/2024', '3/8/2024', '3/19/2024', '3/19/2024', '3/19/2024', '3/19/2024', '3/19/2024', '3/19/2024',],

--- a/src/stories/DateFilter.stories.js
+++ b/src/stories/DateFilter.stories.js
@@ -1,6 +1,5 @@
-import { onBeforeUnmount, onMounted } from 'vue'
+import { computed } from 'vue'
 import DateFilter from '@/lib-components/DateFilter'
-import { useGlobalStore } from '@/stores/GlobalStore'
 
 export default {
   title: 'DateFilter',
@@ -12,37 +11,17 @@ const mock = {
   eventDates: ['2/29/2024', '2/29/2024', '2/29/2024', '2/29/2024', '3/1/2024', '3/2/2024', '3/2/2024', '3/4/2024', '3/6/2024', '3/8/2024', '3/19/2024', '3/19/2024', '3/19/2024', '3/19/2024', '3/19/2024', '3/19/2024',],
 }
 
-function Template(args) {
+export function Default() {
   return {
-    setup() {
-      // Setup function provides a context where you can use Composition API
-      onMounted(() => {
-        const globalStore = useGlobalStore()
-
-        const updateWinWidth = () => {
-          globalStore.winWidth = window.innerWidth
-        }
-
-        // Set initial winWidth
-        updateWinWidth()
-
-        // Update winWidth on window resize
-        window.addEventListener('resize', updateWinWidth)
-
-        // Use onBeforeUnmount to clean up
-        onBeforeUnmount(() => {
-          window.removeEventListener('resize', updateWinWidth)
-        })
-      })
-
-      return { ...mock, ...args }
+    data() {
+      return {
+        ...mock,
+      }
     },
     components: { DateFilter },
     template: '<div style="height:509px"><date-filter :eventDates="eventDates" :hideInput="hideInput"/></div>',
   }
 }
-
-export const Default = Template.bind({})
 
 const mockNoInput = {
   hideInput: true,
@@ -75,19 +54,19 @@ export function InitialDates() {
   }
 }
 
-export function Mobile() {
+export function FTVA() {
   return {
     data() {
       return {
         ...mock,
       }
     },
-    created() {
-      const globalStore = useGlobalStore()
-      globalStore.winWidth = 320
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
     },
     components: { DateFilter },
-    template:
-      '<div style="height:509px"><date-filter :eventDates="eventDates" :hideInput="hideInput"/></div> ',
+    template: '<date-filter :eventDates="eventDates" :initialDates="initialDates"/>',
   }
 }

--- a/src/stories/MobileDrawer.spec.js
+++ b/src/stories/MobileDrawer.spec.js
@@ -1,6 +1,6 @@
 describe('GLOBAL / Mobile Drawer', () => {
   it('Default', () => {
-    cy.visit('/iframe.html?id=mobile-drawer--default&args=&viewMode=story')
+    cy.visit('/iframe.html?id=global-mobile-drawer--default&args=&viewMode=story')
     cy.get('.mobile-drawer').should('exist')
 
     cy.percySnapshot('GLOBAL / Mobile Drawer: Default')

--- a/src/stories/MobileDrawer.spec.js
+++ b/src/stories/MobileDrawer.spec.js
@@ -1,0 +1,8 @@
+describe('GLOBAL / Mobile Drawer', () => {
+  it('Default', () => {
+    cy.visit('/iframe.html?id=mobile-drawer--default&args=&viewMode=story')
+    cy.get('.mobile-drawer').should('exist')
+
+    cy.percySnapshot('GLOBAL / Mobile Drawer: Default')
+  })
+})

--- a/src/stories/MobileDrawer.stories.js
+++ b/src/stories/MobileDrawer.stories.js
@@ -1,0 +1,53 @@
+import { computed } from 'vue'
+import MobileDrawer from '@/lib-components/MobileDrawer.vue'
+
+/**
+ * A component to wrap dropdown fields in a drawer that can be toggled open and closed on mobile with a button.
+ *
+ * The componenet has 2 slots:
+ * - dropdownItems: The items to be displayed in the drawer
+ * - buttonLabel: The label for the button that toggles the drawer open and closed, icons can also be included here
+ */
+export default {
+  title: 'Global / Mobile Drawer',
+  component: MobileDrawer,
+}
+
+export function Default() {
+  return {
+    components: { MobileDrawer },
+    template: `<mobile-drawer>
+    <template v-slot:buttonLabel>BUTTON</template>
+    <template v-slot:dropdownItems>
+        <div class="dropdown-modal-item">
+            <span>some item</span>
+        </div>
+        <div class="dropdown-modal-item">
+            <span>some item 2</span>
+        </div>
+    </template>
+    </mobile-drawer>`,
+  }
+}
+
+export function FTVA() {
+  return {
+    components: { MobileDrawer },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    template: `<mobile-drawer>
+    <template v-slot:buttonLabel>BUTTON</template>
+    <template v-slot:dropdownItems>
+        <div class="dropdown-modal-item">
+            <span>some item</span>
+        </div>
+        <div class="dropdown-modal-item">
+            <span>some item 2</span>
+        </div>
+    </template>
+    </mobile-drawer>`,
+  }
+}

--- a/src/styles/default/_button-dropdown.scss
+++ b/src/styles/default/_button-dropdown.scss
@@ -1,73 +1,9 @@
 .button-dropdown {
-    // display: flex;
-    // position: relative;
-
     .button-svg {
         position: relative;
         top: 1px;
         stroke: #{$primary-blue-03};
     }
-
-    // .button {
-    //     display: flex;
-    //     justify-content: space-between;
-    //     min-width: 194px;
-    //     width: 100%;
-    //     padding: 12px 16px 12px 20px;
-    //     border-radius: 8px;
-    //     border: 1px solid #{$primary-blue-03};
-    //     font-weight: 500;
-    //     font-size: 18px;
-    //     background-color: $white;
-    //     color: #{$primary-blue-03};
-
-    //     .button-inner-wrapper {
-    //         display: flex;
-    //         -moz-column-gap: 8px;
-    //         column-gap: 8px;
-    //         height: 100%;
-    //     }
-
-    //     .button-svg {
-    //         position: relative;
-    //         top: 1px;
-    //         stroke: #{$primary-blue-03};
-    //     }
-    // }
-
-    // .button.is-expanded {
-    //     border-bottom-left-radius: 0;
-    //     border-bottom-right-radius: 0;
-    // }
-
-    // .is-expanded.toggle-triangle-icon > svg {
-    //     transform: rotate(180deg);
-    //     position: relative;
-    //     bottom: 2px;
-    // }
-
-    // .button-dropdown-modal-wrapper {
-    //     display: flex;
-    //     flex-direction: column;
-    //     row-gap: 14px;
-    //     padding: 24px 20px 20px 20px;
-    //     min-height: auto;
-    //     min-width: 186px;
-    //     width: 96%;
-    //     margin: 0 auto;
-    //     border-width: 0 1px 1px 1px;
-    //     border-style: solid;
-    //     border-color: #{$primary-blue-03};
-    //     border-bottom-left-radius: 8px;
-    //     border-bottom-right-radius: 8px;
-    //     background-color: $white;
-    // }
-
-    // .button-dropdown-modal-wrapper.is-expanded {
-    //     position: absolute;
-    //     width: auto;
-    //     margin: 0 4px;
-    // }
 
     .dropdown-modal-item {
         :deep(.icon-with-link) {
@@ -110,14 +46,6 @@
     }
 
     @media #{$has-hover} {
-        // .button:hover {
-        //     background-color: #f1f1f1;
-        // }
-
-        // .svg__icon-close.svg-glyph-close:hover {
-        //     cursor: pointer;
-        // }
-
         :deep(.icon-with-link) .link:hover,
         :deep(.icon-with-link.not-smart-link):hover .text {
             -webkit-text-decoration-color: #{$bright-blue};
@@ -152,47 +80,10 @@
             top: 2px;
         }
 
-        // .button.is-expanded {
-        //     border-bottom-left-radius: 8px;
-        //     border-bottom-right-radius: 8px;
-        // }
-
         .button-text,
         .toggle-triangle-icon {
             display: none;
         }
-
-        // .dropdown-overlay.is-expanded {
-        //     position: fixed;
-        //     top: 0;
-        //     left: 0;
-        //     right: 0;
-        //     bottom: 0;
-        //     background-color: rgba(0, 0, 0, 0.5);
-        //     z-index: 1;
-        // }
-
-        // .button-dropdown-modal {
-        //     position: fixed;
-        //     width: 100%;
-        //     left: 0;
-        //     bottom: 0;
-        //     height: auto;
-        //     z-index: 1;
-        // }
-
-        // .button-dropdown-modal-wrapper.is-expanded {
-        //     width: 100%;
-        //     position: static;
-        //     margin: 0;
-        // }
-
-        // .svg__icon-close.svg-glyph-close {
-        //     position: fixed;
-        //     right: 24px;
-        //     bottom: 190px;
-        //     z-index: 1;
-        // }
 
         :deep(.icon-with-link.is-link-copied) {
             width: 85%;

--- a/src/styles/default/_button-dropdown.scss
+++ b/src/styles/default/_button-dropdown.scss
@@ -1,67 +1,73 @@
 .button-dropdown {
-    display: flex;
-    position: relative;
+    // display: flex;
+    // position: relative;
 
-    .button {
-        display: flex;
-        justify-content: space-between;
-        min-width: 194px;
-        width: 100%;
-        padding: 12px 16px 12px 20px;
-        border-radius: 8px;
-        border: 1px solid #{$primary-blue-03};
-        font-weight: 500;
-        font-size: 18px;
-        background-color: $white;
-        color: #{$primary-blue-03};
-
-        .button-inner-wrapper {
-            display: flex;
-            -moz-column-gap: 8px;
-            column-gap: 8px;
-            height: 100%;
-        }
-
-        .button-svg {
-            position: relative;
-            top: 1px;
-            stroke: #{$primary-blue-03};
-        }
-    }
-
-    .button.is-expanded {
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-    }
-
-    .is-expanded.toggle-triangle-icon > svg {
-        transform: rotate(180deg);
+    .button-svg {
         position: relative;
-        bottom: 2px;
+        top: 1px;
+        stroke: #{$primary-blue-03};
     }
 
-    .button-dropdown-modal-wrapper {
-        display: flex;
-        flex-direction: column;
-        row-gap: 14px;
-        padding: 24px 20px 20px 20px;
-        min-height: auto;
-        min-width: 186px;
-        width: 96%;
-        margin: 0 auto;
-        border-width: 0 1px 1px 1px;
-        border-style: solid;
-        border-color: #{$primary-blue-03};
-        border-bottom-left-radius: 8px;
-        border-bottom-right-radius: 8px;
-        background-color: $white;
-    }
+    // .button {
+    //     display: flex;
+    //     justify-content: space-between;
+    //     min-width: 194px;
+    //     width: 100%;
+    //     padding: 12px 16px 12px 20px;
+    //     border-radius: 8px;
+    //     border: 1px solid #{$primary-blue-03};
+    //     font-weight: 500;
+    //     font-size: 18px;
+    //     background-color: $white;
+    //     color: #{$primary-blue-03};
 
-    .button-dropdown-modal-wrapper.is-expanded {
-        position: absolute;
-        width: auto;
-        margin: 0 4px;
-    }
+    //     .button-inner-wrapper {
+    //         display: flex;
+    //         -moz-column-gap: 8px;
+    //         column-gap: 8px;
+    //         height: 100%;
+    //     }
+
+    //     .button-svg {
+    //         position: relative;
+    //         top: 1px;
+    //         stroke: #{$primary-blue-03};
+    //     }
+    // }
+
+    // .button.is-expanded {
+    //     border-bottom-left-radius: 0;
+    //     border-bottom-right-radius: 0;
+    // }
+
+    // .is-expanded.toggle-triangle-icon > svg {
+    //     transform: rotate(180deg);
+    //     position: relative;
+    //     bottom: 2px;
+    // }
+
+    // .button-dropdown-modal-wrapper {
+    //     display: flex;
+    //     flex-direction: column;
+    //     row-gap: 14px;
+    //     padding: 24px 20px 20px 20px;
+    //     min-height: auto;
+    //     min-width: 186px;
+    //     width: 96%;
+    //     margin: 0 auto;
+    //     border-width: 0 1px 1px 1px;
+    //     border-style: solid;
+    //     border-color: #{$primary-blue-03};
+    //     border-bottom-left-radius: 8px;
+    //     border-bottom-right-radius: 8px;
+    //     background-color: $white;
+    // }
+
+    // .button-dropdown-modal-wrapper.is-expanded {
+    //     position: absolute;
+    //     width: auto;
+    //     margin: 0 4px;
+    // }
 
     .dropdown-modal-item {
         :deep(.icon-with-link) {
@@ -104,13 +110,13 @@
     }
 
     @media #{$has-hover} {
-        .button:hover {
-            background-color: #f1f1f1;
-        }
+        // .button:hover {
+        //     background-color: #f1f1f1;
+        // }
 
-        .svg__icon-close.svg-glyph-close:hover {
-            cursor: pointer;
-        }
+        // .svg__icon-close.svg-glyph-close:hover {
+        //     cursor: pointer;
+        // }
 
         :deep(.icon-with-link) .link:hover,
         :deep(.icon-with-link.not-smart-link):hover .text {
@@ -134,66 +140,59 @@
     }
 
     @media #{$small} {
-        .button {
+        :deep(.mobile-button) {
             display: block;
             width: 36px;
             height: 36px;
             min-width: 0;
-
-            .button-inner-wrapper {
-                justify-content: center;
-                align-items: center;
-                -moz-column-gap: 0;
-                column-gap: 0;
-            }
-
-            .button-svg {
-                left: -2px;
-                top: 2px;
-            }
         }
 
-        .button.is-expanded {
-            border-bottom-left-radius: 8px;
-            border-bottom-right-radius: 8px;
+        .button-svg {
+            left: -2px;
+            top: 2px;
         }
+
+        // .button.is-expanded {
+        //     border-bottom-left-radius: 8px;
+        //     border-bottom-right-radius: 8px;
+        // }
 
         .button-text,
         .toggle-triangle-icon {
             display: none;
         }
 
-        .dropdown-overlay.is-expanded {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background-color: rgba(0, 0, 0, 0.5);
-            z-index: 1;
-        }
+        // .dropdown-overlay.is-expanded {
+        //     position: fixed;
+        //     top: 0;
+        //     left: 0;
+        //     right: 0;
+        //     bottom: 0;
+        //     background-color: rgba(0, 0, 0, 0.5);
+        //     z-index: 1;
+        // }
 
-        .button-dropdown-modal {
-            position: fixed;
-            width: 100%;
-            left: 0;
-            bottom: 0;
-            height: auto;
-            z-index: 1;
-        }
+        // .button-dropdown-modal {
+        //     position: fixed;
+        //     width: 100%;
+        //     left: 0;
+        //     bottom: 0;
+        //     height: auto;
+        //     z-index: 1;
+        // }
 
-        .button-dropdown-modal-wrapper.is-expanded {
-            width: 100%;
-            position: static;
-            margin: 0;
-        }
+        // .button-dropdown-modal-wrapper.is-expanded {
+        //     width: 100%;
+        //     position: static;
+        //     margin: 0;
+        // }
 
-        .svg__icon-close.svg-glyph-close {
-            position: fixed;
-            right: 24px;
-            bottom: 190px;
-            z-index: 1;
-        }
+        // .svg__icon-close.svg-glyph-close {
+        //     position: fixed;
+        //     right: 24px;
+        //     bottom: 190px;
+        //     z-index: 1;
+        // }
 
         :deep(.icon-with-link.is-link-copied) {
             width: 85%;

--- a/src/styles/default/_mobile-drawer.scss
+++ b/src/styles/default/_mobile-drawer.scss
@@ -2,7 +2,7 @@
     display: flex;
     position: relative;
 
-    .button {
+    .mobile-button {
         display: flex;
         justify-content: space-between;
         min-width: 194px;
@@ -22,14 +22,15 @@
             height: 100%;
         }
 
-        .button-svg {
-            position: relative;
-            top: 1px;
-            stroke: #{$primary-blue-03};
-        }
+        //TODO
+        // :deep(.button-svg) {
+        //     position: relative;
+        //     top: 1px;
+        //     stroke: #{$primary-blue-03};
+        // }
     }
 
-    .button.is-expanded {
+    .mobile-button.is-expanded {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
     }
@@ -63,48 +64,48 @@
         margin: 0 4px;
     }
 
-    .dropdown-modal-item {
-        :deep(.icon-with-link) {
-            .icon-with-link-container {
-                gap: var(--space-s);
-                padding: 5px 0 3px 5px;
-            }
-        }
+    // .dropdown-modal-item {
+    //     :deep(.icon-with-link) {
+    //         .icon-with-link-container {
+    //             gap: var(--space-s);
+    //             padding: 5px 0 3px 5px;
+    //         }
+    //     }
 
-        :deep(.icon-with-link.not-smart-link) .text,
-        :deep(.icon-with-link) .text {
-            align-self: baseline;
-        }
+    //     :deep(.icon-with-link.not-smart-link) .text,
+    //     :deep(.icon-with-link) .text {
+    //         align-self: baseline;
+    //     }
 
-        :deep(.icon-with-link) .text {
-            font-family: "Karbon", Helvetica, Arial, sans-serif;
-            font-weight: 500;
-            color: $medium-grey;
-        }
+    //     :deep(.icon-with-link) .text {
+    //         font-family: "Karbon", Helvetica, Arial, sans-serif;
+    //         font-weight: 500;
+    //         color: $medium-grey;
+    //     }
 
-        :deep(.icon-with-link) .link,
-        :deep(.icon-with-link.not-smart-link) .text {
-            text-decoration: underline;
-            text-decoration-thickness: 3px;
-            text-underline-offset: 6px;
-            -webkit-text-decoration-color: $grey-blue;
-            text-decoration-color: $grey-blue;
-        }
+    //     :deep(.icon-with-link) .link,
+    //     :deep(.icon-with-link.not-smart-link) .text {
+    //         text-decoration: underline;
+    //         text-decoration-thickness: 3px;
+    //         text-underline-offset: 6px;
+    //         -webkit-text-decoration-color: $grey-blue;
+    //         text-decoration-color: $grey-blue;
+    //     }
 
-        :deep(.icon-with-link.not-smart-link) {
-            width: unset;
-        }
+    //     :deep(.icon-with-link.not-smart-link) {
+    //         width: unset;
+    //     }
 
-        :deep(.icon-with-link.is-link-copied) {
-            .text {
-                position: relative;
-                top: 3px;
-            }
-        }
-    }
+    //     :deep(.icon-with-link.is-link-copied) {
+    //         .text {
+    //             position: relative;
+    //             top: 3px;
+    //         }
+    //     }
+    // }
 
     @media #{$has-hover} {
-        .button:hover {
+        .mobile-button:hover {
             background-color: #f1f1f1;
         }
 
@@ -112,33 +113,31 @@
             cursor: pointer;
         }
 
-        :deep(.icon-with-link) .link:hover,
-        :deep(.icon-with-link.not-smart-link):hover .text {
-            -webkit-text-decoration-color: #{$bright-blue};
-            text-decoration-color: #{$bright-blue};
-        }
+        // :deep(.icon-with-link) .link:hover,
+        // :deep(.icon-with-link.not-smart-link):hover .text {
+        //     -webkit-text-decoration-color: #{$bright-blue};
+        //     text-decoration-color: #{$bright-blue};
+        // }
 
-        :deep(.icon-with-link) {
-            .link:hover {
-                text-decoration-thickness: 3px;
-                text-underline-offset: 6px;
-            }
-        }
+        // :deep(.icon-with-link) {
+        //     .link:hover {
+        //         text-decoration-thickness: 3px;
+        //         text-underline-offset: 6px;
+        //     }
+        // }
 
-        :deep(.icon-with-link.not-smart-link):hover {
+        // :deep(.icon-with-link.not-smart-link):hover {
 
-            .text,
-            .icon {
-                cursor: pointer;
-            }
-        }
+        //     .text,
+        //     .icon {
+        //         cursor: pointer;
+        //     }
+        // }
     }
 
     @media #{$small} {
-        .button {
+        .mobile-button {
             display: block;
-            // width: 36px;
-            // height: 36px;
             min-width: 0;
 
             .button-inner-wrapper {
@@ -147,14 +146,9 @@
                 -moz-column-gap: 0;
                 column-gap: 0;
             }
-
-            .button-svg {
-                left: -2px;
-                top: 2px;
-            }
         }
 
-        .button.is-expanded {
+        .mobile-button.is-expanded {
             border-bottom-left-radius: 8px;
             border-bottom-right-radius: 8px;
         }
@@ -190,28 +184,27 @@
         }
 
         .svg__icon-close.svg-glyph-close {
-            // TODO
-            position: absolute; // was fixed
+            position: absolute;
             right: 24px;
-            top: 24px; // was bottom: 190px;
+            top: 24px;
 
             z-index: 1;
         }
 
-        :deep(.icon-with-link.is-link-copied) {
-            width: 85%;
-            background-color: $page-blue;
+        // :deep(.icon-with-link.is-link-copied) {
+        //     width: 85%;
+        //     background-color: $page-blue;
 
-            .text {
-                top: 3px;
-            }
-        }
+        //     .text {
+        //         top: 3px;
+        //     }
+        // }
 
-        .dropdown-modal-item {
-            :deep(.icon-with-link):active {
-                background-color: #faf5f4;
-                width: 85%;
-            }
-        }
+        // .dropdown-modal-item {
+        //     :deep(.icon-with-link):active {
+        //         background-color: #faf5f4;
+        //         width: 85%;
+        //     }
+        // }
     }
 }

--- a/src/styles/default/_mobile-drawer.scss
+++ b/src/styles/default/_mobile-drawer.scss
@@ -21,13 +21,6 @@
             column-gap: 8px;
             height: 100%;
         }
-
-        //TODO
-        // :deep(.button-svg) {
-        //     position: relative;
-        //     top: 1px;
-        //     stroke: #{$primary-blue-03};
-        // }
     }
 
     .mobile-button.is-expanded {
@@ -64,46 +57,6 @@
         margin: 0 4px;
     }
 
-    // .dropdown-modal-item {
-    //     :deep(.icon-with-link) {
-    //         .icon-with-link-container {
-    //             gap: var(--space-s);
-    //             padding: 5px 0 3px 5px;
-    //         }
-    //     }
-
-    //     :deep(.icon-with-link.not-smart-link) .text,
-    //     :deep(.icon-with-link) .text {
-    //         align-self: baseline;
-    //     }
-
-    //     :deep(.icon-with-link) .text {
-    //         font-family: "Karbon", Helvetica, Arial, sans-serif;
-    //         font-weight: 500;
-    //         color: $medium-grey;
-    //     }
-
-    //     :deep(.icon-with-link) .link,
-    //     :deep(.icon-with-link.not-smart-link) .text {
-    //         text-decoration: underline;
-    //         text-decoration-thickness: 3px;
-    //         text-underline-offset: 6px;
-    //         -webkit-text-decoration-color: $grey-blue;
-    //         text-decoration-color: $grey-blue;
-    //     }
-
-    //     :deep(.icon-with-link.not-smart-link) {
-    //         width: unset;
-    //     }
-
-    //     :deep(.icon-with-link.is-link-copied) {
-    //         .text {
-    //             position: relative;
-    //             top: 3px;
-    //         }
-    //     }
-    // }
-
     @media #{$has-hover} {
         .mobile-button:hover {
             background-color: #f1f1f1;
@@ -112,27 +65,6 @@
         .svg__icon-close.svg-glyph-close:hover {
             cursor: pointer;
         }
-
-        // :deep(.icon-with-link) .link:hover,
-        // :deep(.icon-with-link.not-smart-link):hover .text {
-        //     -webkit-text-decoration-color: #{$bright-blue};
-        //     text-decoration-color: #{$bright-blue};
-        // }
-
-        // :deep(.icon-with-link) {
-        //     .link:hover {
-        //         text-decoration-thickness: 3px;
-        //         text-underline-offset: 6px;
-        //     }
-        // }
-
-        // :deep(.icon-with-link.not-smart-link):hover {
-
-        //     .text,
-        //     .icon {
-        //         cursor: pointer;
-        //     }
-        // }
     }
 
     @media #{$small} {
@@ -190,21 +122,5 @@
 
             z-index: 1;
         }
-
-        // :deep(.icon-with-link.is-link-copied) {
-        //     width: 85%;
-        //     background-color: $page-blue;
-
-        //     .text {
-        //         top: 3px;
-        //     }
-        // }
-
-        // .dropdown-modal-item {
-        //     :deep(.icon-with-link):active {
-        //         background-color: #faf5f4;
-        //         width: 85%;
-        //     }
-        // }
     }
 }

--- a/src/styles/default/_mobile-drawer.scss
+++ b/src/styles/default/_mobile-drawer.scss
@@ -1,0 +1,217 @@
+.mobile-drawer {
+    display: flex;
+    position: relative;
+
+    .button {
+        display: flex;
+        justify-content: space-between;
+        min-width: 194px;
+        width: 100%;
+        padding: 12px 16px 12px 20px;
+        border-radius: 8px;
+        border: 1px solid #{$primary-blue-03};
+        font-weight: 500;
+        font-size: 18px;
+        background-color: $white;
+        color: #{$primary-blue-03};
+
+        .button-inner-wrapper {
+            display: flex;
+            -moz-column-gap: 8px;
+            column-gap: 8px;
+            height: 100%;
+        }
+
+        .button-svg {
+            position: relative;
+            top: 1px;
+            stroke: #{$primary-blue-03};
+        }
+    }
+
+    .button.is-expanded {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
+    .is-expanded.toggle-triangle-icon>svg {
+        transform: rotate(180deg);
+        position: relative;
+        bottom: 2px;
+    }
+
+    .button-dropdown-modal-wrapper {
+        display: flex;
+        flex-direction: column;
+        row-gap: 14px;
+        padding: 24px 20px 20px 20px;
+        min-height: auto;
+        min-width: 186px;
+        width: 96%;
+        margin: 0 auto;
+        border-width: 0 1px 1px 1px;
+        border-style: solid;
+        border-color: #{$primary-blue-03};
+        border-bottom-left-radius: 8px;
+        border-bottom-right-radius: 8px;
+        background-color: $white;
+    }
+
+    .button-dropdown-modal-wrapper.is-expanded {
+        position: absolute;
+        width: auto;
+        margin: 0 4px;
+    }
+
+    .dropdown-modal-item {
+        :deep(.icon-with-link) {
+            .icon-with-link-container {
+                gap: var(--space-s);
+                padding: 5px 0 3px 5px;
+            }
+        }
+
+        :deep(.icon-with-link.not-smart-link) .text,
+        :deep(.icon-with-link) .text {
+            align-self: baseline;
+        }
+
+        :deep(.icon-with-link) .text {
+            font-family: "Karbon", Helvetica, Arial, sans-serif;
+            font-weight: 500;
+            color: $medium-grey;
+        }
+
+        :deep(.icon-with-link) .link,
+        :deep(.icon-with-link.not-smart-link) .text {
+            text-decoration: underline;
+            text-decoration-thickness: 3px;
+            text-underline-offset: 6px;
+            -webkit-text-decoration-color: $grey-blue;
+            text-decoration-color: $grey-blue;
+        }
+
+        :deep(.icon-with-link.not-smart-link) {
+            width: unset;
+        }
+
+        :deep(.icon-with-link.is-link-copied) {
+            .text {
+                position: relative;
+                top: 3px;
+            }
+        }
+    }
+
+    @media #{$has-hover} {
+        .button:hover {
+            background-color: #f1f1f1;
+        }
+
+        .svg__icon-close.svg-glyph-close:hover {
+            cursor: pointer;
+        }
+
+        :deep(.icon-with-link) .link:hover,
+        :deep(.icon-with-link.not-smart-link):hover .text {
+            -webkit-text-decoration-color: #{$bright-blue};
+            text-decoration-color: #{$bright-blue};
+        }
+
+        :deep(.icon-with-link) {
+            .link:hover {
+                text-decoration-thickness: 3px;
+                text-underline-offset: 6px;
+            }
+        }
+
+        :deep(.icon-with-link.not-smart-link):hover {
+
+            .text,
+            .icon {
+                cursor: pointer;
+            }
+        }
+    }
+
+    @media #{$small} {
+        .button {
+            display: block;
+            // width: 36px;
+            // height: 36px;
+            min-width: 0;
+
+            .button-inner-wrapper {
+                justify-content: center;
+                align-items: center;
+                -moz-column-gap: 0;
+                column-gap: 0;
+            }
+
+            .button-svg {
+                left: -2px;
+                top: 2px;
+            }
+        }
+
+        .button.is-expanded {
+            border-bottom-left-radius: 8px;
+            border-bottom-right-radius: 8px;
+        }
+
+        .button-text,
+        .toggle-triangle-icon {
+            display: none;
+        }
+
+        .dropdown-overlay.is-expanded {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: rgba(0, 0, 0, 0.5);
+            z-index: 1;
+        }
+
+        .button-dropdown-modal {
+            position: fixed;
+            width: 100%;
+            left: 0;
+            bottom: 0;
+            height: auto;
+            z-index: 1;
+        }
+
+        .button-dropdown-modal-wrapper.is-expanded {
+            width: 100%;
+            position: static;
+            margin: 0;
+        }
+
+        .svg__icon-close.svg-glyph-close {
+            // TODO
+            position: absolute; // was fixed
+            right: 24px;
+            top: 24px; // was bottom: 190px;
+
+            z-index: 1;
+        }
+
+        :deep(.icon-with-link.is-link-copied) {
+            width: 85%;
+            background-color: $page-blue;
+
+            .text {
+                top: 3px;
+            }
+        }
+
+        .dropdown-modal-item {
+            :deep(.icon-with-link):active {
+                background-color: #faf5f4;
+                width: 85%;
+            }
+        }
+    }
+}

--- a/src/styles/ftva/_button-dropdown.scss
+++ b/src/styles/ftva/_button-dropdown.scss
@@ -1,12 +1,11 @@
 .ftva.button-dropdown {
-    .button {
-        border-color: $medium-grey;
-        color: $medium-grey;
-
+    // .button {
+    //     border-color: $medium-grey;
+    //     color: $medium-grey;
         .button-svg {
             stroke: unset;
         }
-    }
+    // }
 
     .toggle-triangle-icon {
         :deep(.svg__fill--accent-blue) {

--- a/src/styles/ftva/_button-dropdown.scss
+++ b/src/styles/ftva/_button-dropdown.scss
@@ -1,11 +1,7 @@
 .ftva.button-dropdown {
-    // .button {
-    //     border-color: $medium-grey;
-    //     color: $medium-grey;
-        .button-svg {
-            stroke: unset;
-        }
-    // }
+    .button-svg {
+        stroke: unset;
+    }
 
     .toggle-triangle-icon {
         :deep(.svg__fill--accent-blue) {

--- a/src/styles/ftva/_mobile-drawer.scss
+++ b/src/styles/ftva/_mobile-drawer.scss
@@ -1,5 +1,5 @@
 .ftva.mobile-drawer {
-    .button {
+    .mobile-button {
         border-color: $medium-grey;
         color: $medium-grey;
 

--- a/src/styles/ftva/_mobile-drawer.scss
+++ b/src/styles/ftva/_mobile-drawer.scss
@@ -1,0 +1,23 @@
+.ftva.mobile-drawer {
+    .button {
+        border-color: $medium-grey;
+        color: $medium-grey;
+
+        .button-svg {
+            stroke: unset;
+        }
+    }
+
+    .toggle-triangle-icon {
+        :deep(.svg__fill--accent-blue) {
+            fill: $medium-grey;
+        }
+    }
+
+    .button-dropdown-modal-wrapper {
+        border-left-width: 1px;
+        border-right-width: 1px;
+        border-bottom-width: 1px;
+        border-color: $medium-grey;
+    }
+}


### PR DESCRIPTION
Connected to [APPS-3045](https://jira.library.ucla.edu/browse/APPS-3045)

**Component Created:** MobileDrawer.vue

**Stories:** ~/stories/MobileDrawer.stories.js

**Spec:** ~/stories/MobileDrawer.spec.js

**Notes:**

Work done:
- [X] Move desired functionality into new component **MobileDrawer.vue**, which has slots for button content and drawer content
- [X] Refactor ButtonDropdown.vue to use MobileDrawer.vue (@tinuola reviewed this part of the work to ensure ButtonDropdown looked the same, thanks Tinu)
- [X] Refactor DateFilter.vue to use MobileDrawer.vue
- [X] Add new button styles (@tieserena will send)

Not done:
*factor <VueDatePicker> component into its own file*
DateFilter.vue had to be duplicated in the template to get it to fit into our mobile designs (it shows in one spot if we are on mobile, a different spot if we aren't). 

To prevent duplicating the code, I had wanted to refactor our implementation to put the <VueDatePicker> code in its own component, thus making it easier/shorter to duplicate that component. However, I stopped because the MobileDrawer component needs to pass a removeOverlay method to a specific button on the VueDatePicker to allow it to close the drawer, and I could not figure out how to pass this slot meothd through that many layers without the VueDatePicker button and the MobileDrawer being in the same file. 

I'm happy to go back to it if anyone has ideas. 

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
ftva-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-3045]: https://uclalibrary.atlassian.net/browse/APPS-3045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ