### PR TITLE
feat: APPS-3072 remove icon in BlockTag from BlockCardThreeColumn

### DIFF
--- a/src/lib-components/BlockCardThreeColumn.vue
+++ b/src/lib-components/BlockCardThreeColumn.vue
@@ -140,7 +140,6 @@ const parsedDateFormat = computed(() => {
           >
             <BlockTag
               :label="label.title"
-              icon-name="SvgIconGuest"
               :is-secondary="true"
             />
           </div>


### PR DESCRIPTION
Connected to [APPS-3072](https://jira.library.ucla.edu/browse/APPS-3072)

**Component Edited:** BlockCardThreeColumn.vue

**Notes:**

BlockCardThreeColumn will no longer put the guest-speaker icon in tags it renders

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [ ] I used a conventional commit message
-   [ ] I assigned myself to this PR
