### PR TITLE
feat: APPS-3107 create ftva variation of block card with image and card meta component for the article listing page

### DIFF
--- a/src/lib-components/BlockCardWithImage.vue
+++ b/src/lib-components/BlockCardWithImage.vue
@@ -1,7 +1,4 @@
-<script
-  setup
-  lang="ts"
->
+<script setup lang="ts">
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import type { PropType } from 'vue'
@@ -165,14 +162,19 @@ const parsedDateFormat = computed(() => {
       :language="language"
       :section-handle="sectionHandle"
       :date-created="dateCreated"
-    />
+    >
+      <template #title>
+        <slot name="description" />
+      </template>
+
+      <template #description>
+        <slot name="description" />
+      </template>
+    </CardMeta>
   </li>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 @import "@/styles/default/_block-card-with-image.scss";
 @import "@/styles/ftva/_block-card-with-image.scss";
 </style>

--- a/src/lib-components/BlockCardWithImage.vue
+++ b/src/lib-components/BlockCardWithImage.vue
@@ -116,6 +116,7 @@ const classes = computed(() => {
     theme?.value || ''
   ]
 })
+
 // dates are formatted in the short format for ftva only
 const parsedDateFormat = computed(() => {
   return theme?.value === 'ftva' ? 'short' : 'long'

--- a/src/lib-components/BlockCardWithImage.vue
+++ b/src/lib-components/BlockCardWithImage.vue
@@ -164,7 +164,7 @@ const parsedDateFormat = computed(() => {
       :date-created="dateCreated"
     >
       <template #title>
-        <slot name="description" />
+        <slot name="title" />
       </template>
 
       <template #description>

--- a/src/lib-components/BlockStaffSubjectLibrarian.vue
+++ b/src/lib-components/BlockStaffSubjectLibrarian.vue
@@ -152,7 +152,7 @@ const classes = computed(() => {
       </div>
     </td>
     <template v-if="props.numExtraCells !== 0">
-      <td v-for="i in props.numExtraCells" :class="`column-${i}`" :key="i">
+      <td v-for="i in props.numExtraCells" :key="i" :class="`column-${i}`">
         <slot :name="`column${i}`" />
       </td>
     </template>

--- a/src/lib-components/BlockStaffSubjectLibrarian.vue
+++ b/src/lib-components/BlockStaffSubjectLibrarian.vue
@@ -103,27 +103,47 @@ const classes = computed(() => {
 <template>
   <tr :class="classes">
     <!-- SUBJECT AREA -->
-    <td v-if="subjectArea || nameFirst" class="academic-department">
+    <td
+      v-if="subjectArea || nameFirst"
+      class="academic-department"
+    >
       {{ subjectArea }}
     </td>
 
     <!-- NAME -->
-    <td v-if="nameFirst || nameLast" class="librarian-block">
+    <td
+      v-if="nameFirst || nameLast"
+      class="librarian-block"
+    >
       <SmartLink
-        v-if="props.alternativeName.length === 0 || props.alternativeName === null" :to="to"
+        v-if="props.alternativeName.length === 0 || props.alternativeName === null"
+        :to="to"
         class="staff-name"
       >
         {{ parsedStaffName }}
       </SmartLink>
 
-      <SmartLink v-else :to="to" class="staff-name">
+      <SmartLink
+        v-else
+        :to="to"
+        class="staff-name"
+      >
         {{ parsedStaffName }}
-        <span v-if="props.alternativeName && props.alternativeName != null" :lang="parsedLanguage">
+        <span
+          v-if="props.alternativeName && props.alternativeName != null"
+          :lang="parsedLanguage"
+        >
           {{ parsedAlternativeFullName }}</span>
       </SmartLink>
-      <div class="job-title" v-html="jobTitle" />
+      <div
+        class="job-title"
+        v-html="jobTitle"
+      />
 
-      <ul v-if="departments.length" class="departments">
+      <ul
+        v-if="departments.length"
+        class="departments"
+      >
         <li class="department">
           {{ lastDepartment }}
         </li>
@@ -131,28 +151,56 @@ const classes = computed(() => {
 
       <div v-if="locations.length">
         <IconWithLink
-          v-for=" location in locations " :key="`location-${location.id}`" :text="location.title ?? ''"
-          icon-name="svg-icon-location" :to="`/${location.to}`"
+          v-for=" location in locations "
+          :key="`location-${location.id}`"
+          :text="location.title ?? ''"
+          icon-name="svg-icon-location"
+          :to="`/${location.to}`"
         />
       </div>
     </td>
 
     <!-- CONTACT INFO -->
-    <td v-if="email || nameFirst" class="contact-info">
+    <td
+      v-if="email || nameFirst"
+      class="contact-info"
+    >
       <div class="email">
-        <IconWithLink :text="email" icon-name="svg-icon-email" :to="`mailto:${email}`" />
+        <IconWithLink
+          :text="email"
+          icon-name="svg-icon-email"
+          :to="`mailto:${email}`"
+        />
       </div>
 
-      <div v-if="phone" class="phone">
-        <IconWithLink :text="phone" icon-name="svg-icon-phone" :to="`tel:${phone}`" />
+      <div
+        v-if="phone"
+        class="phone"
+      >
+        <IconWithLink
+          :text="phone"
+          icon-name="svg-icon-phone"
+          :to="`tel:${phone}`"
+        />
       </div>
 
-      <div v-if="consultation" class="consultation">
-        <IconWithLink text="Book a consultation" icon-name="svg-icon-consultation" :to="consultation" />
+      <div
+        v-if="consultation"
+        class="consultation"
+      >
+        <IconWithLink
+          text="Book a consultation"
+          icon-name="svg-icon-consultation"
+          :to="consultation"
+        />
       </div>
     </td>
     <template v-if="props.numExtraCells !== 0">
-      <td v-for="i in props.numExtraCells" :key="i" :class="`column-${i}`">
+      <td
+        v-for="i in props.numExtraCells"
+        :class="`column-${i}`"
+        :key="i"
+      >
         <slot :name="`column${i}`" />
       </td>
     </template>

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -22,6 +22,7 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  // the data is often an array that needs to be combined on the page into one string
   category: {
     type: String,
     default: '',
@@ -220,7 +221,33 @@ const classes = computed(() => {
     />
 
     <div
-      v-if="(bylineOne || bylineTwo) || dateCreated"
+      v-if="$slots.postdate"
+      class="schedule-item date-created"
+    >{{ parsedDateCreated }}
+      <slot name="postdate" />
+    </div>
+
+    <div
+      v-if="
+        (!bylineOne || !bylineTwo)
+        && dateCreated"
+      class="schedule-item date-created"
+    >
+      <div
+        v-if="dateCreated"
+        class="schedule-item date-created"
+      >
+        {{ parsedDateCreated }}
+      </div>
+    </div>
+
+    <div
+      v-if="
+        (bylineOne
+          ||
+          bylineTwo)
+        &&
+        dateCreated"
       class="byline-group"
     >
       <div

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -223,14 +223,15 @@ const classes = computed(() => {
     <div
       v-if="$slots.postdate"
       class="schedule-item date-created"
-    >{{ parsedDateCreated }}
+    >
+      {{ parsedDateCreated }}
       <slot name="postdate" />
     </div>
 
     <div
       v-if="
         (!bylineOne || !bylineTwo)
-        && dateCreated"
+          && dateCreated"
       class="schedule-item date-created"
     >
       <div
@@ -244,10 +245,8 @@ const classes = computed(() => {
     <div
       v-if="
         (bylineOne
-          ||
-          bylineTwo)
-        &&
-        dateCreated"
+          || bylineTwo)
+          && dateCreated"
       class="byline-group"
     >
       <div

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -1,7 +1,4 @@
-<script
-  setup
-  lang="ts"
->
+<script setup lang="ts">
 import { computed, defineAsyncComponent } from 'vue'
 
 import format from 'date-fns/format'
@@ -166,7 +163,10 @@ const classes = computed(() => {
 
 <template>
   <div :class="classes">
-    <div v-if="$slots.linkedcategoryslot" class="linked-category">
+    <div
+      v-if="$slots.linkedcategoryslot"
+      class="linked-category"
+    >
       <slot name="linkedcategoryslot" />
     </div>
 
@@ -175,6 +175,15 @@ const classes = computed(() => {
       class="category"
       v-html="category"
     />
+
+    <!-- Named slot for title -->
+    <div
+      v-if="$slots.title"
+      class="custom-title"
+    >
+      <slot name="title" />
+    </div>
+
     <SmartLink
       v-if="to"
       :link-target="parsedTarget"
@@ -195,6 +204,14 @@ const classes = computed(() => {
       class="title-no-link"
       v-html="title"
     />
+
+    <!-- Named slot for description -->
+    <div
+      v-if="$slots.description"
+      class="custom-description"
+    >
+      <slot name="description" />
+    </div>
 
     <RichText
       v-if="guestSpeaker"
@@ -296,10 +313,7 @@ const classes = computed(() => {
   </div>
 </template>
 
-<style
-  lang="scss"
-  scoped
->
+<style lang="scss" scoped>
 @import "@/styles/default/_card-meta.scss";
 @import "@/styles/ftva/_card-meta.scss";
 </style>

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -221,24 +221,7 @@ const classes = computed(() => {
     />
 
     <div
-      v-if="
-        (!bylineOne || !bylineTwo)
-          && dateCreated"
-      class="schedule-item date-created"
-    >
-      <div
-        v-if="dateCreated"
-        class="schedule-item date-created"
-      >
-        {{ parsedDateCreated }}
-      </div>
-    </div>
-
-    <div
-      v-if="
-        (bylineOne
-          || bylineTwo)
-          && dateCreated"
+      v-if="(bylineOne || bylineTwo) || dateCreated"
       class="byline-group"
     >
       <div

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -223,7 +223,7 @@ const classes = computed(() => {
     <div
       v-if="
         (!bylineOne || !bylineTwo)
-        && dateCreated"
+          && dateCreated"
       class="schedule-item date-created"
     >
       <div
@@ -238,7 +238,7 @@ const classes = computed(() => {
       v-if="
         (bylineOne
           || bylineTwo)
-        && dateCreated"
+          && dateCreated"
       class="byline-group"
     >
       <div

--- a/src/lib-components/CardMeta.vue
+++ b/src/lib-components/CardMeta.vue
@@ -221,17 +221,9 @@ const classes = computed(() => {
     />
 
     <div
-      v-if="$slots.postdate"
-      class="schedule-item date-created"
-    >
-      {{ parsedDateCreated }}
-      <slot name="postdate" />
-    </div>
-
-    <div
       v-if="
         (!bylineOne || !bylineTwo)
-          && dateCreated"
+        && dateCreated"
       class="schedule-item date-created"
     >
       <div
@@ -246,7 +238,7 @@ const classes = computed(() => {
       v-if="
         (bylineOne
           || bylineTwo)
-          && dateCreated"
+        && dateCreated"
       class="byline-group"
     >
       <div

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -81,7 +81,7 @@ LongTitle.args = {
 export const TallImage = Template.bind({})
 TallImage.args = {
   title: 'Test Other Image Sizes',
-  image: { ...API.image, src: 'https://via.placeholder.com/1080x1920', height: 1920, width: 1920, },
+  image: { ...API.image, src: 'https://placehold.co/1080x1920', height: 1920, width: 1920, },
   imageAspectRatio: 150
 }
 
@@ -122,7 +122,7 @@ FTVAItemsNoImage.args = {
 
 export const FTVAItemsPostedDate = Template.bind({})
 FTVAItemsPostedDate.args = {
-  image: null,
+  image: API.image,
   title: 'Black Perspectives on Local L.A. TV',
   category: null,
   theme: 'ftva',
@@ -139,24 +139,12 @@ FTVAItemsPostedDate.args = {
 }
 
 const mockCustomTitleAndDesription = {
-  title: "Preserving “In Transit: The Chinese in California”",
-  postDate: "2024-05-07T13:00:00-07:00",
-  ftvaHomepageDescription: "<p>In the summer of 2023, I had the chance to select and restore a student film as part of the UCLA Student Film Initiative Internship: The Present Preserving the Past.</p>",
-  uri: "blog/preserving-in-transit-the-chinese-in-california",
-  ftvaImage: [
-    {
-      id: "3619987",
-      src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg",
-      height: 1813,
-      width: 2560,
-      srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w",
-      alt: null,
-      focalPoint: [
-        0.5,
-        0.5
-      ]
-    }
-  ]
+  category: 'Interview, People',
+  title: '<h3>Preserving <em>In <strong>Transit</strong>:</em> The Chinese in California</h3>',
+  postDate: '2024-05-07T13:00:00-07:00',
+  ftvaHomepageDescription: '<p>Three alumni’s student films, made in the 1970s-1980s, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film & Television Archive staff.</p>',
+  uri: 'blog/preserving-in-transit-the-chinese-in-california',
+  image: API.image,
 }
 
 function TemplateFTVACustomTitleDescription(args) {
@@ -174,22 +162,23 @@ function TemplateFTVACustomTitleDescription(args) {
     },
     components: { BlockCardWithImage },
     template: `
-    <block-card-with-image
-      :image="image"
-      :to="uri"
-      :category="category"
-      :start-date="postDate"
-      :image-aspect-ratio="imageAspectRatio"
-      >
-      <template #title>
-        <RichText v-html="title" />
-      </template>
+      <block-card-with-image
+        :image="image"
+        :to="uri"
+        :category="category"
+        :dateCreated="postDate"
+        :image-aspect-ratio="imageAspectRatio"
+        >
 
-      <template #description>
-        <RichText v-html="ftvaHomepageDescription" />
-      </template>
-    </block-card-with-image>
-`,
+        <template #title>
+          <RichText v-html="title" />
+        </template>
+
+        <template #description>
+          <RichText v-html="ftvaHomepageDescription" />
+        </template>
+      </block-card-with-image>
+    `,
   }
 }
 

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -124,7 +124,7 @@ FTVAItemsNoImage.args = {
 
 export const FTVAItemsPostedDate = Template.bind({})
 FTVAItemsPostedDate.args = {
-  image: null,,
+  image: null,
   title: 'Black Perspectives on Local L.A. TV',
   category: null,
   theme: 'ftva',

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -197,7 +197,7 @@ function TemplateFTVACustomTitleDescription(args) {
   return {
     data() {
       return {
-        ...mock,
+        ...mockCustomTitleAndDesription,
         ...args,
       }
     },
@@ -216,11 +216,11 @@ function TemplateFTVACustomTitleDescription(args) {
       :image-aspect-ratio="imageAspectRatio"
       >
       <template #title>
-        test title
+        <RichText v-html="title" />
       </template>
 
       <template #description>
-        test description
+        <RichText v-html="ftvaHomepageDescription" />
       </template>
     </block-card-with-image>
 `,

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -200,20 +200,21 @@ const mockArticles = [
     postDate: '2024-05-07T13:00:00-07:00',
     ftvaHomepageDescription: '<p>Three alumnis student films, made in the <strong>1970s-1980s</strong>, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film &amp; Television Archive staff.</p>',
     uri: 'blog/preserving-in-transit-the-chinese-in-california',
-    ftvaImage: [
-      {
-        id: '3619987',
-        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg',
-        height: 1813,
-        width: 2560,
-        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w',
-        alt: null,
-        focalPoint: [
-          0.5,
-          0.5
-        ]
-      }
-    ]
+    image: API.image,
+  //   ftvaImage: [
+  //     {
+  //       id: '3619987',
+  //       src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg',
+  //       height: 1813,
+  //       width: 2560,
+  //       srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w',
+  //       alt: null,
+  //       focalPoint: [
+  //         0.5,
+  //         0.5
+  //       ]
+  //     }
+  //   ]
   },
   {
     title: '<h3>From McKinley to LBJ: Presidents in the Hearst Newsreels</h3>',
@@ -228,20 +229,21 @@ const mockArticles = [
     postDate: '2024-02-19T16:00:00-08:00',
     ftvaHomepageDescription: '<p>Curated by UCLA Film &amp; Television Archive Senior Newsreel Preservationist Jeffrey Bickel, the newsreels presented here cover the period from 1897 to 1967.</p>',
     uri: 'blog/from-mckinley-to-lbj-presidents-in-the-hearst-newsreels',
-    ftvaImage: [
-      {
-        id: '3619990',
-        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/WilsonTaft-crop.png',
-        height: 1792,
-        width: 2560,
-        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/WilsonTaft-crop.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/WilsonTaft-crop.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/WilsonTaft-crop.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/WilsonTaft-crop.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/WilsonTaft-crop.png 2560w',
-        alt: null,
-        focalPoint: [
-          0.5,
-          0.5
-        ]
-      }
-    ]
+    image: API.image,
+    // ftvaImage: [
+    //   {
+    //     id: '3619990',
+    //     src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/WilsonTaft-crop.png',
+    //     height: 1792,
+    //     width: 2560,
+    //     srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/WilsonTaft-crop.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/WilsonTaft-crop.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/WilsonTaft-crop.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/WilsonTaft-crop.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/WilsonTaft-crop.png 2560w',
+    //     alt: null,
+    //     focalPoint: [
+    //       0.5,
+    //       0.5
+    //     ]
+    //   }
+    // ]
   },
   {
     title: '<h3>The Effervescent Artist, Educator and Activist Betty Chen</h3>',
@@ -256,20 +258,21 @@ const mockArticles = [
     postDate: '2023-08-24T12:00:00-07:00',
     ftvaHomepageDescription: '<p><strong>In the spring of 2022</strong>, UCLA-trained filmmaker Betty Yao-Jung Chen (November 5, 1943 throughApril 26, 2022) died in Florida. The news was confirmed by her niece and nephew.</p>',
     uri: 'blog/the-effervescent-artist-educator-and-activist-betty-chen',
-    ftvaImage: [
-      {
-        id: '3620037',
-        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/BettyChen-blog1.png',
-        height: 1813,
-        width: 2560,
-        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/BettyChen-blog1.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/BettyChen-blog1.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/BettyChen-blog1.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/BettyChen-blog1.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/BettyChen-blog1.png 2560w',
-        alt: null,
-        focalPoint: [
-          0.5,
-          0.5
-        ]
-      }
-    ]
+    image: API.image,
+    // ftvaImage: [
+    //   {
+    //     id: '3620037',
+    //     src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/BettyChen-blog1.png',
+    //     height: 1813,
+    //     width: 2560,
+    //     srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/BettyChen-blog1.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/BettyChen-blog1.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/BettyChen-blog1.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/BettyChen-blog1.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/BettyChen-blog1.png 2560w',
+    //     alt: null,
+    //     focalPoint: [
+    //       0.5,
+    //       0.5
+    //     ]
+    //   }
+    // ]
   }
 ]
 
@@ -294,7 +297,12 @@ function TemplateFTVAArticleBlogListing(args) {
       theme="paleblue"
     >
       <block-card-with-image
-        :image="mockArticles[0].ftvaImage[0]"
+        class="block-highlight"
+        style="
+          background-color:white;
+        "
+        :image="image"
+        :image-aspect-ratio="imageAspectRatio"
         :to="mockArticles[0].uri"
         category="Interview, People"
         :dateCreated="mockArticles[0].postDate"
@@ -314,12 +322,15 @@ function TemplateFTVAArticleBlogListing(args) {
           style="
             display: flex;
             flex-direction: row;
-            gap: var(--space-xl);
+            gap: 28px;
             margin-top: 40px;
           "
       >
           <block-card-with-image
-            :image="mockArticles[1].ftvaImage[0]"
+            class="block-highlight"
+            style="background-color:white;"
+            :image="image"
+            :image-aspect-ratio="imageAspectRatio"
             :to="mockArticles[1].uri"
             category="Interview, People"
             :dateCreated="mockArticles[1].postDate"
@@ -335,7 +346,10 @@ function TemplateFTVAArticleBlogListing(args) {
           </block-card-with-image>
 
           <block-card-with-image
-            :image="mockArticles[2].ftvaImage[0]"
+            class="block-highlight"
+            style="background-color:white;"
+            :image="image"
+            :image-aspect-ratio="imageAspectRatio"
             :to="mockArticles[2].uri"
             category="Interview, People"
             :dateCreated="mockArticles[2].postDate"

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -124,7 +124,7 @@ FTVAItemsNoImage.args = {
 
 export const FTVAItemsPostedDate = Template.bind({})
 FTVAItemsPostedDate.args = {
-  image: API.image,
+  image: null,,
   title: 'Black Perspectives on Local L.A. TV',
   category: null,
   theme: 'ftva',

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -140,7 +140,7 @@ FTVAItemsPostedDate.args = {
 
 const mockCustomTitleAndDesription = {
   title: "Preserving “In Transit: The Chinese in California”",
-  startDate: "2024-05-07T13:00:00-07:00",
+  postDate: "2024-05-07T13:00:00-07:00",
   ftvaHomepageDescription: "<p>In the summer of 2023, I had the chance to select and restore a student film as part of the UCLA Student Film Initiative Internship: The Present Preserving the Past.</p>",
   uri: "blog/preserving-in-transit-the-chinese-in-california",
   ftvaImage: [
@@ -159,40 +159,6 @@ const mockCustomTitleAndDesription = {
   ]
 }
 
-// export function FtvaCustomTitleAndDesription() {
-//   return {
-//     data() {
-//       return {
-//         ...mockCustomTitleAndDesription,
-//       }
-//     },
-//     provide() {
-//       return {
-//         theme: computed(() => 'ftva'),
-//       }
-//     },
-//     components: { CardMeta, RichText },
-//     template: `
-//       <block-card-with-image
-//         image: API.image,
-//         to: '/visit/foo/bar/',
-//         title: 'Seven seas of the ancient world',
-//         startDate: '2022-03-31T07:00:00+00:00',
-//         >
-//         <card-meta>
-//           <template v-slot:title>
-//             <RichText  v-html="ftvaFeaturedArticles[0].title" />
-//           </template>
-
-//           <template v-slot:description>
-//             <RichText v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
-//           </template>
-//         </card-meta>
-//       </block-card-with-image>
-//     `,
-//   }
-// }
-
 function TemplateFTVACustomTitleDescription(args) {
   return {
     data() {
@@ -210,9 +176,9 @@ function TemplateFTVACustomTitleDescription(args) {
     template: `
     <block-card-with-image
       :image="image"
-      :to="to"
+      :to="uri"
       :category="category"
-      :start-date="startDate"
+      :start-date="postDate"
       :image-aspect-ratio="imageAspectRatio"
       >
       <template #title>
@@ -227,4 +193,4 @@ function TemplateFTVACustomTitleDescription(args) {
   }
 }
 
-export const Default2= TemplateFTVACustomTitleDescription.bind({})
+export const FTVACustomTitleDescription = TemplateFTVACustomTitleDescription.bind({})

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -143,7 +143,7 @@ const mockCustomTitleAndDesription = {
   category: 'Interview, People',
   title: '<h3>Preserving <em>In <strong>Transit</strong>:</em> The Chinese in California</h3>',
   postDate: '2024-05-07T13:00:00-07:00',
-  ftvaHomepageDescription: '<p>Three alumni’s student films, made in the 1970s-1980s, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film & Television Archive staff.</p>',
+  ftvaHomepageDescription: '<p>Three alumni student films, made in the <strong>1970s-1980s</strong>, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film & Television Archive staff.</p>',
   uri: 'blog/preserving-in-transit-the-chinese-in-california',
   image: API.image,
 }

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -9,7 +9,7 @@ import * as API from '@/stories/mock-api.json'
 // Storybook default settings
 export default {
   title: 'BLOCK / Card With Image',
-  component: BlockCardWithImage,
+  component: BlockCardWithImage
 }
 
 const mock = {
@@ -48,21 +48,21 @@ function Template(args) {
     components: { BlockCardWithImage },
     template: `
     <block-card-with-image
-      :image="image"
-      :to="to"
-      :category="category"
-      :title="title"
-      :start-date="startDate"
-      :end-date="endDate"
-      :text="text"
-      :image-aspect-ratio="imageAspectRatio"
-      :locations="locations"
-      :alternativeFullName="alternativeFullName"
-      :language="language"
-      :section-handle="sectionHandle"
-      :date-created="dateCreated"
-      :byline-one="bylineOne"
-      :byline-two="bylineTwo"
+        :image="image"
+        :to="to"
+        :category="category"
+        :title="title"
+        :start-date="startDate"
+        :end-date="endDate"
+        :text="text"
+        :image-aspect-ratio="imageAspectRatio"
+        :locations="locations"
+        :alternativeFullName="alternativeFullName"
+        :language="language"
+        :section-handle="sectionHandle"
+        :date-created="dateCreated"
+        :byline-one="bylineOne"
+        :byline-two="bylineTwo"
     />
 `,
   }

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -1,5 +1,6 @@
 import { computed } from 'vue'
 import BlockCardWithImage from '@/lib-components/BlockCardWithImage'
+import RichText from '@/lib-components/RichText.vue'
 
 // Import mock api data
 import * as API from '@/stories/mock-api.json'
@@ -160,7 +161,7 @@ function TemplateFTVACustomTitleDescription(args) {
         theme: computed(() => args.theme ? args.theme : ''),
       }
     },
-    components: { BlockCardWithImage },
+    components: { BlockCardWithImage, RichText},
     template: `
       <block-card-with-image
         :image="image"
@@ -170,12 +171,12 @@ function TemplateFTVACustomTitleDescription(args) {
         :image-aspect-ratio="imageAspectRatio"
         >
 
-        <template #title>
-          <RichText v-html="title" />
+        <template v-slot:title>
+          <rich-text v-html="title" />
         </template>
 
-        <template #description>
-          <RichText v-html="ftvaHomepageDescription" />
+        <template v-slot:description>
+          <rich-text v-html="ftvaHomepageDescription" />
         </template>
       </block-card-with-image>
     `,

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -188,7 +188,7 @@ export const FTVACustomTitleDescription = TemplateFTVACustomTitleDescription.bin
 
 const mockArticles = [
   {
-    title: '<h3><em>Preserving In Transit:</em> The Chinese in California<h3>',
+    title: '<h3><em>Preserving In Transit:</em> The Chinese in California</h3>',
     articleCategories: [
       {
         title: 'Interview'
@@ -197,8 +197,8 @@ const mockArticles = [
         title: 'People'
       }
     ],
-    postDate: '2024-02-19T16:00:00-08:00',
-    ftvaHomepageDescription: '<p>Three alumni student films, made in the 1970s-1980s, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film &amp; Television Archive staff.</p>',
+    postDate: '2024-05-07T13:00:00-07:00',
+    ftvaHomepageDescription: '<p>Three alumnis student films, made in the <strong>1970s-1980s</strong>, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film &amp; Television Archive staff.</p>',
     uri: 'blog/preserving-in-transit-the-chinese-in-california',
     ftvaImage: [
       {
@@ -213,16 +213,16 @@ const mockArticles = [
           0.5
         ]
       }
-    ],
+    ]
   },
   {
-    title: '<h3><em>From McKinley to LBJ:</em> Presidents in the Hearst Newsreels<h3>',
+    title: '<h3>From McKinley to LBJ: Presidents in the Hearst Newsreels</h3>',
     articleCategories: [
       {
-        title: 'Interview'
+        title: 'Newsreels'
       },
       {
-        title: 'People'
+        title: 'Presidents'
       }
     ],
     postDate: '2024-02-19T16:00:00-08:00',
@@ -244,17 +244,17 @@ const mockArticles = [
     ]
   },
   {
-    title: '<h3>The “Effervescent” Artist, Educator and Activist Betty Chen</h3>',
+    title: '<h3>The Effervescent Artist, Educator and Activist Betty Chen</h3>',
     articleCategories: [
       {
-        title: 'Interview'
+        title: 'Educators'
       },
       {
-        title: 'People'
+        title: 'Artists'
       }
     ],
     postDate: '2023-08-24T12:00:00-07:00',
-    ftvaHomepageDescription: '<p><span>In the spring of 2022, UCLA-trained filmmaker Betty Yao-Jung Chen (</span><span>November 5, 1943–April 26, 2022) died in Florida. The news was confirmed by her niece and nephew, who had reached out to me in 2021 after reading an article I had written about their aunt for </span><a href=\'https://online.ucpress.edu/fq/issue/73/3\' target=\'_blank\' rel=\'noreferrer noopener\'><em>Film Quarterly</em> March 2020 dossier</a><span>, <em>Asian American Film at Fifty.</em></span></p>',
+    ftvaHomepageDescription: '<p><strong>In the spring of 2022</strong>, UCLA-trained filmmaker Betty Yao-Jung Chen (November 5, 1943 throughApril 26, 2022) died in Florida. The news was confirmed by her niece and nephew.</p>',
     uri: 'blog/the-effervescent-artist-educator-and-activist-betty-chen',
     ftvaImage: [
       {

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -1,6 +1,8 @@
 import { computed } from 'vue'
 import BlockCardWithImage from '@/lib-components/BlockCardWithImage'
 import RichText from '@/lib-components/RichText.vue'
+import SectionWrapper from '@/lib-components/SectionWrapper.vue'
+
 
 // Import mock api data
 import * as API from '@/stories/mock-api.json'
@@ -184,3 +186,180 @@ function TemplateFTVACustomTitleDescription(args) {
 }
 
 export const FTVACustomTitleDescription = TemplateFTVACustomTitleDescription.bind({})
+
+const mockArticles = [
+  {
+    title: '<h3><em>Preserving In Transit:</em> The Chinese in California<h3>',
+    articleCategories: [
+      {
+        title: 'Interview'
+      },
+      {
+        title: 'People'
+      }
+    ],
+    postDate: '2024-02-19T16:00:00-08:00',
+    ftvaHomepageDescription: '<p>Three alumni student films, made in the 1970s-1980s, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film &amp; Television Archive staff.</p>',
+    uri: 'blog/preserving-in-transit-the-chinese-in-california',
+    ftvaImage: [
+      {
+        id: '3619987',
+        src:  'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg',
+              height: 1813,
+              width: 2560,
+              srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w',
+        alt: null,
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ],
+  },
+  {
+    title: '<h3><em>From McKinley to LBJ:</em> Presidents in the Hearst Newsreels<h3>',
+    articleCategories: [
+      {
+        title: 'Interview'
+      },
+      {
+        title: 'People'
+      }
+    ],
+    postDate: '2024-02-19T16:00:00-08:00',
+    ftvaHomepageDescription: '<p>Curated by UCLA Film &amp; Television Archive Senior Newsreel Preservationist Jeffrey Bickel, the newsreels presented here cover the period from 1897 to 1967.</p>',
+    uri: 'blog/from-mckinley-to-lbj-presidents-in-the-hearst-newsreels',
+    ftvaImage: [
+      {
+        id: '3619990',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/WilsonTaft-crop.png',
+        height: 1792,
+        width: 2560,
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/WilsonTaft-crop.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/WilsonTaft-crop.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/WilsonTaft-crop.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/WilsonTaft-crop.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/WilsonTaft-crop.png 2560w',
+        alt: null,
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ]
+  },
+  {
+    title: '<h3>The “Effervescent” Artist, Educator and Activist Betty Chen</h3>',
+    articleCategories: [
+      {
+        title: 'Interview'
+      },
+      {
+        title: 'People'
+      }
+    ],
+    postDate: '2023-08-24T12:00:00-07:00',
+    ftvaHomepageDescription: '<p><span>In the spring of 2022, UCLA-trained filmmaker Betty Yao-Jung Chen (</span><span>November 5, 1943–April 26, 2022) died in Florida. The news was confirmed by her niece and nephew, who had reached out to me in 2021 after reading an article I had written about their aunt for </span><a href=\'https://online.ucpress.edu/fq/issue/73/3\' target=\'_blank\' rel=\'noreferrer noopener\'><em>Film Quarterly</em> March 2020 dossier</a><span>, <em>Asian American Film at Fifty.</em></span></p>',
+    uri: 'blog/the-effervescent-artist-educator-and-activist-betty-chen',
+    ftvaImage: [
+      {
+        id: '3620037',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/BettyChen-blog1.png',
+        height: 1813,
+        width: 2560,
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/BettyChen-blog1.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/BettyChen-blog1.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/BettyChen-blog1.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/BettyChen-blog1.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/BettyChen-blog1.png 2560w',
+        alt: null,
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ]
+  }
+]
+
+function TemplateFTVAArticleBlogListing(args) {
+  return {
+    data() {
+      return {
+        mockArticles,
+        ...args,
+      }
+    },
+    provide() {
+      return {
+      theme: computed(() => 'ftva'),
+      }
+    },
+    components: { SectionWrapper, BlockCardWithImage, RichText },
+    template: `
+
+    <section-wrapper
+      section-title="Featured Blogs"
+      theme="paleblue"
+    >
+      <block-card-with-image
+        :image="mockArticles[0].ftvaImage[0]"
+        :to="mockArticles[0].uri"
+        category="Interview, People"
+        :dateCreated="mockArticles[0].postDate"
+        :image-aspect-ratio="60"
+        >
+
+        <template v-slot:title>
+          <rich-text v-html="mockArticles[0].title" />
+        </template>
+
+        <template v-slot:description>
+          <rich-text v-html="mockArticles[0].ftvaHomepageDescription" />
+        </template>
+      </block-card-with-image>
+
+      <div
+          class="block-card-half"
+          style="
+            display: flex;
+            flex-direction: row;
+            gap: var(--space-xl);
+            margin-top: 40px;
+          "
+      >
+          <block-card-with-image
+            :image="mockArticles[1].ftvaImage[0]"
+            :to="mockArticles[1].uri"
+            category="Interview, People"
+            :dateCreated="mockArticles[1].postDate"
+            :image-aspect-ratio="100"
+            >
+
+            <template v-slot:title>
+              <rich-text v-html="mockArticles[1].title" />
+            </template>
+
+            <template v-slot:description>
+              <rich-text v-html="mockArticles[1].ftvaHomepageDescription" />
+            </template>
+          </block-card-with-image>
+
+          <block-card-with-image
+            :image="mockArticles[2].ftvaImage[0]"
+            :to="mockArticles[2].uri"
+            category="Interview, People"
+            :dateCreated="mockArticles[2].postDate"
+            :image-aspect-ratio="100"
+            >
+
+            <template v-slot:title>
+              <rich-text v-html="mockArticles[2].title" />
+            </template>
+
+            <template v-slot:description>
+              <rich-text v-html="mockArticles[2].ftvaHomepageDescription" />
+            </template>
+          </block-card-with-image>
+      </div>
+      <section-wrapper>
+
+      </section-wrapper>
+    </section-wrapper>
+    `,
+  }
+}
+
+export const FTVAArticleBlogListing = TemplateFTVAArticleBlogListing.bind({})

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -7,7 +7,7 @@ import * as API from '@/stories/mock-api.json'
 // Storybook default settings
 export default {
   title: 'BLOCK / Card With Image',
-  component: BlockCardWithImage
+  component: BlockCardWithImage,
 }
 
 const mock = {
@@ -46,21 +46,21 @@ function Template(args) {
     components: { BlockCardWithImage },
     template: `
     <block-card-with-image
-        :image="image"
-        :to="to"
-        :category="category"
-        :title="title"
-        :start-date="startDate"
-        :end-date="endDate"
-        :text="text"
-        :image-aspect-ratio="imageAspectRatio"
-        :locations="locations"
-        :alternativeFullName="alternativeFullName"
-        :language="language"
-        :section-handle="sectionHandle"
-        :date-created="dateCreated"
-        :byline-one="bylineOne"
-        :byline-two="bylineTwo"
+      :image="image"
+      :to="to"
+      :category="category"
+      :title="title"
+      :start-date="startDate"
+      :end-date="endDate"
+      :text="text"
+      :image-aspect-ratio="imageAspectRatio"
+      :locations="locations"
+      :alternativeFullName="alternativeFullName"
+      :language="language"
+      :section-handle="sectionHandle"
+      :date-created="dateCreated"
+      :byline-one="bylineOne"
+      :byline-two="bylineTwo"
     />
 `,
   }
@@ -137,3 +137,94 @@ FTVAItemsPostedDate.args = {
   cardIsLink: true,
   dateCreated: '2022-01-31T07:00:00+00:00',
 }
+
+const mockCustomTitleAndDesription = {
+  title: "Preserving “In Transit: The Chinese in California”",
+  startDate: "2024-05-07T13:00:00-07:00",
+  ftvaHomepageDescription: "<p>In the summer of 2023, I had the chance to select and restore a student film as part of the UCLA Student Film Initiative Internship: The Present Preserving the Past.</p>",
+  uri: "blog/preserving-in-transit-the-chinese-in-california",
+  ftvaImage: [
+    {
+      id: "3619987",
+      src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg",
+      height: 1813,
+      width: 2560,
+      srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w",
+      alt: null,
+      focalPoint: [
+        0.5,
+        0.5
+      ]
+    }
+  ]
+}
+
+// export function FtvaCustomTitleAndDesription() {
+//   return {
+//     data() {
+//       return {
+//         ...mockCustomTitleAndDesription,
+//       }
+//     },
+//     provide() {
+//       return {
+//         theme: computed(() => 'ftva'),
+//       }
+//     },
+//     components: { CardMeta, RichText },
+//     template: `
+//       <block-card-with-image
+//         image: API.image,
+//         to: '/visit/foo/bar/',
+//         title: 'Seven seas of the ancient world',
+//         startDate: '2022-03-31T07:00:00+00:00',
+//         >
+//         <card-meta>
+//           <template v-slot:title>
+//             <RichText  v-html="ftvaFeaturedArticles[0].title" />
+//           </template>
+
+//           <template v-slot:description>
+//             <RichText v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
+//           </template>
+//         </card-meta>
+//       </block-card-with-image>
+//     `,
+//   }
+// }
+
+function TemplateFTVACustomTitleDescription(args) {
+  return {
+    data() {
+      return {
+        ...mock,
+        ...args,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => args.theme ? args.theme : ''),
+      }
+    },
+    components: { BlockCardWithImage },
+    template: `
+    <block-card-with-image
+      :image="image"
+      :to="to"
+      :category="category"
+      :start-date="startDate"
+      :image-aspect-ratio="imageAspectRatio"
+      >
+      <template #title>
+        test title
+      </template>
+
+      <template #description>
+        test description
+      </template>
+    </block-card-with-image>
+`,
+  }
+}
+
+export const Default2= TemplateFTVACustomTitleDescription.bind({})

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -298,7 +298,6 @@ function TemplateFTVAArticleBlogListing(args) {
         :to="mockArticles[0].uri"
         category="Interview, People"
         :dateCreated="mockArticles[0].postDate"
-        :image-aspect-ratio="60"
         >
 
         <template v-slot:title>
@@ -324,7 +323,6 @@ function TemplateFTVAArticleBlogListing(args) {
             :to="mockArticles[1].uri"
             category="Interview, People"
             :dateCreated="mockArticles[1].postDate"
-            :image-aspect-ratio="100"
             >
 
             <template v-slot:title>
@@ -341,7 +339,6 @@ function TemplateFTVAArticleBlogListing(args) {
             :to="mockArticles[2].uri"
             category="Interview, People"
             :dateCreated="mockArticles[2].postDate"
-            :image-aspect-ratio="100"
             >
 
             <template v-slot:title>

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -3,7 +3,6 @@ import BlockCardWithImage from '@/lib-components/BlockCardWithImage'
 import RichText from '@/lib-components/RichText.vue'
 import SectionWrapper from '@/lib-components/SectionWrapper.vue'
 
-
 // Import mock api data
 import * as API from '@/stories/mock-api.json'
 
@@ -204,10 +203,10 @@ const mockArticles = [
     ftvaImage: [
       {
         id: '3619987',
-        src:  'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg',
-              height: 1813,
-              width: 2560,
-              srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg',
+        height: 1813,
+        width: 2560,
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w',
         alt: null,
         focalPoint: [
           0.5,
@@ -284,7 +283,7 @@ function TemplateFTVAArticleBlogListing(args) {
     },
     provide() {
       return {
-      theme: computed(() => 'ftva'),
+        theme: computed(() => 'ftva'),
       }
     },
     components: { SectionWrapper, BlockCardWithImage, RichText },

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -83,7 +83,7 @@ LongTitle.args = {
 export const TallImage = Template.bind({})
 TallImage.args = {
   title: 'Test Other Image Sizes',
-  image: { ...API.image, src: 'https://placehold.co/1080x1920', height: 1920, width: 1920, },
+  image: { ...API.image, src: 'https://via.placeholder.com/1080x1920', height: 1920, width: 1920, },
   imageAspectRatio: 150
 }
 

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -161,7 +161,7 @@ function TemplateFTVACustomTitleDescription(args) {
         theme: computed(() => args.theme ? args.theme : ''),
       }
     },
-    components: { BlockCardWithImage, RichText},
+    components: { BlockCardWithImage, RichText },
     template: `
       <block-card-with-image
         :image="image"

--- a/src/stories/CardMeta.stories.js
+++ b/src/stories/CardMeta.stories.js
@@ -5,6 +5,16 @@ import SmartLink from '@/lib-components/SmartLink.vue'
 import RichText from '@/lib-components/RichText.vue'
 import { useGlobalStore } from '@/stores/GlobalStore'
 
+// UTILITY FUNCTIONS
+import formatDates from '@/utils/formatEventDates'
+
+const parsedDateCreated = computed(() => {
+  if (props.dateCreated)
+    return format(new Date(props.dateCreated), 'MMMM d, yyyy')
+
+  return ''
+})
+
 // Storybook default settings
 export default {
   title: 'Card Meta',
@@ -71,7 +81,6 @@ export function Ongoing() {
           :locations="locations"
           :alternativeFullName="alternativeFullName"
           :language="language"
-          :section-handle="sectionHandle"
       />
   `,
   }
@@ -185,7 +194,9 @@ const mockFTVAArticleData = {
   ],
   sectionHandle: 'ftvaArticle'
 }
+
 const parsedArticleCategories = mockFTVAArticleData.articleCategories.map(category => category.title).join(', ')
+
 // data for share button in slot
 const mockSocialList = {
   buttonTitle: 'Share',
@@ -300,7 +311,9 @@ export function FtvaCustomTitleAndDesription() {
         ftvaFeaturedArticles: [
           {
             title: "<h3>Preserving <em>In Transit</em>: <a href=#>The Chinese</a> in California</h3>",
-            ftvaHomepageDescription: "<p><strong>In the summer</strong> of 2023, <a href=#>I had the chance</a> to select and restore a student film as part of the UCLA Student Film Initiative Internship: The Present Preserving the Past.</p>"
+            ftvaHomepageDescription: "<p><strong>In the summer</strong> of 2023, <a href=#>I had the chance</a> to select and restore a student film as part of the UCLA Student Film Initiative Internship: The Present Preserving the Past.</p>",
+            articleCategories: 'People, Places',
+            postDate:"2024-10-09T09:00:00-07:00"
           }
         ]
       }
@@ -312,12 +325,15 @@ export function FtvaCustomTitleAndDesription() {
     },
     components: { CardMeta, RichText },
     template: `
-      <card-meta>
-        <template v-slot:title>
-          <RichText  v-html="ftvaFeaturedArticles[0].title" />
+      <card-meta
+       :category= "ftvaFeaturedArticles[0].articleCategories"
+       :dateCreated="ftvaFeaturedArticles[0].postDate"
+      >
+        <template #title>
+          <RichText v-html="ftvaFeaturedArticles[0].title" />
         </template>
 
-        <template v-slot:description>
+        <template #description>
           <RichText v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
         </template>
       </card-meta>

--- a/src/stories/CardMeta.stories.js
+++ b/src/stories/CardMeta.stories.js
@@ -319,12 +319,12 @@ export function FtvaCustomTitleAndDesription() {
        :category= "ftvaFeaturedArticles[0].articleCategories"
        :dateCreated="ftvaFeaturedArticles[0].postDate"
       >
-        <template #title>
-          <RichText v-html="ftvaFeaturedArticles[0].title" />
+        <template v-slot:title>
+          <rich-text v-html="ftvaFeaturedArticles[0].title" />
         </template>
 
-        <template #description>
-          <RichText v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
+        <template v-slot:description>
+          <rich-text v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
         </template>
       </card-meta>
     `,

--- a/src/stories/CardMeta.stories.js
+++ b/src/stories/CardMeta.stories.js
@@ -322,6 +322,6 @@ export function FtvaCustomTitleAndDesription() {
         </template>
       </card-meta>
     `,
-    }
   }
+}
 

--- a/src/stories/CardMeta.stories.js
+++ b/src/stories/CardMeta.stories.js
@@ -71,6 +71,7 @@ export function Ongoing() {
           :locations="locations"
           :alternativeFullName="alternativeFullName"
           :language="language"
+          :section-handle="sectionHandle"
       />
   `,
   }

--- a/src/stories/CardMeta.stories.js
+++ b/src/stories/CardMeta.stories.js
@@ -5,15 +5,6 @@ import SmartLink from '@/lib-components/SmartLink.vue'
 import RichText from '@/lib-components/RichText.vue'
 import { useGlobalStore } from '@/stores/GlobalStore'
 
-// UTILITY FUNCTIONS
-
-const parsedDateCreated = computed(() => {
-  if (props.dateCreated)
-    return format(new Date(props.dateCreated), 'MMMM d, yyyy')
-
-  return ''
-})
-
 // Storybook default settings
 export default {
   title: 'Card Meta',

--- a/src/stories/CardMeta.stories.js
+++ b/src/stories/CardMeta.stories.js
@@ -2,6 +2,7 @@ import { computed, onBeforeUnmount, onMounted } from 'vue'
 import CardMeta from '@/lib-components/CardMeta'
 import ButtonDropdown from '@/lib-components/ButtonDropdown.vue'
 import SmartLink from '@/lib-components/SmartLink.vue'
+import RichText from '@/lib-components/RichText.vue'
 import { useGlobalStore } from '@/stores/GlobalStore'
 
 // Storybook default settings
@@ -291,3 +292,36 @@ export function FtvaLinkedCategoryAndTitle() {
   `,
   }
 }
+
+export function FtvaCustomTitleAndDesription() {
+  return {
+    data() {
+      return {
+        ftvaFeaturedArticles: [
+          {
+            title: "<h3>Preserving <em>In Transit</em>: <a href=#>The Chinese</a> in California</h3>",
+            ftvaHomepageDescription: "<p><strong>In the summer</strong> of 2023, <a href=#>I had the chance</a> to select and restore a student film as part of the UCLA Student Film Initiative Internship: The Present Preserving the Past.</p>"
+          }
+        ]
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { CardMeta, RichText },
+    template: `
+      <card-meta>
+        <template v-slot:title>
+          <RichText  v-html="ftvaFeaturedArticles[0].title" />
+        </template>
+
+        <template v-slot:description>
+          <RichText v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
+        </template>
+      </card-meta>
+    `,
+    }
+  }
+

--- a/src/stories/CardMeta.stories.js
+++ b/src/stories/CardMeta.stories.js
@@ -6,7 +6,6 @@ import RichText from '@/lib-components/RichText.vue'
 import { useGlobalStore } from '@/stores/GlobalStore'
 
 // UTILITY FUNCTIONS
-import formatDates from '@/utils/formatEventDates'
 
 const parsedDateCreated = computed(() => {
   if (props.dateCreated)
@@ -310,10 +309,10 @@ export function FtvaCustomTitleAndDesription() {
       return {
         ftvaFeaturedArticles: [
           {
-            title: "<h3>Preserving <em>In Transit</em>: <a href=#>The Chinese</a> in California</h3>",
-            ftvaHomepageDescription: "<p><strong>In the summer</strong> of 2023, <a href=#>I had the chance</a> to select and restore a student film as part of the UCLA Student Film Initiative Internship: The Present Preserving the Past.</p>",
+            title: '<h3>Preserving <em>In Transit</em>: <a href=#>The Chinese</a> in California</h3>',
+            ftvaHomepageDescription: '<p><strong>In the summer</strong> of 2023, <a href=#>I had the chance</a> to select and restore a student film as part of the UCLA Student Film Initiative Internship: The Present Preserving the Past.</p>',
             articleCategories: 'People, Places',
-            postDate:"2024-10-09T09:00:00-07:00"
+            postDate: '2024-10-09T09:00:00-07:00'
           }
         ]
       }
@@ -340,4 +339,3 @@ export function FtvaCustomTitleAndDesription() {
     `,
   }
 }
-

--- a/src/stories/SectionWrapper.stories.js
+++ b/src/stories/SectionWrapper.stories.js
@@ -5,6 +5,7 @@ import { mock as mockMediaWithText } from './mock/BlockMediaWithText'
 import * as API from '@/stories/mock-api.json'
 import SectionWrapper from '@/lib-components/SectionWrapper'
 
+import BlockCardWithImage from '@/lib-components/BlockCardWithImage'
 import BlockMediaWithText from '@/lib-components/BlockMediaWithText'
 import DividerWayFinder from '@/lib-components/DividerWayFinder'
 import SectionTeaserCard from '@/lib-components/SectionTeaserCard'
@@ -770,6 +771,144 @@ export function FtvaSeriesListing() {
             </template>
           </TabItem>
         </TabList>
+      </SectionWrapper>
+  `,
+  }
+}
+
+const mockArticles = [
+  {
+    typeHandle: "ftvaArticle",
+    id: "3357303",
+    title: "Hispanic and Latin American Heritage in the Hearst Newsreels",
+    postDate: "2024-10-09T09:00:00-07:00",
+    ftvaHomepageDescription: "<p><span>The selection of newsreels and outtake footage presented here highlights prominent figures of Hispanic and Latin American heritage who influenced motion picture and television history, politics and sports, while other clips offer time capsules of various regions and cultural celebrations.</span></p>",
+    uri: "blog/hispanic-and-latin-american-heritage-in-the-hearst-newsreels",
+    ftvaImage: [
+      {
+        id: "3144324",
+        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Eva02_0.jpg",
+        height: 1917,
+        width: 2560,
+        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Eva02_0.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Eva02_0.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Eva02_0.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Eva02_0.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Eva02_0.jpg 2560w",
+        alt: "Eva (1962)",
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ]
+  },
+  {
+    typeHandle: "ftvaArticle",
+    id: "3266907",
+    title: "TEST - Hot Air Balloons",
+    postDate: "2024-09-20T10:50:00-07:00",
+    ftvaHomepageDescription: null,
+    uri: "blog/test-hot-air-balloons",
+    ftvaImage: [
+      {
+        id: "3280520",
+        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/hot_air_balloon.jpg",
+        height: 1280,
+        width: 2560,
+        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/hot_air_balloon.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/hot_air_balloon.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/hot_air_balloon.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/hot_air_balloon.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/hot_air_balloon.jpg 2560w",
+        alt: "Hot air balloon",
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ]
+  },
+  {
+    typeHandle: "ftvaArticle",
+    id: "3264674",
+    title: "TEST -  Coronae Borealis Nova",
+    postDate: "2024-09-20T00:49:00-07:00",
+    ftvaHomepageDescription: "<p>The nova in Corona Borealis, also known as T Coronae Borealis or the Blaze Star, is <mark>a recurring astronomical event that occurs when a binary star system erupts in a thermonuclear blast</mark></p>",
+    uri: "blog/test-coronae-borealis-nova",
+    ftvaImage: [
+      {
+        id: "3264682",
+        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Coronae-Borealis-nova.webp",
+        height: 1436,
+        width: 2560,
+        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 2560w",
+        alt: null,
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ]
+  },
+  {
+    typeHandle: "ftvaArticle",
+    id: "3357305",
+    title: "They Can’t Take It Away: Education and the Traditions of the L.A. Rebellion in “Rich”",
+    postDate: "2024-07-09T10:00:00-07:00",
+    ftvaHomepageDescription: "<p><span>The night before his high school graduation, Richard “Rich” Lawson dreams of his late father. His words are clear in Rich’s mind: </span><em>Your education is very important. It’s something that, once you have it, they can’t take it away</em><span>. This is a sentiment Rich has carried throughout his life.</span></p>",
+    uri: "blog/they-cant-take-it-away-education-and-the-traditions-of-the-l-a-rebellion-in-rich",
+    ftvaImage: []
+  }
+]
+
+export function FtvaArticleBlogListing() {
+  return {
+    data() {
+      return {
+        mockArticles
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { SectionWrapper, BlockCardWithImage },
+    template: `
+      <SectionWrapper
+        section-title="Screening Series"
+        section-summary="Discover the magic of our Upcoming Series, where we curate an immersive experience that transcends time and genre. From classic masterpieces to cutting-edge contemporary works, our series showcase the diverse voices and visions that have shaped the evolution of visual storytelling."
+        theme="paleblue"
+      >
+
+    <BlockCardWithImage
+      :image="image"
+      :to="to"
+      :category="category"
+      :title="title"
+      :start-date="startDate"
+      :end-date="endDate"
+      :text="text"
+      :image-aspect-ratio="imageAspectRatio"
+      :locations="locations"
+      :alternativeFullName="alternativeFullName"
+      :language="language"
+      :section-handle="sectionHandle"
+      :date-created="dateCreated"
+      :byline-one="bylineOne"
+      :byline-two="bylineTwo"
+    >
+      <template #title>
+        <RichText  v-html="ftvaFeaturedArticles[0].title" />
+      </template>
+
+      <template #description>
+        <RichText v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
+      </template>
+    </BlockCardWithImage>
+
+      <card-meta>
+        <template v-slot:title>
+          <RichText  v-html="ftvaFeaturedArticles[0].title" />
+        </template>
+
+        <template v-slot:description>
+          <RichText v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
+        </template>
+      </card-meta>
       </SectionWrapper>
   `,
   }

--- a/src/stories/SectionWrapper.stories.js
+++ b/src/stories/SectionWrapper.stories.js
@@ -778,63 +778,53 @@ export function FtvaSeriesListing() {
 
 const mockArticles = [
   {
-    typeHandle: "ftvaArticle",
-    id: "3357303",
-    title: "Hispanic and Latin American Heritage in the Hearst Newsreels",
-    postDate: "2024-10-09T09:00:00-07:00",
-    ftvaHomepageDescription: "<p><span>The selection of newsreels and outtake footage presented here highlights prominent figures of Hispanic and Latin American heritage who influenced motion picture and television history, politics and sports, while other clips offer time capsules of various regions and cultural celebrations.</span></p>",
-    uri: "blog/hispanic-and-latin-american-heritage-in-the-hearst-newsreels",
+    title: "<h3><em>Preserving In Transit:</em> The Chinese in California<h3>",
+    articleCategories: [
+      {
+        title: "Interview"
+      },
+      {
+        title: "People"
+      }
+    ],
+    postDate: "2024-02-19T16:00:00-08:00",
+    ftvaHomepageDescription: "<p>Three alumni student films, made in the 1970s-1980s, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film &amp; Television Archive staff.</p>",
+    uri: "blog/preserving-in-transit-the-chinese-in-california",
     ftvaImage: [
       {
-        id: "3144324",
-        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Eva02_0.jpg",
-        height: 1917,
+        id: "3619987",
+        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg",
+        height: 1813,
         width: 2560,
-        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Eva02_0.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Eva02_0.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Eva02_0.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Eva02_0.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Eva02_0.jpg 2560w",
-        alt: "Eva (1962)",
+        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w",
+        alt: null,
         focalPoint: [
           0.5,
           0.5
         ]
       }
-    ]
+    ],
   },
   {
-    typeHandle: "ftvaArticle",
-    id: "3266907",
-    title: "TEST - Hot Air Balloons",
-    postDate: "2024-09-20T10:50:00-07:00",
-    ftvaHomepageDescription: null,
-    uri: "blog/test-hot-air-balloons",
-    ftvaImage: [
+    title: "<h3><em>From McKinley to LBJ:</em> Presidents in the Hearst Newsreels<h3>",
+    articleCategories: [
       {
-        id: "3280520",
-        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/hot_air_balloon.jpg",
-        height: 1280,
-        width: 2560,
-        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/hot_air_balloon.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/hot_air_balloon.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/hot_air_balloon.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/hot_air_balloon.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/hot_air_balloon.jpg 2560w",
-        alt: "Hot air balloon",
-        focalPoint: [
-          0.5,
-          0.5
-        ]
+        title: "Interview"
+      },
+      {
+        title: "People"
       }
-    ]
-  },
-  {
-    typeHandle: "ftvaArticle",
-    id: "3264674",
-    title: "TEST -  Coronae Borealis Nova",
-    postDate: "2024-09-20T00:49:00-07:00",
-    ftvaHomepageDescription: "<p>The nova in Corona Borealis, also known as T Coronae Borealis or the Blaze Star, is <mark>a recurring astronomical event that occurs when a binary star system erupts in a thermonuclear blast</mark></p>",
-    uri: "blog/test-coronae-borealis-nova",
+    ],
+    postDate: "2024-02-19T16:00:00-08:00",
+    ftvaHomepageDescription: "<p>Curated by UCLA Film &amp; Television Archive Senior Newsreel Preservationist Jeffrey Bickel, the newsreels presented here cover the period from 1897 to 1967.</p>",
+    uri: "blog/from-mckinley-to-lbj-presidents-in-the-hearst-newsreels",
     ftvaImage: [
       {
-        id: "3264682",
-        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Coronae-Borealis-nova.webp",
-        height: 1436,
+        id: "3619990",
+        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/WilsonTaft-crop.png",
+        height: 1792,
         width: 2560,
-        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Coronae-Borealis-nova.webp 2560w",
+        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/WilsonTaft-crop.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/WilsonTaft-crop.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/WilsonTaft-crop.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/WilsonTaft-crop.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/WilsonTaft-crop.png 2560w",
         alt: null,
         focalPoint: [
           0.5,
@@ -844,13 +834,32 @@ const mockArticles = [
     ]
   },
   {
-    typeHandle: "ftvaArticle",
-    id: "3357305",
-    title: "They Can’t Take It Away: Education and the Traditions of the L.A. Rebellion in “Rich”",
-    postDate: "2024-07-09T10:00:00-07:00",
-    ftvaHomepageDescription: "<p><span>The night before his high school graduation, Richard “Rich” Lawson dreams of his late father. His words are clear in Rich’s mind: </span><em>Your education is very important. It’s something that, once you have it, they can’t take it away</em><span>. This is a sentiment Rich has carried throughout his life.</span></p>",
-    uri: "blog/they-cant-take-it-away-education-and-the-traditions-of-the-l-a-rebellion-in-rich",
-    ftvaImage: []
+    title: "<h3>The “Effervescent” Artist, Educator and Activist Betty Chen</h3>",
+    articleCategories: [
+      {
+        title: "Interview"
+      },
+      {
+        title: "People"
+      }
+    ],
+    postDate: "2023-08-24T12:00:00-07:00",
+    ftvaHomepageDescription: "<p><span>In the spring of 2022, UCLA-trained filmmaker Betty Yao-Jung Chen (</span><span>November 5, 1943–April 26, 2022) died in Florida. The news was confirmed by her niece and nephew, who had reached out to me in 2021 after reading an article I had written about their aunt for </span><a href=\'https://online.ucpress.edu/fq/issue/73/3\' target=\'_blank\' rel=\'noreferrer noopener\'><em>Film Quarterly</em> March 2020 dossier</a><span>, <em>Asian American Film at Fifty.</em></span></p>",
+    uri: "blog/the-effervescent-artist-educator-and-activist-betty-chen",
+    ftvaImage: [
+      {
+        id: "3620037",
+        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/BettyChen-blog1.png",
+        height: 1813,
+        width: 2560,
+        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/BettyChen-blog1.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/BettyChen-blog1.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/BettyChen-blog1.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/BettyChen-blog1.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/BettyChen-blog1.png 2560w",
+        alt: null,
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ]
   }
 ]
 
@@ -868,48 +877,56 @@ export function FtvaArticleBlogListing() {
     },
     components: { SectionWrapper, BlockCardWithImage },
     template: `
+
       <SectionWrapper
-        section-title="Screening Series"
-        section-summary="Discover the magic of our Upcoming Series, where we curate an immersive experience that transcends time and genre. From classic masterpieces to cutting-edge contemporary works, our series showcase the diverse voices and visions that have shaped the evolution of visual storytelling."
+        section-title="Featured Blogs"
         theme="paleblue"
       >
 
-    <BlockCardWithImage
-      :image="image"
-      :to="to"
-      :category="category"
-      :title="title"
-      :start-date="startDate"
-      :end-date="endDate"
-      :text="text"
-      :image-aspect-ratio="imageAspectRatio"
-      :locations="locations"
-      :alternativeFullName="alternativeFullName"
-      :language="language"
-      :section-handle="sectionHandle"
-      :date-created="dateCreated"
-      :byline-one="bylineOne"
-      :byline-two="bylineTwo"
-    >
-      <template #title>
-        <RichText  v-html="ftvaFeaturedArticles[0].title" />
-      </template>
-
-      <template #description>
-        <RichText v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
-      </template>
-    </BlockCardWithImage>
-
-      <card-meta>
-        <template v-slot:title>
-          <RichText  v-html="ftvaFeaturedArticles[0].title" />
+      <BlockCardWithImage
+        :image="mockArticles[1].ftvaImage[0]"
+        :to="to"
+        category="Interview, People"
+        :image-aspect-ratio="100"
+        :date-created="mockArticles[1].postDate"
+      >
+        <template #title>
+          <RichText  v-html="mockArticles[1].title" />
         </template>
 
-        <template v-slot:description>
-          <RichText v-html="ftvaFeaturedArticles[0].ftvaHomepageDescription" />
+        <template #description>
+          <RichText v-html="mockArticles[1].ftvaHomepageDescription" />
         </template>
-      </card-meta>
-      </SectionWrapper>
+      </BlockCardWithImage>
+
+
+      <BlockCardWithImage
+        :image="mockArticles[2].ftvaImage[0]"
+        :to="to"
+        category="Interview, People"
+        :image-aspect-ratio="100"
+        :date-created="mockArticles[2].postDate"
+      >
+        <template #title>
+          <RichText  v-html="mockArticles[2].title" />
+        </template>
+
+        <template #description>
+          <RichText v-html="mockArticles[2].ftvaHomepageDescription" />
+        </template>
+      </BlockCardWithImage>
+
+  </SectionWrapper>
   `,
   }
 }
+
+    // .simple-cards-list {
+    //     display: flex;
+    //     flex-direction: row;
+    //     flex-wrap: wrap;
+    //     justify-content: flex-start;
+    //     align-content: flex-start;
+    //     align-items: stretch;
+    //     gap: 16px;
+    // }

--- a/src/stories/SectionWrapper.stories.js
+++ b/src/stories/SectionWrapper.stories.js
@@ -778,25 +778,25 @@ export function FtvaSeriesListing() {
 
 const mockArticles = [
   {
-    title: "<h3><em>Preserving In Transit:</em> The Chinese in California<h3>",
+    title: '<h3><em>Preserving In Transit:</em> The Chinese in California<h3>',
     articleCategories: [
       {
-        title: "Interview"
+        title: 'Interview'
       },
       {
-        title: "People"
+        title: 'People'
       }
     ],
-    postDate: "2024-02-19T16:00:00-08:00",
-    ftvaHomepageDescription: "<p>Three alumni student films, made in the 1970s-1980s, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film &amp; Television Archive staff.</p>",
-    uri: "blog/preserving-in-transit-the-chinese-in-california",
+    postDate: '2024-02-19T16:00:00-08:00',
+    ftvaHomepageDescription: '<p>Three alumni student films, made in the 1970s-1980s, were preserved over a 10-week period by current MLIS student interns, all under the supervision of UCLA Film &amp; Television Archive staff.</p>',
+    uri: 'blog/preserving-in-transit-the-chinese-in-california',
     ftvaImage: [
       {
-        id: "3619987",
-        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg",
+        id: '3619987',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/In_Transit_blog2.jpeg',
         height: 1813,
         width: 2560,
-        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w",
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/In_Transit_blog2.jpeg 2560w',
         alt: null,
         focalPoint: [
           0.5,
@@ -806,25 +806,25 @@ const mockArticles = [
     ],
   },
   {
-    title: "<h3><em>From McKinley to LBJ:</em> Presidents in the Hearst Newsreels<h3>",
+    title: '<h3><em>From McKinley to LBJ:</em> Presidents in the Hearst Newsreels<h3>',
     articleCategories: [
       {
-        title: "Interview"
+        title: 'Interview'
       },
       {
-        title: "People"
+        title: 'People'
       }
     ],
-    postDate: "2024-02-19T16:00:00-08:00",
-    ftvaHomepageDescription: "<p>Curated by UCLA Film &amp; Television Archive Senior Newsreel Preservationist Jeffrey Bickel, the newsreels presented here cover the period from 1897 to 1967.</p>",
-    uri: "blog/from-mckinley-to-lbj-presidents-in-the-hearst-newsreels",
+    postDate: '2024-02-19T16:00:00-08:00',
+    ftvaHomepageDescription: '<p>Curated by UCLA Film &amp; Television Archive Senior Newsreel Preservationist Jeffrey Bickel, the newsreels presented here cover the period from 1897 to 1967.</p>',
+    uri: 'blog/from-mckinley-to-lbj-presidents-in-the-hearst-newsreels',
     ftvaImage: [
       {
-        id: "3619990",
-        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/WilsonTaft-crop.png",
+        id: '3619990',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/WilsonTaft-crop.png',
         height: 1792,
         width: 2560,
-        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/WilsonTaft-crop.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/WilsonTaft-crop.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/WilsonTaft-crop.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/WilsonTaft-crop.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/WilsonTaft-crop.png 2560w",
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/WilsonTaft-crop.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/WilsonTaft-crop.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/WilsonTaft-crop.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/WilsonTaft-crop.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/WilsonTaft-crop.png 2560w',
         alt: null,
         focalPoint: [
           0.5,
@@ -834,25 +834,25 @@ const mockArticles = [
     ]
   },
   {
-    title: "<h3>The “Effervescent” Artist, Educator and Activist Betty Chen</h3>",
+    title: '<h3>The “Effervescent” Artist, Educator and Activist Betty Chen</h3>',
     articleCategories: [
       {
-        title: "Interview"
+        title: 'Interview'
       },
       {
-        title: "People"
+        title: 'People'
       }
     ],
-    postDate: "2023-08-24T12:00:00-07:00",
-    ftvaHomepageDescription: "<p><span>In the spring of 2022, UCLA-trained filmmaker Betty Yao-Jung Chen (</span><span>November 5, 1943–April 26, 2022) died in Florida. The news was confirmed by her niece and nephew, who had reached out to me in 2021 after reading an article I had written about their aunt for </span><a href=\'https://online.ucpress.edu/fq/issue/73/3\' target=\'_blank\' rel=\'noreferrer noopener\'><em>Film Quarterly</em> March 2020 dossier</a><span>, <em>Asian American Film at Fifty.</em></span></p>",
-    uri: "blog/the-effervescent-artist-educator-and-activist-betty-chen",
+    postDate: '2023-08-24T12:00:00-07:00',
+    ftvaHomepageDescription: '<p><span>In the spring of 2022, UCLA-trained filmmaker Betty Yao-Jung Chen (</span><span>November 5, 1943–April 26, 2022) died in Florida. The news was confirmed by her niece and nephew, who had reached out to me in 2021 after reading an article I had written about their aunt for </span><a href=\'https://online.ucpress.edu/fq/issue/73/3\' target=\'_blank\' rel=\'noreferrer noopener\'><em>Film Quarterly</em> March 2020 dossier</a><span>, <em>Asian American Film at Fifty.</em></span></p>',
+    uri: 'blog/the-effervescent-artist-educator-and-activist-betty-chen',
     ftvaImage: [
       {
-        id: "3620037",
-        src: "https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/BettyChen-blog1.png",
+        id: '3620037',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/BettyChen-blog1.png',
         height: 1813,
         width: 2560,
-        srcset: "https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/BettyChen-blog1.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/BettyChen-blog1.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/BettyChen-blog1.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/BettyChen-blog1.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/BettyChen-blog1.png 2560w",
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/BettyChen-blog1.png 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/BettyChen-blog1.png 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/BettyChen-blog1.png 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/BettyChen-blog1.png 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/BettyChen-blog1.png 2560w',
         alt: null,
         focalPoint: [
           0.5,
@@ -921,12 +921,12 @@ export function FtvaArticleBlogListing() {
   }
 }
 
-    // .simple-cards-list {
-    //     display: flex;
-    //     flex-direction: row;
-    //     flex-wrap: wrap;
-    //     justify-content: flex-start;
-    //     align-content: flex-start;
-    //     align-items: stretch;
-    //     gap: 16px;
-    // }
+// .simple-cards-list {
+//     display: flex;
+//     flex-direction: row;
+//     flex-wrap: wrap;
+//     justify-content: flex-start;
+//     align-content: flex-start;
+//     align-items: stretch;
+//     gap: 16px;
+// }

--- a/src/stories/SectionWrapper.stories.js
+++ b/src/stories/SectionWrapper.stories.js
@@ -776,7 +776,6 @@ export function FtvaSeriesListing() {
   }
 }
 
-
 const mockFTVAtableHeaders = ['', 'Film', 'Role', 'Year']
 const mockFTVAfilmdata = [
   {

--- a/src/stories/SectionWrapper.stories.js
+++ b/src/stories/SectionWrapper.stories.js
@@ -5,7 +5,6 @@ import { mock as mockMediaWithText } from './mock/BlockMediaWithText'
 import * as API from '@/stories/mock-api.json'
 import SectionWrapper from '@/lib-components/SectionWrapper'
 
-import BlockCardWithImage from '@/lib-components/BlockCardWithImage'
 import BlockMediaWithText from '@/lib-components/BlockMediaWithText'
 import DividerWayFinder from '@/lib-components/DividerWayFinder'
 import SectionTeaserCard from '@/lib-components/SectionTeaserCard'
@@ -920,13 +919,3 @@ export function FtvaArticleBlogListing() {
   `,
   }
 }
-
-// .simple-cards-list {
-//     display: flex;
-//     flex-direction: row;
-//     flex-wrap: wrap;
-//     justify-content: flex-start;
-//     align-content: flex-start;
-//     align-items: stretch;
-//     gap: 16px;
-// }

--- a/src/stories/impact-report_index.json
+++ b/src/stories/impact-report_index.json
@@ -2,8 +2,8 @@
     "story": [
         {
             "image": {
-                "src": "https://placehold.co/1920x1080",
-                "srcset": "https://placehold.co/960x540 960w, https://placehold.co/1280x720 1280w, https://placehold.co/1920x1080 1920w",
+                "src": "https://via.placeholder.com/1920x1080",
+                "srcset": "https://via.placeholder.com/960x540 960w, https://via.placeholder.com/1280x720 1280w, https://via.placeholder.com/1920x1080 1920w",
                 "sizes": "100vw",
                 "alt": "Peter Conheim and Viviana Garcia-Besne. Getty Images.",
                 "title": "Peter Conheim and Viviana Garcia-Besne. Getty Images.",

--- a/src/stories/impact-report_index.json
+++ b/src/stories/impact-report_index.json
@@ -2,8 +2,8 @@
     "story": [
         {
             "image": {
-                "src": "https://via.placeholder.com/1920x1080",
-                "srcset": "https://via.placeholder.com/960x540 960w, https://via.placeholder.com/1280x720 1280w, https://via.placeholder.com/1920x1080 1920w",
+                "src": "https://placehold.co/1920x1080",
+                "srcset": "https://placehold.co/960x540 960w, https://placehold.co/1280x720 1280w, https://placehold.co/1920x1080 1920w",
                 "sizes": "100vw",
                 "alt": "Peter Conheim and Viviana Garcia-Besne. Getty Images.",
                 "title": "Peter Conheim and Viviana Garcia-Besne. Getty Images.",

--- a/src/stories/mock-api.json
+++ b/src/stories/mock-api.json
@@ -1,35 +1,38 @@
 {
     "sectionTitle": "Section Title",
     "image": {
-        "src": "https://via.placeholder.com/1920x1080",
-        "srcset": "https://via.placeholder.com/960x540 960w, https://via.placeholder.com/1280x720 1280w, https://via.placeholder.com/1920x1080 1920w",
+        "src": "https://placehold.co/1920x1080",
+        "srcset": "https://placehold.co/960x540 960w, https://placehold.co/1280x720 1280w, https://placehold.co/1920x1080 1920w",
         "sizes": "100vw",
         "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "title": "Lorem ipsum",
         "caption": "Lorem ipsum",
         "height": 1080,
         "width": 1920,
-        "focalPoint": [0.5, 0.5]
+        "focalPoint": [
+            0.5,
+            0.5
+        ]
     },
     "images": [
         {
-            "src": "https://via.placeholder.com/1920x1080",
-            "srcset": "https://via.placeholder.com/960x540 960w, https://via.placeholder.com/1280x720 1280w, https://via.placeholder.com/1920x1080 1920w",
+            "src": "https://placehold.co/1920x1080",
+            "srcset": "https://placehold.co/960x540 960w, https://placehold.co/1280x720 1280w, https://placehold.co/1920x1080 1920w",
             "sizes": "100vw",
             "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             "title": "Lorem ipsum"
         },
         {
-            "src": "https://via.placeholder.com/960x540",
-            "srcset": "https://via.placeholder.com/960x960",
+            "src": "https://placehold.co/960x540",
+            "srcset": "https://placehold.co/960x960",
             "sizes": "100vw",
             "alt": "Morbi quis tellus vel turpis auctor sagittis.",
             "title": "Morbi quis tellus"
         }
     ],
     "image_people": {
-        "src": "https://via.placeholder.com/960x540",
-        "srcset": "https://via.placeholder.com/960x960",
+        "src": "https://placehold.co/960x540",
+        "srcset": "https://placehold.co/960x960",
         "sizes": "100vw",
         "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "title": "Lorem ipsum"
@@ -41,7 +44,10 @@
         "width": 3360,
         "srcset": "",
         "alt": "Ucla impact report animation",
-        "focalPoint": [0.5, 0.5]
+        "focalPoint": [
+            0.5,
+            0.5
+        ]
     },
     "links": [
         {
@@ -98,8 +104,8 @@
     "bricks": [
         {
             "image": {
-                "src": "https://via.placeholder.com/1920x1920",
-                "srcset": "https://via.placeholder.com/960x960 960w, https://via.placeholder.com/1280x1280 1280w, https://via.placeholder.com/1920x1920 1920w",
+                "src": "https://placehold.co/1920x1920",
+                "srcset": "https://placehold.co/960x960 960w, https://placehold.co/1280x1280 1280w, https://placehold.co/1920x1920 1920w",
                 "sizes": "100vw",
                 "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 "title": "Lorem ipsum"
@@ -114,8 +120,8 @@
         },
         {
             "image": {
-                "src": "https://via.placeholder.com/1920x1920",
-                "srcset": "https://via.placeholder.com/960x960 960w, https://via.placeholder.com/1280x1280 1280w, https://via.placeholder.com/1920x1920 1920w",
+                "src": "https://placehold.co/1920x1920",
+                "srcset": "https://placehold.co/960x960 960w, https://placehold.co/1280x1280 1280w, https://placehold.co/1920x1920 1920w",
                 "sizes": "100vw",
                 "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 "title": "Lorem ipsum"

--- a/src/stories/mock-api.json
+++ b/src/stories/mock-api.json
@@ -1,8 +1,8 @@
 {
     "sectionTitle": "Section Title",
     "image": {
-        "src": "https://via.placeholder.com/1920x1080",
-        "srcset": "https://via.placeholder.com/960x540 960w, https://via.placeholder.com/1280x720 1280w, https://via.placeholder.com/1920x1080 1920w",
+        "src": "https://placehold.co/1920x1080",
+        "srcset": "https://placehold.co/960x540 960w, https://placehold.co/1280x720 1280w, https://placehold.co/1920x1080 1920w",
         "sizes": "100vw",
         "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "title": "Lorem ipsum",
@@ -16,23 +16,23 @@
     },
     "images": [
         {
-            "src": "https://via.placeholder.com/1920x1080",
-            "srcset": "https://via.placeholder.com/960x540 960w, https://via.placeholder.com/1280x720 1280w, https://via.placeholder.com/1920x1080 1920w",
+            "src": "https://placehold.co/1920x1080",
+            "srcset": "https://placehold.co/960x540 960w, https://placehold.co/1280x720 1280w, https://placehold.co/1920x1080 1920w",
             "sizes": "100vw",
             "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             "title": "Lorem ipsum"
         },
         {
-            "src": "https://via.placeholder.com/960x540",
-            "srcset": "https://via.placeholder.com/960x960",
+            "src": "https://placehold.co/960x540",
+            "srcset": "https://placehold.co/960x960",
             "sizes": "100vw",
             "alt": "Morbi quis tellus vel turpis auctor sagittis.",
             "title": "Morbi quis tellus"
         }
     ],
     "image_people": {
-        "src": "https://via.placeholder.com/960x540",
-        "srcset": "https://via.placeholder.com/960x960",
+        "src": "https://placehold.co/960x540",
+        "srcset": "https://placehold.co/960x960",
         "sizes": "100vw",
         "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "title": "Lorem ipsum"
@@ -104,8 +104,8 @@
     "bricks": [
         {
             "image": {
-                "src": "https://via.placeholder.com/1920x1920",
-                "srcset": "https://via.placeholder.com/960x960 960w, https://via.placeholder.com/1280x1280 1280w, https://via.placeholder.com/1920x1920 1920w",
+                "src": "https://placehold.co/1920x1920",
+                "srcset": "https://placehold.co/960x960 960w, https://placehold.co/1280x1280 1280w, https://placehold.co/1920x1920 1920w",
                 "sizes": "100vw",
                 "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 "title": "Lorem ipsum"
@@ -120,8 +120,8 @@
         },
         {
             "image": {
-                "src": "https://via.placeholder.com/1920x1920",
-                "srcset": "https://via.placeholder.com/960x960 960w, https://via.placeholder.com/1280x1280 1280w, https://via.placeholder.com/1920x1920 1920w",
+                "src": "https://placehold.co/1920x1920",
+                "srcset": "https://placehold.co/960x960 960w, https://placehold.co/1280x1280 1280w, https://placehold.co/1920x1920 1920w",
                 "sizes": "100vw",
                 "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 "title": "Lorem ipsum"

--- a/src/stories/mock-api.json
+++ b/src/stories/mock-api.json
@@ -1,8 +1,8 @@
 {
     "sectionTitle": "Section Title",
     "image": {
-        "src": "https://placehold.co/1920x1080",
-        "srcset": "https://placehold.co/960x540 960w, https://placehold.co/1280x720 1280w, https://placehold.co/1920x1080 1920w",
+        "src": "https://via.placeholder.com/1920x1080",
+        "srcset": "https://via.placeholder.com/960x540 960w, https://via.placeholder.com/1280x720 1280w, https://via.placeholder.com/1920x1080 1920w",
         "sizes": "100vw",
         "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "title": "Lorem ipsum",
@@ -16,23 +16,23 @@
     },
     "images": [
         {
-            "src": "https://placehold.co/1920x1080",
-            "srcset": "https://placehold.co/960x540 960w, https://placehold.co/1280x720 1280w, https://placehold.co/1920x1080 1920w",
+            "src": "https://via.placeholder.com/1920x1080",
+            "srcset": "https://via.placeholder.com/960x540 960w, https://via.placeholder.com/1280x720 1280w, https://via.placeholder.com/1920x1080 1920w",
             "sizes": "100vw",
             "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             "title": "Lorem ipsum"
         },
         {
-            "src": "https://placehold.co/960x540",
-            "srcset": "https://placehold.co/960x960",
+            "src": "https://via.placeholder.com/960x540",
+            "srcset": "https://via.placeholder.com/960x960",
             "sizes": "100vw",
             "alt": "Morbi quis tellus vel turpis auctor sagittis.",
             "title": "Morbi quis tellus"
         }
     ],
     "image_people": {
-        "src": "https://placehold.co/960x540",
-        "srcset": "https://placehold.co/960x960",
+        "src": "https://via.placeholder.com/960x540",
+        "srcset": "https://via.placeholder.com/960x960",
         "sizes": "100vw",
         "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "title": "Lorem ipsum"
@@ -104,8 +104,8 @@
     "bricks": [
         {
             "image": {
-                "src": "https://placehold.co/1920x1920",
-                "srcset": "https://placehold.co/960x960 960w, https://placehold.co/1280x1280 1280w, https://placehold.co/1920x1920 1920w",
+                "src": "https://via.placeholder.com/1920x1920",
+                "srcset": "https://via.placeholder.com/960x960 960w, https://via.placeholder.com/1280x1280 1280w, https://via.placeholder.com/1920x1920 1920w",
                 "sizes": "100vw",
                 "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 "title": "Lorem ipsum"
@@ -120,8 +120,8 @@
         },
         {
             "image": {
-                "src": "https://placehold.co/1920x1920",
-                "srcset": "https://placehold.co/960x960 960w, https://placehold.co/1280x1280 1280w, https://placehold.co/1920x1920 1920w",
+                "src": "https://via.placeholder.com/1920x1920",
+                "srcset": "https://via.placeholder.com/960x960 960w, https://via.placeholder.com/1280x1280 1280w, https://via.placeholder.com/1920x1920 1920w",
                 "sizes": "100vw",
                 "alt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 "title": "Lorem ipsum"

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -24,7 +24,7 @@
         position: relative;
         margin: 0px;
         padding: 25px 20px 15px 20px;
-        height: 100%;
+        border-radius: 12px;
 
         .title {
             @include ftva-card-title-2;
@@ -50,37 +50,30 @@
             }
         }
     }
+}
 
-    :deep(.rich-text) {
-        @include ftva-body-2;
-        line-height: 1.5;
-        max-width: 100%;
-        position: relative;
+.card-meta-items {
+    margin-left: 20px;
 
-        h3 {
-            @include ftva-h3;
-            color: $body-grey;
-            font-size: 30px;
+    :deep(.custom-title) {
+        .rich-text {
+            max-width: none;
+            margin: 0;
+            padding-right: 0;
+
+            h3 {
+                margin-top: 0;
+                margin-bottom: 12px;
+            }
         }
     }
 
-    .custom-title {
-        :deep(.rich-text) {
-            max-width: none;
-            margin: -20px 0px;
-            padding: 0px;
-        }
-    }
+    :deep(.custom-description) {
 
-    .custom-description {
-        @include truncate(3);
-        margin-bottom: 30px;
-
-        :deep(.rich-text) {
+        .rich-text {
             max-width: none;
-            margin-left: 0px;
-            padding-left: 0px;
-            margin-bottom: 30px;
+            margin-bottom: 24px;
+            padding-right: 0;
         }
     }
 
@@ -135,17 +128,6 @@
     @media #{$has-hover} {
         &:hover {
             box-shadow: 0 4px 4px rgb(51 51 51 / 0.2);
-        }
-    }
-
-    @media #{$small} {
-        :deep(.rich-text) {
-
-            h3 {
-                @include ftva-h3;
-                color: $body-grey;
-                font-size: 24px;
-            }
         }
     }
 }

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -8,7 +8,6 @@
     }
 
     &.is-vertical {
-
         .image-container {
             aspect-ratio: 1.71 / 1;
 
@@ -20,11 +19,17 @@
         }
     }
 
+    .block-card-half {
+        display: flex;
+        flex-direction: row;
+        gap: var(--space-xl);
+    }
+
     :deep(.card-meta) {
         position: relative;
         margin: 0px;
         padding: 25px 20px 15px 20px;
-        border-radius: 12px;
+        border-radius: 0 0 12px 12px;
 
         .title {
             @include ftva-card-title-2;

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -69,11 +69,18 @@
     }
 
     :deep(.custom-description) {
+        padding-bottom: 24px;
 
-        .rich-text {
+        :deep(.rich-text) {
             max-width: none;
             margin-bottom: 24px;
             padding-right: 0;
+
+            p {
+                margin-top: 0;
+                margin-bottom: 12px;
+                @include truncate(3);
+            }
         }
     }
 

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -8,6 +8,7 @@
     }
 
     &.is-vertical {
+
         .image-container {
             aspect-ratio: 1.71 / 1;
 
@@ -19,16 +20,8 @@
         }
     }
 
-    .block-card-half {
-        display: flex;
-        flex-direction: row;
-        gap: var(--space-xl);
-    }
-
     :deep(.card-meta) {
         position: relative;
-
-        min-height: 191px;
         margin: 0px;
         padding: 25px 20px 15px 20px;
         border-radius: 0 0 12px 12px;
@@ -57,10 +50,10 @@
             }
         }
     }
-}
 
-.card-meta-items {
-    margin-left: 20px;
+    .top-text {
+        display: flex;
+    }
 
     :deep(.custom-title) {
         .rich-text {
@@ -82,10 +75,6 @@
             margin-bottom: 24px;
             padding-right: 0;
         }
-    }
-
-    .top-text {
-        display: flex;
     }
 
     :deep(.date-time) {

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -66,8 +66,6 @@
     }
 
     :deep(.custom-description) {
-        padding-bottom: 24px;
-
         :deep(.rich-text) {
             max-width: none;
             margin-bottom: 24px;

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -37,9 +37,6 @@
         }
 
         .byline-group {
-            position: absolute;
-            bottom: var(--space-s);
-
             .date-created::before {
                 content: unset;
             }

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -27,6 +27,8 @@
 
     :deep(.card-meta) {
         position: relative;
+
+        min-height: 191px;
         margin: 0px;
         padding: 25px 20px 15px 20px;
         border-radius: 0 0 12px 12px;

--- a/src/styles/ftva/_block-card-with-image.scss
+++ b/src/styles/ftva/_block-card-with-image.scss
@@ -24,7 +24,7 @@
         position: relative;
         margin: 0px;
         padding: 25px 20px 15px 20px;
-        height: 191px;
+        height: 100%;
 
         .title {
             @include ftva-card-title-2;
@@ -51,6 +51,39 @@
         }
     }
 
+    :deep(.rich-text) {
+        @include ftva-body-2;
+        line-height: 1.5;
+        max-width: 100%;
+        position: relative;
+
+        h3 {
+            @include ftva-h3;
+            color: $body-grey;
+            font-size: 30px;
+        }
+    }
+
+    .custom-title {
+        :deep(.rich-text) {
+            max-width: none;
+            margin: -20px 0px;
+            padding: 0px;
+        }
+    }
+
+    .custom-description {
+        @include truncate(3);
+        margin-bottom: 30px;
+
+        :deep(.rich-text) {
+            max-width: none;
+            margin-left: 0px;
+            padding-left: 0px;
+            margin-bottom: 30px;
+        }
+    }
+
     .top-text {
         display: flex;
     }
@@ -68,7 +101,7 @@
         height: 34px;
         overflow: hidden;
 
-        .ongoing-item + .schedule-item  {
+        .ongoing-item+.schedule-item {
             // hide the date range if the ongoing label is display
             display: none;
         }
@@ -76,6 +109,7 @@
         .schedule-item:nth-of-type(1) {
             position: relative;
             margin-right: 28px;
+
             // show the diamond icon after, but only if it's not the last child
             &:not(:last-child)::after {
                 content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-diamond.svg');
@@ -101,6 +135,17 @@
     @media #{$has-hover} {
         &:hover {
             box-shadow: 0 4px 4px rgb(51 51 51 / 0.2);
+        }
+    }
+
+    @media #{$small} {
+        :deep(.rich-text) {
+
+            h3 {
+                @include ftva-h3;
+                color: $body-grey;
+                font-size: 24px;
+            }
         }
     }
 }

--- a/src/styles/ftva/_card-meta.scss
+++ b/src/styles/ftva/_card-meta.scss
@@ -66,11 +66,13 @@
     @include ftva-body-2;
     color: $medium-grey;
 
-    .date-created::before {
-      content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-diamond.svg');
-      margin: 0 8px;
-      padding-top: -10px;
-      filter: invert(98%) sepia(131%) saturate(1029%) hue-rotate(196deg) brightness(130%) contrast(68%);
+    :not(:first-child) {
+      .date-created::before {
+        content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-diamond.svg');
+        margin: 0 8px;
+        padding-top: -10px;
+        filter: invert(98%) sepia(131%) saturate(1029%) hue-rotate(196deg) brightness(130%) contrast(68%);
+      }
     }
   }
 

--- a/src/styles/ftva/_card-meta.scss
+++ b/src/styles/ftva/_card-meta.scss
@@ -1,6 +1,8 @@
 // CardMeta THEME
 
 .ftva.card-meta {
+  padding: 0px;
+
   .category {
     @include ftva-button-link;
     color: $accent-blue;
@@ -29,8 +31,23 @@
     margin: 0 0 24px;
   }
 
+  .custom-title {
+    :deep(.rich-text) {
+      max-width: none;
+      margin: -20px 0px;
+      padding: 0px;
+    }
+  }
+
   .custom-description {
     @include truncate(3);
+    margin-bottom: 30px;
+
+    :deep(.rich-text) {
+      max-width: none;
+      margin-left: 0px;
+      padding-left: 0px;
+    }
   }
 
   .block-tags {

--- a/src/styles/ftva/_card-meta.scss
+++ b/src/styles/ftva/_card-meta.scss
@@ -1,8 +1,6 @@
 // CardMeta THEME
 
 .ftva.card-meta {
-  padding: 0px;
-
   .category {
     @include ftva-button-link;
     color: $accent-blue;
@@ -25,17 +23,13 @@
     margin: 0 0 24px;
   }
 
-  .title-no-link {
-    @include ftva-h2;
-    color: $heading-grey;
-    margin: 0 0 24px;
-  }
-
   .custom-title {
     :deep(.rich-text) {
       max-width: none;
-      margin: -20px 0px;
-      padding: 0px;
+
+      h3 {
+        margin: 0;
+      }
     }
   }
 
@@ -48,6 +42,12 @@
       margin-left: 0px;
       padding-left: 0px;
     }
+  }
+
+  .title-no-link {
+    @include ftva-h2;
+    color: $heading-grey;
+    margin: 0 0 24px;
   }
 
   .block-tags {

--- a/src/styles/ftva/_card-meta.scss
+++ b/src/styles/ftva/_card-meta.scss
@@ -26,6 +26,8 @@
   .custom-title {
     :deep(.rich-text) {
       max-width: none;
+      margin: 0;
+      padding-right: 0;
 
       h3 {
         margin: 0;

--- a/src/styles/ftva/_card-meta.scss
+++ b/src/styles/ftva/_card-meta.scss
@@ -67,7 +67,7 @@
     color: $medium-grey;
 
     :not(:first-child) {
-      .date-created::before {
+      &.date-created::before {
         content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-diamond.svg');
         margin: 0 8px;
         padding-top: -10px;

--- a/src/styles/ftva/_card-meta.scss
+++ b/src/styles/ftva/_card-meta.scss
@@ -29,6 +29,10 @@
     margin: 0 0 24px;
   }
 
+  .custom-description {
+    @include truncate(3);
+  }
+
   .block-tags {
     display: flex;
     flex-direction: row;

--- a/src/styles/ftva/_section-wrapper.scss
+++ b/src/styles/ftva/_section-wrapper.scss
@@ -117,6 +117,12 @@
                     background-color: var(--color-theme);
                     background-color: var(--color-children-theme);
                 }
+
+                .block-highlight {
+                    .card-meta {
+                        background-color: white;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Connected to [APPS-3107](https://jira.library.ucla.edu/browse/APPS-3107)

I updated the broken images:  
from: https://via.placeholder.com. 
to: https://placehold.co/

**Notes:**
<img width="1187" alt="Screenshot 2025-01-22 at 10 39 17 AM" src="https://github.com/user-attachments/assets/999b2fbe-d1a6-4a27-9eef-90ac5228d00b" />

### HalfWidth
```html

      <div class="block-card-half-width">
        <BlockCardWithImage
          :image="mockCustomTitleAndDesription.image"
          :start-date="mockCustomTitleAndDesription.startDate"
          :category="mockCustomTitleAndDesription.category"
          :dateCreated="mockCustomTitleAndDesription.postDate"
        >
          <template #title>
            <RichText v-html="mockCustomTitleAndDesription.title" />
          </template>

          <template #description>
            <RichText v-html="mockCustomTitleAndDesription.ftvaHomepageDescription" />
          </template>

        </BlockCardWithImage>

        <BlockCardWithImage
          :image="mockCustomTitleAndDesription.image"
          :start-date="mockCustomTitleAndDesription.startDate"
          :category="mockCustomTitleAndDesription.category"
          :dateCreated="mockCustomTitleAndDesription.postDate"
        >
          <template #title>
            <RichText v-html="mockCustomTitleAndDesription.title" />
          </template>

          <template #description>
            <RichText v-html="mockCustomTitleAndDesription.ftvaHomepageDescription" />
          </template>

        </BlockCardWithImage>
      </div>

<style scoped>
.block-card-half-width {
  display: flex;
  flex-direction: row;
  gap: 28px;

  .block-highlight {
    width: 50%;

    .card-meta {
      padding: 25px 20px 15px 20px;
    }
  }
}
</style>
```
[APPS-3107]: https://uclalibrary.atlassian.net/browse/APPS-3107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ