### PR TITLE
fix: APPS-3042 Embedded video height in RichText

### DIFF
--- a/src/styles/default/_rich-text.scss
+++ b/src/styles/default/_rich-text.scss
@@ -68,7 +68,8 @@
 
   :deep(img) {
     height: auto;
-    object-fit: cover;
+    -o-object-fit: cover;
+       object-fit: cover;
     display: inline-block;
   }
 
@@ -111,7 +112,8 @@
   :deep(iframe) {
     width: 100%;
     height: 400px;
-    object-fit: cover;
+    -o-object-fit: cover;
+       object-fit: cover;
   }
 
   :deep(a) {
@@ -259,8 +261,7 @@
 
     :deep(iframe) {
       width: 100%;
-      width: 100%;
-      height: auto;
+      min-height: 100%;
     }
 
     :deep(blockquote) {


### PR DESCRIPTION
Connected to [APPS-3042](https://jira.library.ucla.edu/browse/APPS-3042)

**Component Created:** RichText.vue

**Notes:**
- Updated the height setting for iframe videos embedded in RichText to preserve their height

**Local Nuxt Previews:**
*Before:*
![embedded-iframe_before](https://github.com/user-attachments/assets/c7cbea67-3961-4aa9-9546-b10a3a067df8)

*After:*
![embedded-iframe_after](https://github.com/user-attachments/assets/3ddf764d-e062-499b-a8fe-3e264451fd4c)

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3042]: https://uclalibrary.atlassian.net/browse/APPS-3042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ