### PR TITLE
fix: APPS-3247 Add FlexibleMediaText's missing Divider import

### DIFF
--- a/packages/vue-component-library/src/lib-components/Flexible/MediaWithText.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaWithText.vue
@@ -7,6 +7,7 @@ import { computed } from 'vue'
 
 // COMPONENTS
 import BlockMediaWithText from '@/lib-components/BlockMediaWithText.vue'
+import DividerGeneral from '@/lib-components/DividerGeneral.vue'
 
 // TYPESCRPT
 import type { FlexibleMediaWithText } from '@/types/flexible_types'
@@ -74,7 +75,7 @@ const parsedContent = computed(() => {
           class="flexible-media-with-text"
         />
 
-        <divider-general class="divider" />
+        <DividerGeneral class="divider" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Connected to [APPS-3247](https://jira.library.ucla.edu/browse/APPS-3247)

**Component Updated:** /Flexible/MediaWithText.vue

**Notes:**
- Add missing import statement for DividerGeneral component

**Before:** https://deploy-preview-707--ucla-library-storybook.netlify.app/?path=/docs/flexible-media-with-text--docs

**After:** https://deploy-preview-708--ucla-library-storybook.netlify.app/?path=/docs/flexible-media-with-text--docs

**Checklist:**

-   [x] I checked that it is working locally in the storybook
-   ~~[ ] I checked that it is working locally in the dev server~~
-   ~~[ ] I checked that it is working locally in the library-website-nuxt dev server~~
-   ~~[ ] I added a screenshot of it working~~
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I have requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3247]: https://uclalibrary.atlassian.net/browse/APPS-3247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ