### PR TITLE
fix: APPS-3231 Delete BlockInfo styles moved to page-level

### DIFF
--- a/packages/vue-component-library/src/styles/ftva/_block-info.scss
+++ b/packages/vue-component-library/src/styles/ftva/_block-info.scss
@@ -4,35 +4,4 @@
         --color-theme: #{$page-blue};
         background-color: var(--color-theme);
     }
-
-    // Move to page level - to be deleted when component is refactored at page-level
-    :deep(.block-info-header) {
-        @include ftva-subtitle-1;
-        text-align: center;
-        color: $heading-grey;
-        border-bottom: 1px solid $grey-blue;
-        padding: 8px 0;
-    }
-
-    // Move to page level - to be deleted when component is refactored at page-level
-    :deep(.block-info-list) {
-        padding: 16px 0 16px 20px;
-
-        li {
-            @include ftva-body-2;
-            color: $body-grey;
-
-            &::marker {
-                color: $body-grey;
-            }
-        }
-    }
-
-    // Move to page level - to be deleted when component is refactored at page-level
-    :deep(.button-link) {
-        font-size: 18px;
-        padding-left: 16px;
-        padding-right: 16px;
-        margin: 10px auto;
-    }
 }


### PR DESCRIPTION
Connected to [APPS-3231](https://jira.library.ucla.edu/browse/APPS-3231)

**Component Updated:** BlockInfo.vue

**Notes:**

- Deleted styles that have been moved to the page level

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   ~~[ ] I checked that it is working locally in the library-website-nuxt dev server~~
-   ~~[ ] I added a screenshot of it working~~
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I have requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3231]: https://uclalibrary.atlassian.net/browse/APPS-3231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ