### PR TITLE
fix: APPS-3043 Add z-index to dropdown button

### DIFF
--- a/src/styles/default/_button-dropdown.scss
+++ b/src/styles/default/_button-dropdown.scss
@@ -1,4 +1,7 @@
 .button-dropdown {
+    position: relative;
+    z-index: 100;
+
     .button-svg {
         position: relative;
         top: 1px;


### PR DESCRIPTION
Connected to [APPS-3043](https://jira.library.ucla.edu/browse/APPS-3043)

**Component Updated:** ButtonDropdown.vue

**Notes:**
- Fixed page/rich-text content overlaying on top of share button dropdown links

**Local Nuxt Previews:**

![overlay-before](https://github.com/user-attachments/assets/6f921701-eabf-426b-80fc-63bf131f3262)

![overlay-after](https://github.com/user-attachments/assets/834113e1-8b01-430e-87eb-157fd248fed0)

![overlay2-before](https://github.com/user-attachments/assets/62b68397-0029-49f7-ac5f-3bddfbcb7cf6)

![overlay2-after](https://github.com/user-attachments/assets/93829c1a-afe6-4e81-86f0-5b3ec34db058)


**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3043]: https://uclalibrary.atlassian.net/browse/APPS-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ