### PR TITLE
fix: Add attribute inheritance when component has multiple root nodes

### DIFF
--- a/src/lib-components/TabList.vue
+++ b/src/lib-components/TabList.vue
@@ -198,6 +198,7 @@ function animateTabGlider(elem: HTMLElement, hasInitialWidth: boolean) {
   <div
     :class="[classes, alignment]"
     role="tabs"
+    v-bind="$attrs"
   >
     <!-- Slot: Dropdown Filters -->
     <div


### PR DESCRIPTION
Connected to [APPS-3118](https://jira.library.ucla.edu/browse/APPS-3118)

**Component updated:** TabList.vue

When refactoring the duplicate scrolling and moving the sticky on tablist we saw this warning in console

[Vue warn]: Extraneous non-props attributes (class) were applied to component but could not be automatically inherited because component renders multiple root nodes.

https://vuejs.org/guide/components/attrs#attribute-inheritance-on-multiple-root-nodes

[APPS-3118]: https://uclalibrary.atlassian.net/browse/APPS-3118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ