### PR TITLE
feat: APPS-3165 Update SectionTeaserCard & BlockCardWIthImage for Collection Item page

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "sass": "^1.79.5",
     "storybook": "^7.4.1",
     "typescript": "^5.6.3",
-    "ucla-library-design-tokens": "^5.28.0",
+    "ucla-library-design-tokens": "^5.29.0",
     "video.js": "^8.5.2",
     "vite": "^5.4.8",
     "vite-svg-loader": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         specifier: ^5.6.3
         version: 5.6.3
       ucla-library-design-tokens:
-        specifier: ^5.28.0
-        version: 5.28.0
+        specifier: ^5.29.0
+        version: 5.29.0
       video.js:
         specifier: ^8.5.2
         version: 8.19.1
@@ -5958,8 +5958,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ucla-library-design-tokens@5.28.0:
-    resolution: {integrity: sha512-qgxGlK3/m0VwYGumzLZTTB/ae03DY41+80vFhm4+gukzh8XiqUsN71cg3ijk23Dl9awyicoELbRgnUV4nj3e0g==}
+  ucla-library-design-tokens@5.29.0:
+    resolution: {integrity: sha512-jKHo5fQU7rz1nxzi8in5MyTF05mI5Rctmp49xQyXzNNHxsQx0l23MueKbvWbD23ePa8P+rHjhlqf9Vg0LgfGrQ==}
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -6182,8 +6182,8 @@ packages:
   vscode-uri@3.0.8:
     resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
-  vue-component-type-helpers@2.2.0:
-    resolution: {integrity: sha512-cYrAnv2me7bPDcg9kIcGwjJiSB6Qyi08+jLDo9yuvoFQjzHiPTzML7RnkJB1+3P6KMsX/KbCD4QE3Tv/knEllw==}
+  vue-component-type-helpers@2.2.2:
+    resolution: {integrity: sha512-6lLY+n2xz2kCYshl59mL6gy8OUUTmkscmDFMO8i7Lj+QKwgnIFUZmM1i/iTYObtrczZVdw7UakPqDTGwVSGaRg==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -8905,7 +8905,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.12(typescript@5.6.3)
-      vue-component-type-helpers: 2.2.0
+      vue-component-type-helpers: 2.2.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13128,7 +13128,7 @@ snapshots:
 
   typescript@5.6.3: {}
 
-  ucla-library-design-tokens@5.28.0: {}
+  ucla-library-design-tokens@5.29.0: {}
 
   ufo@1.5.4: {}
 
@@ -13314,7 +13314,7 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-component-type-helpers@2.2.0: {}
+  vue-component-type-helpers@2.2.2: {}
 
   vue-demi@0.14.10(vue@3.5.12(typescript@5.6.3)):
     dependencies:

--- a/src/lib-components/BlockCardWithImage.vue
+++ b/src/lib-components/BlockCardWithImage.vue
@@ -134,7 +134,7 @@ const parsedDateFormat = computed(() => {
         :aspect-ratio="imageAspectRatio"
         class="image"
       >
-        <template #toptext>
+        <template v-if="$slots.toptext" #toptext>
           <slot name="toptext" />
         </template>
       </ResponsiveImage>

--- a/src/lib-components/BlockCardWithImage.vue
+++ b/src/lib-components/BlockCardWithImage.vue
@@ -133,11 +133,12 @@ const parsedDateFormat = computed(() => {
         :media="image"
         :aspect-ratio="imageAspectRatio"
         class="image"
-      />
-      <div
-        v-else
-        class="molecule-no-image"
       >
+        <template #toptext>
+          <slot name="toptext" />
+        </template>
+      </ResponsiveImage>
+      <div v-else class="molecule-no-image">
         <MoleculePlaceholder
           class="molecule"
           aria-hidden="true"
@@ -145,34 +146,16 @@ const parsedDateFormat = computed(() => {
       </div>
     </div>
     <CardMeta
-      class="card-meta-items"
-      :to="to"
-      :category="category"
-      :title="title"
-      :start-date="startDate"
-      :end-date="endDate"
-      :date-format="parsedDateFormat"
-      :ongoing="ongoing"
-      :text="text"
-      :byline-one="bylineOne"
-      :byline-two="bylineTwo"
-      :locations="locations"
-      :alternative-full-name="alternativeFullName"
-      :language="language"
-      :section-handle="sectionHandle"
-      :date-created="dateCreated"
+      class="card-meta-items" :to="to" :category="category" :title="title" :start-date="startDate"
+      :end-date="endDate" :date-format="parsedDateFormat" :ongoing="ongoing" :text="text" :byline-one="bylineOne"
+      :byline-two="bylineTwo" :locations="locations" :alternative-full-name="alternativeFullName" :language="language"
+      :section-handle="sectionHandle" :date-created="dateCreated"
     >
-      <template
-        v-if="$slots.customTitle"
-        #customTitle
-      >
+      <template v-if="$slots.customTitle" #customTitle>
         <slot name="customTitle" />
       </template>
 
-      <template
-        v-if="$slots.customDescription"
-        #customDescription
-      >
+      <template v-if="$slots.customDescription" #customDescription>
         <slot name="customDescription" />
       </template>
     </CardMeta>

--- a/src/lib-components/ResponsiveImage.vue
+++ b/src/lib-components/ResponsiveImage.vue
@@ -186,6 +186,9 @@ const classes = computed (() => {
       z-index: 1;
       .image-top-text {
         padding: 16px 16px;
+        :deep(svg.svg__icon-ftva-video) {
+          margin: -10px; // remove extra space from edges of 'icon-ftva-video' icon specifically
+        }
       }
     }
 }

--- a/src/lib-components/ResponsiveImage.vue
+++ b/src/lib-components/ResponsiveImage.vue
@@ -185,7 +185,7 @@ const classes = computed (() => {
       right: 0;
       z-index: 1;
       .image-top-text {
-        padding: 8px 8px;
+        padding: 16px 16px;
       }
     }
 }

--- a/src/lib-components/ResponsiveImage.vue
+++ b/src/lib-components/ResponsiveImage.vue
@@ -105,6 +105,11 @@ const classes = computed (() => {
     />
     <div class="sizer" :style="styles" />
     <slot />
+    <div v-if="$slots.toptext" class="toptext">
+      <div class="image-top-text">
+        <slot name="toptext" />
+      </div>
+    </div>
     <div v-if="$slots.credit" class="credit">
       <div class="credit-text">
         <slot name="credit" />
@@ -171,6 +176,16 @@ const classes = computed (() => {
         white-space: pre;
         overflow: hidden;
         text-overflow: ellipsis;
+      }
+    }
+
+    .toptext {
+      position: absolute;
+      top: 0;
+      right: 0;
+      z-index: 1;
+      .image-top-text {
+        padding: 8px 8px;
       }
     }
 }

--- a/src/lib-components/SectionTeaserCard.vue
+++ b/src/lib-components/SectionTeaserCard.vue
@@ -4,7 +4,7 @@
 >
 import { computed } from 'vue'
 import type { PropType } from 'vue'
-import IconFTVAVideo from 'ucla-library-design-tokens/assets/svgs/icon-ftva-digitalformat.svg'
+import IconFTVAVideo from 'ucla-library-design-tokens/assets/svgs/icon-ftva-video.svg'
 import type { BlockCardMetaType, CollectionItemType, EventItemType } from '@/types/types'
 import { useTheme } from '@/composables/useTheme'
 

--- a/src/lib-components/SectionTeaserCard.vue
+++ b/src/lib-components/SectionTeaserCard.vue
@@ -52,7 +52,7 @@ const currentTheme = computed(() => {
     >
       <template v-if="item.videoEmbed && item.videoEmbed !== null" #toptext>
         <BlockTag>
-          <IconFTVAVideo class="white-icon" /> &nbsp; Video
+          <IconFTVAVideo class="white-icon" />
         </BlockTag>
       </template>
     </BlockCardWithImage>

--- a/src/lib-components/SectionTeaserCard.vue
+++ b/src/lib-components/SectionTeaserCard.vue
@@ -4,14 +4,16 @@
 >
 import { computed } from 'vue'
 import type { PropType } from 'vue'
-import type { BlockCardMetaType, EventItemType } from '@/types/types'
+import IconFTVAVideo from 'ucla-library-design-tokens/assets/svgs/icon-ftva-digitalformat.svg'
+import type { BlockCardMetaType, CollectionItemType, EventItemType } from '@/types/types'
 import { useTheme } from '@/composables/useTheme'
 
 import BlockCardWithImage from '@/lib-components/BlockCardWithImage.vue'
+import BlockTag from '@/lib-components/BlockTag.vue'
 
 const { items } = defineProps({
   items: {
-    type: Array as PropType<BlockCardMetaType[] & EventItemType[]>,
+    type: Array as PropType<BlockCardMetaType[] & EventItemType[] & CollectionItemType[]>,
     default: () => [],
   },
   sectionTitle: {
@@ -26,37 +28,34 @@ const classes = computed(() => {
   return ['section-teaser-card', theme?.value || '']
 })
 
+const parsedAspectRatio = computed(() => {
+  if (items[0].sectionHandle === 'ftvaItemInCollection')
+    return 75
+
+  return 60
+})
+
 const currentTheme = computed(() => {
   return theme?.value || ''
 })
 </script>
 
 <template>
-  <ul
-    :class="classes"
-    :data-header="sectionTitle ? sectionTitle : null"
-  >
+  <ul :class="classes" :data-header="sectionTitle ? sectionTitle : null">
     <BlockCardWithImage
-      v-for="(item, index) in items"
-      :key="`Card${index}`"
-      :image="item.image"
-      :to="item.to"
-      :category="item.category"
-      :title="item.title"
-      :alternative-full-name="item.alternativeFullName"
-      :language="item.language"
-      :start-date="item.startDate"
-      :end-date="item.endDate"
-      :text="item.text"
-      :image-aspect-ratio="60"
-      :is-vertical="true"
-      :byline-one="item.bylineOne"
-      :byline-two="item.bylineTwo"
-      :section-handle="item.sectionHandle"
-      :ongoing="item.ongoing"
-      :date-created="currentTheme === 'ftva' ? item.postDate : ''"
-      class="card"
-    />
+      v-for="(item, index) in items" :key="`Card${index}`" :image="item.image" :to="item.to"
+      :category="item.category" :title="item.title" :alternative-full-name="item.alternativeFullName"
+      :language="item.language" :start-date="item.startDate" :end-date="item.endDate" :text="item.text"
+      :image-aspect-ratio="parsedAspectRatio" :is-vertical="true" :byline-one="item.bylineOne" :byline-two="item.bylineTwo"
+      :section-handle="item.sectionHandle" :ongoing="item.ongoing"
+      :date-created="currentTheme === 'ftva' ? item.postDate : ''" class="card"
+    >
+      <template v-if="item.videoEmbed && item.videoEmbed !== null" #toptext>
+        <BlockTag>
+          <IconFTVAVideo class="white-icon" /> &nbsp; Video
+        </BlockTag>
+      </template>
+    </BlockCardWithImage>
   </ul>
 </template>
 

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -1,5 +1,5 @@
 import { computed } from 'vue'
-import IconFTVAVideo from 'ucla-library-design-tokens/assets/svgs/icon-ftva-digitalformat.svg'
+import IconFTVAVideo from 'ucla-library-design-tokens/assets/svgs/icon-ftva-video.svg'
 import BlockCardWithImage from '@/lib-components/BlockCardWithImage'
 import RichText from '@/lib-components/RichText.vue'
 import SectionWrapper from '@/lib-components/SectionWrapper.vue'
@@ -403,7 +403,7 @@ function TemplateFTVAMoreCollectionItems(args) {
         :title="title"
     >
       <template #toptext>
-        <block-tag><IconFTVAVideo class="white-icon"/> &nbsp Video</block-tag>
+        <block-tag><IconFTVAVideo class="white-icon" />
       </template>
     </block-card-with-image>
 `,

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -1,7 +1,9 @@
 import { computed } from 'vue'
+import IconFTVAVideo from 'ucla-library-design-tokens/assets/svgs/icon-ftva-digitalformat.svg'
 import BlockCardWithImage from '@/lib-components/BlockCardWithImage'
 import RichText from '@/lib-components/RichText.vue'
 import SectionWrapper from '@/lib-components/SectionWrapper.vue'
+import BlockTag from '@/lib-components/BlockTag.vue'
 
 // Import mock api data
 import * as API from '@/stories/mock-api.json'
@@ -368,3 +370,43 @@ function TemplateFTVAArticleBlogListing(args) {
 }
 
 export const FTVAArticleBlogListing = TemplateFTVAArticleBlogListing.bind({})
+
+const mockMoreCollectionItem = {
+  title: 'Test Collection Item: \'Event Audio Recordings\' item w/ Video',
+  image: API.image,
+  videoEmbed: '<figure><iframe style="width:500px;height:281px;" src="//www.youtube.com/embed/C5osK7kvRGk" frameborder="0"></iframe></figure>',
+  slug: 'test-collection-item-for-archive-events-audio-recordings-2-2-2-2',
+  sectionHandle: 'ftvaItemInCollection'
+}
+function TemplateFTVAMoreCollectionItems(args) {
+  return {
+    data() {
+      return {
+        ...mockMoreCollectionItem,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { BlockCardWithImage, BlockTag, IconFTVAVideo },
+    template: `
+    <component is="style" type="text/css">
+    .white-icon > path {
+      fill: white !important;
+    }
+    </component>
+    <block-card-with-image
+        :image="image"
+        :to="to"
+        :title="title"
+    >
+      <template #toptext>
+        <block-tag><IconFTVAVideo class="white-icon"/> &nbsp Video</block-tag>
+      </template>
+    </block-card-with-image>
+`,
+  }
+}
+export const FTVAMoreCollectionItems = TemplateFTVAMoreCollectionItems.bind({})

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -394,7 +394,7 @@ function TemplateFTVAMoreCollectionItems(args) {
     template: `
     <component is="style" type="text/css">
     .white-icon > path {
-      fill: white !important;
+      fill: white;
     }
     </component>
     <block-card-with-image

--- a/src/stories/BlockCardWithImage.stories.js
+++ b/src/stories/BlockCardWithImage.stories.js
@@ -403,7 +403,7 @@ function TemplateFTVAMoreCollectionItems(args) {
         :title="title"
     >
       <template #toptext>
-        <block-tag><IconFTVAVideo class="white-icon" />
+        <block-tag><IconFTVAVideo class="white-icon" /></block-tag>
       </template>
     </block-card-with-image>
 `,

--- a/src/stories/ResponsiveImage.stories.js
+++ b/src/stories/ResponsiveImage.stories.js
@@ -1,4 +1,6 @@
+import { computed } from 'vue'
 import ResponsiveImage from '@/lib-components/ResponsiveImage'
+import BlockTag from '@/lib-components/BlockTag'
 
 // Import mock api data
 import * as API from '@/stories/mock-api.json'
@@ -91,6 +93,33 @@ export function WithLongCreditText() {
         >
         <template v-slot:credit>
                lacus sed turpis tincidunt id aliquet risus feugiat in ante metus dictum 
+        </template>
+        </responsive-image>
+    `,
+  }
+}
+
+export function WithBadgeAtTop() {
+  return {
+    components: { ResponsiveImage, BlockTag },
+    data() {
+      return {
+        image: API.image,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    template: `
+        <responsive-image
+            :media="image"
+        >
+        <template v-slot:toptext>
+            <block-tag
+            label="Some Label"
+          />
         </template>
         </responsive-image>
     `,

--- a/src/stories/SectionTeaserCard.stories.js
+++ b/src/stories/SectionTeaserCard.stories.js
@@ -439,3 +439,91 @@ export function FTVABlogSeries() {
   `,
   }
 }
+
+const mockCollectionItems = [
+  {
+    title: 'Test Collection Item: \'Event Audio Recordings\' item w/ Video',
+    slug: 'test-collection-item-for-archive-events-audio-recordings-2-2-2-2',
+    ftvaImage: [
+      {
+        id: '3156835',
+        src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/TomReed_MalcolmX.webp',
+        height: 1813,
+        width: 2560,
+        srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/TomReed_MalcolmX.webp 2560w',
+        alt: 'Tom Reed hosting an episode exploring the teachings of Malcolm X',
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ],
+    videoEmbed: null,
+    sectionHandle: 'ftvaItemInCollection'
+  },
+  {
+    title: 'Test Collection Item 4: Another \'Event Audio Recordings\' item w/ Video',
+    slug: 'test-collection-item-for-archive-events-audio-recordings-2-2-2',
+    ftvaImage: [
+      {
+        id: '3280534',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/kpil7j-21cut1large.webp',
+        height: 1664,
+        width: 2560,
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/kpil7j-21cut1large.webp 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/kpil7j-21cut1large.webp 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/kpil7j-21cut1large.webp 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/kpil7j-21cut1large.webp 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/kpil7j-21cut1large.webp 2560w',
+        alt: 'many hot air balloons in the air',
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ],
+    videoEmbed: '<figure><iframe style="width:500px;height:281px;" src="//www.youtube.com/embed/C5osK7kvRGk" frameborder="0"></iframe></figure>',
+    sectionHandle: 'ftvaItemInCollection'
+  },
+  {
+    title: 'Test Collection Item 2: \'Event Audio Recordings\' item w/ Image, No video',
+    slug: 'test-collection-item-for-archive-events-audio-recordings-2-2',
+    ftvaImage: [
+      {
+        id: '3701680',
+        src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/PXL_20240323_163248504.jpg',
+        height: 1920,
+        width: 2560,
+        srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/PXL_20240323_163248504.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/PXL_20240323_163248504.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/PXL_20240323_163248504.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/PXL_20240323_163248504.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/PXL_20240323_163248504.jpg 2560w',
+        alt: 'Image alt text here',
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ],
+    videoEmbed: null,
+    sectionHandle: 'ftvaItemInCollection'
+  }
+]
+const parsedFTVACollectionItems = mockCollectionItems.map((item) => {
+  return {
+    ...item,
+    to: item.slug, // might be item.uri in actual data
+    image: item.ftvaImage[0]
+  }
+})
+export function FTVAMoreCollectionItems() {
+  return {
+    data() {
+      return { items: parsedFTVACollectionItems }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { SectionTeaserCard },
+    template: `
+      <section-teaser-card
+        :items="items"
+      />
+  `,
+  }
+}

--- a/src/styles/default/_section-teaser-card.scss
+++ b/src/styles/default/_section-teaser-card.scss
@@ -9,7 +9,7 @@
     gap: var(--space-xl) 16px;
 
     .white-icon > :deep(path) {
-        fill: white !important;
+        fill: white;
     }
     .card {
         width: calc((100% - 32px) / 3);

--- a/src/styles/default/_section-teaser-card.scss
+++ b/src/styles/default/_section-teaser-card.scss
@@ -8,6 +8,9 @@
     justify-content: flex-start;
     gap: var(--space-xl) 16px;
 
+    .white-icon > :deep(path) {
+        fill: white !important;
+    }
     .card {
         width: calc((100% - 32px) / 3);
     }

--- a/src/styles/ftva/_section-teaser-card.scss
+++ b/src/styles/ftva/_section-teaser-card.scss
@@ -17,6 +17,10 @@
         min-width: 280px;
         margin-bottom: 15px;
         min-height: 350px;
+
+        :deep(.ftvaItemInCollection) {
+            min-height: 60px;
+        }
     }
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -145,6 +145,12 @@ export interface CardItemType {
   to: string
   type?: string
 }
+export interface CollectionItemType {
+  image: MediaItemType
+  title: string
+  to: string
+  videoEmbed: string
+}
 
 export interface DepartmentItemType {
   id?: string


### PR DESCRIPTION
Connected to [APPS-3165](https://jira.library.ucla.edu/browse/APPS-3165)

**Notes:**

- I added a slot to the `ResponsiveImage` component to allow us to put content in the top right corner of an image, similar to the credit slot we already have.
- I implemented a story for ResponsiveImage using the new slot
- I added a slot with the same name to BlockCardWithImage to allow us to pass this slot through that component
- I implemented a story for BlockCardWithImage using the new slot
- Lastly, I added some logic to SectionTeaserCard to allow it to display FTVACollectionItems with a 'Video' BlockTag when the item has a VideoEmbed field

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-3165]: https://uclalibrary.atlassian.net/browse/APPS-3165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ