### PR TITLE
chore: start documenting ftva data structure in stories

### DIFF
--- a/src/lib-components/SectionStaffSubjectLibrarian.vue
+++ b/src/lib-components/SectionStaffSubjectLibrarian.vue
@@ -5,7 +5,43 @@
 import type { PropType } from 'vue'
 
 // TYPESCRIPT
-import type { BlockStaffListItemType } from '@/types/types'
+import type { BlockStaffListItemType, MediaItemType } from '@/types/types'
+export interface FilmographyListItemType {
+  to: string
+  nameLast: string
+  nameFirst: string
+  // jobTitle: string
+  // departments: DepartmentItemType[]
+  // email: string
+  // topics: TopicsItemType[]
+  // alternativeName?: AlternativeNameItemType[]
+  // alternativeFullName?: string
+  // subjectArea?: string
+  // staffName?: string
+  // language?: string
+  // locations?: StaffLocationItemType[]
+  // phone?: string
+  // consultation?: string
+  // academicDepartments?: AcademicDepartmentsItemType[]
+  uri: string
+  image?: MediaItemType
+  // biography?: string
+  // orcid?: string
+  // publications?: string
+  // pronouns?: string
+  slug: string
+  // sectionHandle: string // MAYBE?
+  // subjectLibrarian: boolean
+  // TODO NEW FIELDS - or map below to existing fields somehow
+  titleGeneral: string,
+  description: string,
+  roles: string,
+  year: string,
+  filmLink: {
+    uri: string,
+    slug: string
+  }[]
+}
 
 import BlockStaffSubjectLibrarian from '@/lib-components/BlockStaffSubjectLibrarian.vue'
 

--- a/src/stories/BlockStaffSubjectLibrarian.stories.js
+++ b/src/stories/BlockStaffSubjectLibrarian.stories.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue'
 import BlockStaffSubjectLibrarian from '@/lib-components/BlockStaffSubjectLibrarian'
 
 // Storybook default settings
@@ -127,6 +128,55 @@ export function AlternativeName() {
         item: {
           ...mockAlternativeName,
         },
+      }
+    },
+    components: { BlockStaffSubjectLibrarian },
+    template: `
+      <block-staff-subject-librarian
+        v-bind="item"
+      />
+  `,
+  }
+}
+
+const mockFilm = {
+          image: [
+            {
+              id: "3593326",
+              src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/gay-abel-bey.jpeg",
+              height: 1434,
+              width: 2560,
+              srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/gay-abel-bey.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/gay-abel-bey.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/gay-abel-bey.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/gay-abel-bey.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/gay-abel-bey.jpeg 2560w",
+              alt: null,
+              focalPoint: [
+                0.5,
+                0.5
+              ]
+            }
+          ],
+          titleGeneral: "Associated Film #1 Title",
+          description: "Associated Film #1 Description",
+          roles: "Associated Film #1 Role(s)",
+          year: "1990",
+          filmLink: [
+            {
+              uri: "collections/l-a-rebellion/as-above-so-below",
+              slug: "as-above-so-below"
+            }
+          ]
+}
+export function FTVAFilmography() {
+  return {
+    data() {
+      return {
+        item: {
+          ...mockFilm,
+        },
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
       }
     },
     components: { BlockStaffSubjectLibrarian },

--- a/src/stories/SectionStaffSubjectLibrarian.stories.js
+++ b/src/stories/SectionStaffSubjectLibrarian.stories.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue'
 // Import component
 import SectionStaffSubjectLibrarian from '@/lib-components/SectionStaffSubjectLibrarian'
 
@@ -124,6 +125,83 @@ export function Default() {
   return {
     data() {
       return { items: mockDefault, tableHeaders: tableH }
+    },
+    components: { SectionStaffSubjectLibrarian },
+    template: `
+      <section-staff-subject-librarian
+        :items="items"
+        :tableHeaders="tableHeaders"
+      />
+  `,
+  }
+}
+
+
+const mockFTVAtableHeaders = ['Image', 'Film', 'Role', 'Year']
+// TODO type for this data structure, remove qutoes or paste from BlockStaffSubjectLibrarian
+const mockFTVAfilmdata = [
+  {
+          "image": [
+            {
+              "id": "3593326",
+              "src": "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/gay-abel-bey.jpeg",
+              "height": 1434,
+              "width": 2560,
+              "srcset": "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/gay-abel-bey.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/gay-abel-bey.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/gay-abel-bey.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/gay-abel-bey.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/gay-abel-bey.jpeg 2560w",
+              "alt": null,
+              "focalPoint": [
+                0.5,
+                0.5
+              ]
+            }
+          ],
+          "titleGeneral": "Associated Film #1 Title",
+          "description": "Associated Film #1 Description",
+          "roles": "Associated Film #1 Role(s)",
+          "year": "1990",
+          "filmLink": [
+            {
+              "uri": "collections/l-a-rebellion/as-above-so-below",
+              "slug": "as-above-so-below"
+            }
+          ]
+  },
+  {
+          "image": [
+            {
+              "id": "3593326",
+              "src": "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/gay-abel-bey.jpeg",
+              "height": 1434,
+              "width": 2560,
+              "srcset": "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/gay-abel-bey.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/gay-abel-bey.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/gay-abel-bey.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/gay-abel-bey.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/gay-abel-bey.jpeg 2560w",
+              "alt": null,
+              "focalPoint": [
+                0.5,
+                0.5
+              ]
+            }
+          ],
+          "titleGeneral": "Associated Film #1 Title",
+          "description": "Associated Film #1 Description",
+          "roles": "Associated Film #1 Role(s)",
+          "year": "1990",
+          "filmLink": [
+            {
+              "uri": "collections/l-a-rebellion/as-above-so-below",
+              "slug": "as-above-so-below"
+            }
+          ]
+  }]
+// This component is used to display Filmography data in the FTVA site
+export function FTVAFilmography() {
+  return {
+    data() {
+      return { items: mockFTVAfilmdata, tableHeaders: mockFTVAtableHeaders }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
     },
     components: { SectionStaffSubjectLibrarian },
     template: `


### PR DESCRIPTION
Connected to [APPS-3089](https://jira.library.ucla.edu/browse/APPS-3089)

**Component(s) Updated:** BlockStaffSubjectLibrarian.vue, SectionStaffSubjectLibrarian.vue, 

**Stories:** ~/stories/BlockStaffSubjectLibrarian.stories.js, ~/stories/SectionStaffSubjectLibrarian.stories.js, 


**Notes:**

This makes some changes to the BlockStaffSubjectLibrarian component to allow us to use it for Filmography data for the FTVA website. 

In Progress.

**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [ ] I used a conventional commit message
-   [X] I assigned myself to this PR
