### PR TITLE
chore: APPS-3112 unify styles between datefilter and filterdropdown

### DIFF
--- a/src/lib-components/DateFilter.vue
+++ b/src/lib-components/DateFilter.vue
@@ -228,9 +228,9 @@ onMounted(() => {
     >
       <template #input-icon>
         <SvgIconFTVACalender />
-        <span :class="inputIconClass">
+        <!-- <span :class="inputIconClass">
           <SvgIconFTVADropTriangle />
-        </span>
+        </span> -->
       </template>
 
       <template #clear-icon="{ clear }">
@@ -485,6 +485,9 @@ onMounted(() => {
       &:hover, &:focus {
         border-color: #ddd;
       }
+      &:hover {
+        background-color: #f1f1f1;
+      }
 
       @media #{$small} {
         padding-inline-start: 57px;
@@ -501,7 +504,7 @@ onMounted(() => {
 
       svg {
         position: absolute;
-        right: 40px;
+        right: 30px;
         transform: translateY(-50%);
 
         @media #{$small} {

--- a/src/lib-components/DateFilter.vue
+++ b/src/lib-components/DateFilter.vue
@@ -482,6 +482,9 @@ onMounted(() => {
       font-size: 18px;
       color: $medium-grey;
       border-radius: 8px;
+      &:hover, &:focus {
+        border-color: #ddd;
+      }
 
       @media #{$small} {
         padding-inline-start: 57px;
@@ -819,7 +822,7 @@ onMounted(() => {
     .mobile-button {
       width: 166px;
       padding: 6px;
-      border: none;
+      // border: none;
 
       &:active {
         color: white;

--- a/src/lib-components/DateFilter.vue
+++ b/src/lib-components/DateFilter.vue
@@ -477,9 +477,11 @@ onMounted(() => {
     // Input styling
     :deep(.dp__input) {
       height: 59px;
-      font-family: var(--font-secondary);
+      font-family: var(--font-primary);
+      font-weight: 500;
       font-size: 18px;
       color: $medium-grey;
+      border-radius: 8px;
 
       @media #{$small} {
         padding-inline-start: 57px;
@@ -817,7 +819,8 @@ onMounted(() => {
     .mobile-button {
       width: 166px;
       padding: 6px;
-      border-radius: 4px;
+      // border-radius: 4px;
+      border: none;
 
       &:active {
         color: white;

--- a/src/lib-components/DateFilter.vue
+++ b/src/lib-components/DateFilter.vue
@@ -819,7 +819,6 @@ onMounted(() => {
     .mobile-button {
       width: 166px;
       padding: 6px;
-      // border-radius: 4px;
       border: none;
 
       &:active {

--- a/src/lib-components/FiltersDropdown.vue
+++ b/src/lib-components/FiltersDropdown.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type { PropType } from 'vue'
 import SvgGlyphX from 'ucla-library-design-tokens/assets/svgs/icon-ftva-xtag.svg'
 import SvgFilterIcon from 'ucla-library-design-tokens/assets/svgs/icon-ftva-filter.svg'
+import { useWindowSize } from '@vueuse/core'
 import BlockTag from './BlockTag.vue'
 import ButtonLink from './ButtonLink.vue'
 import MobileDrawer from './MobileDrawer.vue'
@@ -57,8 +58,15 @@ function onDoneClick() {
 
 // THEME
 const theme = useTheme()
+const isMobile = ref(false)
 const parsedClasses = computed(() => {
   return ['filters-dropdown', theme?.value || '']
+})
+onMounted(() => {
+  const { width } = useWindowSize()
+  watch(width, (newWidth) => {
+    isMobile.value = newWidth <= 750
+  }, { immediate: true })
 })
 </script>
 
@@ -67,7 +75,12 @@ const parsedClasses = computed(() => {
     <MobileDrawer>
       <template #buttonLabel>
         <div class="filter-summary">
-          Filters ({{ numOfSelectedFilters }} selected )
+          <template v-if="!isMobile">
+            Filters ({{ numOfSelectedFilters }} selected )
+          </template>
+          <template v-else>
+            Filters
+          </template>
         </div>
         <span class="icon-svg">
           <SvgFilterIcon aria-hidden="true" />
@@ -82,8 +95,8 @@ const parsedClasses = computed(() => {
               <label v-for="option in group.options" :key="option" class="pill-label">
                 <!-- Hidden checkbox for managing selection & screen-reader user interaction -->
                 <input
-                  :id="option" v-model="selectedFilters[group.searchField]" type="checkbox" class="pill-checkbox" :name="option"
-                  :value="option"
+                  :id="option" v-model="selectedFilters[group.searchField]" type="checkbox" class="pill-checkbox"
+                  :name="option" :value="option"
                 >
                 <!-- BlockTag component for display -->
                 <BlockTag :label="option" :is-secondary="true">
@@ -96,7 +109,10 @@ const parsedClasses = computed(() => {
             </div>
           </div>
           <div class="action-row">
-            <ButtonLink class="action-row-button select-button" label="Done" icon-name="none" @click="onDoneClick(); removeOverlay();" />
+            <ButtonLink
+              class="action-row-button select-button" label="Done" icon-name="none"
+              @click="onDoneClick(); removeOverlay();"
+            />
             <ButtonLink
               class="action-row-button clear-button" label="Clear" icon-name="icon-close"
               @click="clearFilters"

--- a/src/styles/default/_filters-dropdown.scss
+++ b/src/styles/default/_filters-dropdown.scss
@@ -133,7 +133,7 @@
             width: 166px;
             min-width: unset;
             padding: 6px; 
-            border: none;
+            // border: none;
             .button-inner-wrapper {
                 flex-direction: row-reverse;
                 justify-content: center;

--- a/src/styles/default/_filters-dropdown.scss
+++ b/src/styles/default/_filters-dropdown.scss
@@ -2,6 +2,7 @@
     // Dropdown  Window Size & Input
     :deep(.mobile-button) {
         min-width: 380px;
+        border-color: #ddd;
         .toggle-triangle-icon { 
             path.svg__fill--accent-blue {
                 fill: $accent-blue;
@@ -26,6 +27,9 @@
         margin: auto;
         padding: 24px 30px 30px 30px;
         width: 100%; // filters dropdown grows to container width
+        box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+        border-radius: 0px 0px 10px 10px;
+        border: none;
     }
 
     // Filter Heading
@@ -120,6 +124,19 @@
                 :deep(.svg__stroke--primary-blue-03) {
                     stroke: var(--color-white);
                 }
+            }
+        }
+    }
+
+    @media #{$small} {
+        :deep(.mobile-button) {
+            width: 166px;
+            min-width: unset;
+            padding: 6px; 
+            border: none;
+            .button-inner-wrapper {
+                flex-direction: row-reverse;
+                justify-content: center;
             }
         }
     }

--- a/src/styles/default/_mobile-drawer.scss
+++ b/src/styles/default/_mobile-drawer.scss
@@ -58,12 +58,14 @@
     }
 
     @media #{$has-hover} {
-        .mobile-button:hover {
-            background-color: #f1f1f1;
-        }
+        @media #{$small} {
+            .mobile-button:hover {
+                background-color: #f1f1f1;
+            }
 
-        .svg__icon-close.svg-glyph-close:hover {
-            cursor: pointer;
+            .svg__icon-close.svg-glyph-close:hover {
+                cursor: pointer;
+            }
         }
     }
 

--- a/src/styles/ftva/_filters-dropdown.scss
+++ b/src/styles/ftva/_filters-dropdown.scss
@@ -4,6 +4,9 @@
         &:hover, &:focus {
             border-color: #ddd;
         }
+        &:hover {
+            background-color: #f1f1f1;
+        }
     }
     // Done / Clear Buttons
     .action-row {
@@ -51,10 +54,9 @@
         // Input field / Button on Mobile
         :deep(.mobile-button) {
             border-color: $medium-grey;
-            &:hover,
-                &:focus {
-                    border-color: $medium-grey;
-                }
+            &:hover, &:focus {
+                border-color: $medium-grey;
+            }
             &.is-expanded {
                     color: $accent-blue;
                     border: 2px solid $accent-blue;

--- a/src/styles/ftva/_filters-dropdown.scss
+++ b/src/styles/ftva/_filters-dropdown.scss
@@ -1,4 +1,8 @@
 .ftva.filters-dropdown {
+    :deep(.mobile-button) {
+        border-color: #ddd;
+    }
+    // Done / Clear Buttons
     .action-row {
         .action-row-button {
             color: $accent-blue;
@@ -31,12 +35,23 @@
             color: white;
         }
     }
-    :deep(.svg__icon-close) {
+    .icon-close {
         path {
             stroke: white;
         }
         circle {
             fill: transparent;
+        }
+    }
+
+    @media #{$small} { 
+        // Input field / Button on Mobile
+        .icon-svg {
+            :deep(svg) {
+                path.svg__fill--accent-blue {
+                    fill: $medium-grey;
+                }
+            }
         }
     }
 }

--- a/src/styles/ftva/_filters-dropdown.scss
+++ b/src/styles/ftva/_filters-dropdown.scss
@@ -1,6 +1,9 @@
 .ftva.filters-dropdown {
     :deep(.mobile-button) {
         border-color: #ddd;
+        &:hover, &:focus {
+            border-color: #ddd;
+        }
     }
     // Done / Clear Buttons
     .action-row {
@@ -46,6 +49,21 @@
 
     @media #{$small} { 
         // Input field / Button on Mobile
+        :deep(.mobile-button) {
+            border-color: $medium-grey;
+            &:hover,
+                &:focus {
+                    border-color: $medium-grey;
+                }
+            &.is-expanded {
+                    color: $accent-blue;
+                    border: 2px solid $accent-blue;
+            
+                    path.svg__fill--accent-blue {
+                        fill: $accent-blue;
+                    }
+                }
+        }
         .icon-svg {
             :deep(svg) {
                 path.svg__fill--accent-blue {


### PR DESCRIPTION
Connected to [APPS-3112](https://jira.library.ucla.edu/browse/APPS-3112)

**Notes:**

When implementing filters side by side on event listing page we noticed style differences. This PR will unify the styles between the 2.

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-3112]: https://uclalibrary.atlassian.net/browse/APPS-3112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ