### PR TITLE
feat: APPS-3067 add ishighlighted prop to BlockTag.vue

### DIFF
--- a/src/lib-components/BlockTag.vue
+++ b/src/lib-components/BlockTag.vue
@@ -6,7 +6,7 @@ import { computed, defineAsyncComponent } from 'vue'
 import { useTheme } from '@/composables/useTheme'
 
 // PROPS & DATA
-const { label, iconName, isSecondary } = defineProps({
+const { label, iconName, isSecondary, isHighlighted } = defineProps({
   label: {
     type: String,
     default: '' // Text displayed on the tag or pill.
@@ -19,11 +19,10 @@ const { label, iconName, isSecondary } = defineProps({
     type: Boolean,
     default: false
   },
-  // TODO ADD PROP TO HANDLE isSelected prop
-  // isSelected: {
-  //   type: Boolean,
-  //   default: false
-  // },
+  isHighlighted: {
+    type: Boolean,
+    default: false
+  },
 })
 
 // THEME
@@ -63,7 +62,7 @@ const BlockTagIcons: any = {
 }
 
 const classes = computed(() => {
-  return ['block-tag', theme?.value || '', isSecondary ? '' : 'primary']
+  return ['block-tag', theme?.value || '', isSecondary ? '' : 'primary', isHighlighted ? 'highlighted' : '']
 })
 </script>
 

--- a/src/stories/BlockTag.stories.js
+++ b/src/stories/BlockTag.stories.js
@@ -1,6 +1,20 @@
 import { computed } from 'vue'
 import BlockTag from '@/lib-components/BlockTag'
 
+/**
+ * A component to display a non-interactive tag with a label and an optional icon. <br>
+ * <sub>(For an interactive tag that can be clicked to remove it from a list, try BlockRemoveSearchFilter). </sub>
+ *
+ * Props:
+ * - <b>label</b>: A string representing the text to display in the tag
+ * - <b>iconName</b>: A string representing the name of the icon to display in the tag. <br>
+ * <sub>Valid names: <i>SvgIconGuest, SvgIconFilm, SvgIconTV, SvgIconFilmreel, SvgIconDigital, SvgIconOnline, SvgIconFamilyFriendly</i></sub>
+ * - <b>isSecondary</b>: A boolean value to determine if the tag is styled with primary or secondary styles
+ *
+ * Props added 2024-11-19:
+ *
+ * - <b>isHighlighted</b>: A boolean value to determine if the tag is styled with highlight styles
+ */
 export default {
   title: 'BLOCK / Tag',
   component: BlockTag
@@ -104,25 +118,25 @@ export function SecondaryFTVANoIcon() {
   }
 }
 
-// TODO
-// export function SecondaryFTVASelected() {
-//   return {
-//     data() {
-//       return {
-//         ...ftvamockwLinkLabel
-//       }
-//     },
-//     provide() {
-//       return {
-//         theme: computed(() => 'ftva'),
-//       }
-//     },
-//     components: { BlockTag },
-//     template: `
-//     <block-tag
-//         :label="label"
-//         isSecondary="true"
-//     />
-//   `,
-//   }
-// }
+export function SecondaryFTVAHighlighted() {
+  return {
+    data() {
+      return {
+        ...ftvamock
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { BlockTag },
+    template: `
+    <block-tag
+        :label="label"
+        isSecondary="true"
+        isHighlighted="true"
+    />
+  `,
+  }
+}

--- a/src/styles/default/_block-tag.scss
+++ b/src/styles/default/_block-tag.scss
@@ -15,4 +15,15 @@
     .label {
         color: #{$primary-blue-05};
     }
+
+    // primary colors & styles
+    &.highlighted {
+        color: #{$white};
+        background-color: var(--color-default-cyan-0);
+        border: none;
+
+        .label {
+            color: #{$white};
+        }
+    }
 }

--- a/src/styles/ftva/_block-tag.scss
+++ b/src/styles/ftva/_block-tag.scss
@@ -1,12 +1,12 @@
 .ftva.block-tag {
     @include ftva-tags;
+     // secondary colors and styles
     background-color: transparent;
     border: 1.5px solid $subtitle-grey;
     border-radius: 16px;
     color: $subtitle-grey;
     padding: 8px 16px;
     height: 32px;
-    // secondary colors and styles
     // focused and disabled,styled in blockRemoveSearchFilter
 
     .label {
@@ -35,7 +35,12 @@
         }
     }
 
-    &.is-selected {
+    &.highlighted {
         background-color: $page-blue;
+        // color: #{$white};
+        // border: none;  
+        .label {
+            // color: #{$white};
+        }
     }
 }


### PR DESCRIPTION
Connected to [APPS-3067](https://jira.library.ucla.edu/browse/APPS-3067)

**Component Edited:** BlockTag.vue

**Stories:** ~/stories/BlockTag.stories.js


**Notes:**

In progress

- Added prop 'isHighlighted' to allow the parent component of blocktag to highlight tags. 
- Checking accessibility of blocktag

**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [ ] I used a conventional commit message
-   [ ] I assigned myself to this PR
