### PR TITLE
fix: release config error

### DIFF
--- a/packages/vue-component-library/release.config.cjs
+++ b/packages/vue-component-library/release.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
     {
+      preset: 'angular',
       releaseRules: [
         { type: 'refactor', release: 'patch' },
         { type: 'chore', release: 'patch' },


### PR DESCRIPTION
Connected to [APPS-3134](https://jira.library.ucla.edu/browse/APPS-3134)
```
Error: semantic-release-monorepo: Incorrect plugin name type. Expected string but was {"releaseRules":[{"type":"refactor","release":"patch"},{"type":"chore","release":"patch"}]}.
    at semantic-release-monorepo
```

[APPS-3134]: https://uclalibrary.atlassian.net/browse/APPS-3134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ