### PR TITLE
fix: APPS-3074 add watchers for pagination reactivity

### DIFF
--- a/src/lib-components/SectionPagination.vue
+++ b/src/lib-components/SectionPagination.vue
@@ -118,11 +118,11 @@ const isNotLastPage = computed(() => {
 
 // WATCHERS - we use watch instead of computed because we are using variables derived from props during render
 // note: this ensures the component will update when props change
-watch(() => pages, (newPageVal, oldPageVal) => {
+watch(() => pages, () => {
   // regenerate pages when pages change
   generateLeftPages()
 }, { immediate: true })
-watch(() => initialCurrentPage, (newVal, oldVal) => {
+watch(() => initialCurrentPage, (newVal) => {
   // set current page when initialCurrentPage changes
   currPage.value = newVal as number
 }, { immediate: true })

--- a/src/lib-components/SectionPagination.vue
+++ b/src/lib-components/SectionPagination.vue
@@ -116,6 +116,17 @@ const isNotLastPage = computed(() => {
   return (initialCurrentPage && pages) && currPage?.value !== pages
 })
 
+// WATCHERS - we use watch instead of computed because we are using variables derived from props during render
+// note: this ensures the component will update when props change
+watch(() => pages, (newPageVal, oldPageVal) => {
+  // regenerate pages when pages change
+  generateLeftPages()
+}, { immediate: true })
+watch(() => initialCurrentPage, (newVal, oldVal) => {
+  // set current page when initialCurrentPage changes
+  currPage.value = newVal as number
+}, { immediate: true })
+
 onMounted(() => {
   // legacy implementation does not require any onMounted logic
   if (!initialCurrentPage || !pages)

--- a/src/stories/SectionPagination.stories.js
+++ b/src/stories/SectionPagination.stories.js
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import SectionPagination from '@/lib-components/SectionPagination'
 
 /**
@@ -49,6 +49,8 @@ export function WithPagesAndCurrentPage() {
   }
 }
 
+// this story uses an async fetch to get the total number of pages
+// like the FTVA event listing page
 export function FTVA() {
   return {
     components: { SectionPagination },
@@ -57,6 +59,25 @@ export function FTVA() {
         theme: computed(() => 'ftva'),
       }
     },
-    template: '<section-pagination :pages="23" :initialCurrentPage="14" />',
+    setup() {
+      // similar to ftva event listing page logic
+      const totalPages = ref(0)
+
+      // Set totalPages.value asynchronously
+      const fetchTotalPages = async () => {
+        // Mocking an async fetch call
+        const response = await new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(20)
+          }, 1000)
+        })
+        totalPages.value = response
+      }
+
+      fetchTotalPages()
+
+      return { totalPages }
+    },
+    template: '<section-pagination :pages="totalPages" :initialCurrentPage="6" />'
   }
 }


### PR DESCRIPTION
Connected to [APPS-3074](https://jira.library.ucla.edu/browse/APPS-3074)

**Component Edited:** SectionPagination.vue

**Stories Updated:** ~/stories/SectionPagination.stories.js

**Notes:**

@pghorpade noticed during implementation in the FTVA project that the `SectionPagination.vue` component was not mounting correctly. 

Upon investigation, this was because we only use the props `pages` & ` initialCurrentPage` on initialization of the component, not in the render template itself. This PR fixes that.

- [X] added a story to asynchronously return the `pages` value to re-create this bug
- [X] added watchers to `SectionPagination.vue` to re-trigger relevant bits of logic when props update

No visual changes were made

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-3074]: https://uclalibrary.atlassian.net/browse/APPS-3074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ