### PR TITLE
fix: NO MERGE-APPS 3248 Spacing between FTVA FlexibleBlocks

### DIFF
--- a/packages/vue-component-library/src/lib-components/FlexibleBlocks.vue
+++ b/packages/vue-component-library/src/lib-components/FlexibleBlocks.vue
@@ -191,6 +191,7 @@ function getComponent(name) {
     <div
       v-for="(block, index) in parsedBlocks"
       :key="`flexibleblocks-${index}`"
+      class="block-wrapper"
     >
       <SectionWrapper
         v-if="block.needsDivider"
@@ -224,6 +225,12 @@ function getComponent(name) {
 .flexible-blocks {
   .more-information {
     @include visually-hidden;
+  }
+}
+
+.ftva.flexible-blocks {
+  .block-wrapper:not(:last-of-type) {
+    margin-bottom: 24px
   }
 }
 </style>


### PR DESCRIPTION
Connected to [APPS-3248](https://jira.library.ucla.edu/browse/APPS-3248)

**Component:** FlexibleBlocks.vue

**Notes: CLOSING TICKET**
- When FlexibleBlocks is wrapped by another component that uses the SectionWrapper component, `top-level`--a computed CSS class from SectionWrapper--is not applied to the SectionWrapper elements/tags in the various blocks. `top-level` appears to be needed for specific spacing styles to be applied to the blocks. Without it, the blocks have no spacing between them.
- This ticket was created to resolve the absence of spacing between the FlexibleBlocks on FTVA's General Content page template which was originally set up with the TwoColLayout component which uses SectionWrapper. To resolve the issue (restore spacing) at the page level, we are removing the TwoColLayout component since it is not essential to the General Content page. Without TwoColLayout as a parent container, FlexibleBlocks on that page will have spacing restored.
- Further exploration and discussion with Axa is needed to understand the workings/logic of the computed CSS values in SectionWrapper


**Checklist:**

-   ~~[ ] I checked that it is working locally in the dev server~~
-   ~~[ ] I checked that it is working locally in the storybook~~
-   ~~[ ] I checked that it is working locally in the library-website-nuxt dev server~~
-   ~~[ ] I added a screenshot of it working~~
-   ~~[ ] UX has reviewed and approved this~~
-   ~~[ ] I have requested a PR review from the Dev team~~
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3248]: https://uclalibrary.atlassian.net/browse/APPS-3248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ