### PR TITLE
feat: APPS-3150 add ftva theme to Flexible ImpactNumberCards

### DIFF
--- a/src/lib-components/Flexible/ImpactNumberCards.vue
+++ b/src/lib-components/Flexible/ImpactNumberCards.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { PropType } from 'vue'
 import type { FlexibleImpactNumberCards } from '@/types/flexible_types'
+import { useTheme } from '@/composables/useTheme'
 
 import ImpactNumberCard from '@/lib-components/ImpactNumberCard.vue'
 
@@ -10,10 +12,15 @@ const { block } = defineProps({
     default: () => { },
   },
 })
+
+const theme = useTheme()
+const classes = computed(() => {
+  return ['impact-number-cards', theme?.value || '']
+})
 </script>
 
 <template>
-  <div class="impact-number-cards">
+  <div :class="classes">
     <div class="section-header">
       <h3
         v-if="block.sectionTitle"
@@ -40,57 +47,6 @@ const { block } = defineProps({
 </template>
 
 <style lang="scss" scoped>
-.impact-number-cards {
-  max-width: $container-l-main + px;
-  margin: 0 auto;
-
-  .section-header {
-    margin-bottom: var(--space-xl);
-  }
-
-  .section-title {
-    @include step-3;
-    color: var(--color-primary-blue-03);
-    margin-bottom: var(--space-m);
-  }
-
-  .section-summary {
-    @include step-0;
-    color: var(--color-black);
-
-    :deep(p) {
-      margin: 0;
-    }
-  }
-
-  .impact-number-cards-list {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    align-content: flex-start;
-    gap: 32px 16px;
-  }
-
-  @media #{$medium} {
-    .impact-number-cards-list {
-      align-items: flex-start;
-
-      .flexible-impact-number-card {
-        width: calc((100% - 16px) / 2);
-      }
-    }
-  }
-
-  @media #{$small} {
-    .impact-number-cards-list {
-      display: flex;
-      flex-direction: column;
-
-      .flexible-impact-number-card {
-        width: 100%;
-      }
-    }
-  }
-}
+@import "@/styles/default/_impact-number-cards.scss";
+@import "@/styles/ftva/_impact-number-cards.scss";
 </style>

--- a/src/lib-components/ImpactNumberCard.vue
+++ b/src/lib-components/ImpactNumberCard.vue
@@ -33,45 +33,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-.impact-number-card {
-    width: calc((100% - 32px) / 3);
-
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-
-    .card {
-        min-height: 300px;
-        border-radius: var(--rounded-slightly-all);
-        overflow: hidden;
-        background-color: var(--color-primary-blue-01);
-
-        display: flex;
-        flex-direction: column;
-        flex-wrap: nowrap;
-        justify-content: center;
-        align-content: center;
-        align-items: center;
-    }
-    .impact-number {
-        @include step-5;
-        font-weight: 500;
-        color: var(--color-primary-blue-05);
-        font-size: 80px;
-        text-align: center;
-    }
-    .title {
-        @include step-1;
-        color: var(--color-primary-blue-05);
-        text-align: center;
-        padding: 0 16px;
-    }
-
-    .text {
-        padding-top: 16px;
-        @include step-0;
-        color: var(--color-primary-blue-05);
-        padding: 0 4px;
-    }
-}
+@import "@/styles/default/_impact-number-card.scss";
+@import "@/styles/ftva/_impact-number-card.scss";
 </style>

--- a/src/lib-components/ImpactNumberCard.vue
+++ b/src/lib-components/ImpactNumberCard.vue
@@ -1,25 +1,31 @@
-<script>
-export default {
-  name: 'ImpactNumberCard',
-  props: {
-    title: {
-      type: String,
-      default: '',
-    },
-    text: {
-      type: String,
-      default: '',
-    },
-    impactNumber: {
-      type: String,
-      default: '',
-    },
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { useTheme } from '@/composables/useTheme'
+
+const { title, text, impactNumber } = defineProps({
+  title: {
+    type: String,
+    default: '',
   },
-}
+  text: {
+    type: String,
+    default: '',
+  },
+  impactNumber: {
+    type: String,
+    default: '',
+  },
+})
+
+// THEME
+const theme = useTheme()
+const classes = computed(() => {
+  return ['impact-number-card', theme?.value || '']
+})
 </script>
 
 <template>
-  <li class="impact-number-card">
+  <li :class="classes">
     <div class="card">
       <div
         v-if="impactNumber"

--- a/src/stories/Flexible_ImpactNumberCards.stories.js
+++ b/src/stories/Flexible_ImpactNumberCards.stories.js
@@ -1,4 +1,6 @@
+import { computed, provide } from 'vue';
 import FlexibleImpactNumberCards from '@/lib-components/Flexible/ImpactNumberCards'
+import { FtvaSeries3Cards } from './SectionWrapper.stories';
 
 export default {
   title: 'FLEXIBLE / Impact Number Cards',
@@ -55,6 +57,26 @@ export function Default() {
     data() {
       return {
         block: mock,
+      }
+    },
+    components: { FlexibleImpactNumberCards },
+    template: `
+        <flexible-impact-number-cards
+            :block="block"
+        />
+    `,
+  }
+}
+export function FTVACards() { 
+  return {
+    data() {
+      return {
+        block: mock,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
       }
     },
     components: { FlexibleImpactNumberCards },

--- a/src/stories/Flexible_ImpactNumberCards.stories.js
+++ b/src/stories/Flexible_ImpactNumberCards.stories.js
@@ -1,6 +1,5 @@
-import { computed, provide } from 'vue';
+import { computed } from 'vue'
 import FlexibleImpactNumberCards from '@/lib-components/Flexible/ImpactNumberCards'
-import { FtvaSeries3Cards } from './SectionWrapper.stories';
 
 export default {
   title: 'FLEXIBLE / Impact Number Cards',
@@ -67,7 +66,7 @@ export function Default() {
     `,
   }
 }
-export function FTVACards() { 
+export function FTVACards() {
   return {
     data() {
       return {

--- a/src/stories/ImpactNumberCard.stories.js
+++ b/src/stories/ImpactNumberCard.stories.js
@@ -1,3 +1,4 @@
+import { computed } from 'vue'
 import ImpactNumberCard from '../lib-components/ImpactNumberCard'
 
 export default {
@@ -17,6 +18,29 @@ export function Default() {
     data() {
       return {
         ...mock,
+      }
+    },
+    components: { ImpactNumberCard },
+    template: `
+        <impact-number-card
+            :text="text"
+            :title="title"
+            :impact-number="impactNumber"
+        />
+    `,
+  }
+}
+
+export function FTVACards() {
+  return {
+    data() {
+      return {
+        ...mock,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
       }
     },
     components: { ImpactNumberCard },

--- a/src/styles/default/_impact-number-card.scss
+++ b/src/styles/default/_impact-number-card.scss
@@ -1,0 +1,43 @@
+.impact-number-card {
+    width: calc((100% - 32px) / 3);
+
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    .card {
+        min-height: 300px;
+        border-radius: var(--rounded-slightly-all);
+        overflow: hidden;
+        background-color: var(--color-primary-blue-01);
+
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        justify-content: center;
+        align-content: center;
+        align-items: center;
+    }
+
+    .impact-number {
+        @include step-5;
+        font-weight: 500;
+        color: var(--color-primary-blue-05);
+        font-size: 80px;
+        text-align: center;
+    }
+
+    .title {
+        @include step-1;
+        color: var(--color-primary-blue-05);
+        text-align: center;
+        padding: 0 16px;
+    }
+
+    .text {
+        padding-top: 16px;
+        @include step-0;
+        color: var(--color-primary-blue-05);
+        padding: 0 4px;
+    }
+}

--- a/src/styles/default/_impact-number-cards.scss
+++ b/src/styles/default/_impact-number-cards.scss
@@ -1,0 +1,53 @@
+.impact-number-cards {
+    max-width: $container-l-main + px;
+    margin: 0 auto;
+
+    .section-header {
+        margin-bottom: var(--space-xl);
+    }
+
+    .section-title {
+        @include step-3;
+        color: var(--color-primary-blue-03);
+        margin-bottom: var(--space-m);
+    }
+
+    .section-summary {
+        @include step-0;
+        color: var(--color-black);
+
+        :deep(p) {
+            margin: 0;
+        }
+    }
+
+    .impact-number-cards-list {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        align-content: flex-start;
+        gap: 32px 16px;
+    }
+
+    @media #{$medium} {
+        .impact-number-cards-list {
+            align-items: flex-start;
+
+            .flexible-impact-number-card {
+                width: calc((100% - 16px) / 2);
+            }
+        }
+    }
+
+    @media #{$small} {
+        .impact-number-cards-list {
+            display: flex;
+            flex-direction: column;
+
+            .flexible-impact-number-card {
+                width: 100%;
+            }
+        }
+    }
+}

--- a/src/styles/ftva/_impact-number-card.scss
+++ b/src/styles/ftva/_impact-number-card.scss
@@ -1,0 +1,3 @@
+.ftva.impact-number-card {
+    //
+}

--- a/src/styles/ftva/_impact-number-card.scss
+++ b/src/styles/ftva/_impact-number-card.scss
@@ -1,3 +1,22 @@
 .ftva.impact-number-card {
-    //
+    .card {
+        background-color: $page-blue;
+    }
+
+    .impact-number {
+        @include ftva-h3;
+        font-size: 60px;
+        color: $navy-blue;
+        padding-bottom: 12px;
+    }
+
+    .title {
+        @include ftva-card-title-2;
+        color: $accent-blue;
+    }
+
+    .text {
+        @include ftva-body;
+        color: $body-grey;
+    }
 }

--- a/src/styles/ftva/_impact-number-cards.scss
+++ b/src/styles/ftva/_impact-number-cards.scss
@@ -1,4 +1,14 @@
 .ftva.impact-number-cards {
+    .section-header {
+        .section-title {
+            @include ftva-h5;
+            color: $accent-blue;
+        }
+        .section-summary {
+            @include ftva-body;
+            color: $body-grey;
+        }
+    }
     .impact-number-cards-list {
         gap: 20px 16px;
     }

--- a/src/styles/ftva/_impact-number-cards.scss
+++ b/src/styles/ftva/_impact-number-cards.scss
@@ -1,9 +1,25 @@
 .ftva.impact-number-cards {
-//   @include ftva-card;
-//   @include ftva-card-variant;
+    .impact-number-cards-list {
+        gap: 20px 16px;
+    }
 
-//   .ftva-card__content {
-//     @include ftva-card-content;
-//     @include ftva-card-content-variant;
-//   }
+    @media #{$medium} {
+        .impact-number-cards-list {
+            align-items: flex-start;
+            .flexible-impact-number-card {
+                width: calc((100% - 16px) / 2);
+            }
+        }
+    }
+
+    @media #{$small} {
+        .impact-number-cards-list {
+            display: flex;
+            flex-direction: column;
+
+            .flexible-impact-number-card {
+                width: 100%;
+            }
+        }
+    }
 }

--- a/src/styles/ftva/_impact-number-cards.scss
+++ b/src/styles/ftva/_impact-number-cards.scss
@@ -11,13 +11,16 @@
     }
     .impact-number-cards-list {
         gap: 16px 20px;
+        .flexible-impact-number-card {
+                width: calc((100% - 40px) / 3);
+            }
     }
 
     @media #{$medium} {
         .impact-number-cards-list {
             align-items: flex-start;
             .flexible-impact-number-card {
-                width: calc((100% - 16px) / 2);
+                width: calc((100% - 40px) / 2);
             }
         }
     }

--- a/src/styles/ftva/_impact-number-cards.scss
+++ b/src/styles/ftva/_impact-number-cards.scss
@@ -10,7 +10,7 @@
         }
     }
     .impact-number-cards-list {
-        gap: 20px 16px;
+        gap: 16px 20px;
     }
 
     @media #{$medium} {

--- a/src/styles/ftva/_impact-number-cards.scss
+++ b/src/styles/ftva/_impact-number-cards.scss
@@ -1,0 +1,9 @@
+.ftva.impact-number-cards {
+//   @include ftva-card;
+//   @include ftva-card-variant;
+
+//   .ftva-card__content {
+//     @include ftva-card-content;
+//     @include ftva-card-content-variant;
+//   }
+}

--- a/src/styles/ftva/_impact-number-cards.scss
+++ b/src/styles/ftva/_impact-number-cards.scss
@@ -13,6 +13,7 @@
         gap: 16px 20px;
         .flexible-impact-number-card {
                 width: calc((100% - 40px) / 3);
+                margin-bottom: 12px;
             }
     }
 


### PR DESCRIPTION
Connected to [APPS-3150](https://jira.library.ucla.edu/browse/APPS-3150)

**Component Updated:** ImpactNumberCard.vue, ImpactNumberCards.vue

**Stories:** ~/stories/ImpactNumberCard.stories.js, ~/stories/Flexible_ImpactNumberCards.stories.js

**Notes:**

- [X] Added new stories for ImpactNumberCard & Flexible_ImpactNumberCards to display the ftva theme
- [X] Added theme to ImpactNumberCard & ImpactNumberCards
- [X] Created scss files and populated theme with styles from [this figma file](https://www.figma.com/design/EKazRIMP4B15bD16UDbOwR/UCLA-Library-Design-System?node-id=6630-47034&p=f&t=GFk8rvGgFhZo8h62-0)

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-3150]: https://uclalibrary.atlassian.net/browse/APPS-3150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ