### PR TITLE
fix: APPS-3263 Fix FTVA PageAnchor alignment

### DIFF
--- a/packages/vue-component-library/src/stories/PageAnchor.stories.js
+++ b/packages/vue-component-library/src/stories/PageAnchor.stories.js
@@ -129,6 +129,7 @@ FTVATheme.args = {
     'Research at UCLA',
     'Acknowledgements',
     'Additional materials',
+    'A Longer Headline for Testing: National Archives of Finland'
   ],
   color: 'default',
 }

--- a/packages/vue-component-library/src/styles/ftva/_page-anchor.scss
+++ b/packages/vue-component-library/src/styles/ftva/_page-anchor.scss
@@ -5,6 +5,7 @@
     }
 
     .dropdown-button {
+        
         span.caret {
             position: relative;
             top: 5px;
@@ -15,7 +16,6 @@
         @include ftva-subtitle-2;
         color: var(--ftva-medium-blue);
         text-transform: unset;
-        align-self: flex-start;
         justify-content: flex-start;
         letter-spacing: normal;
     }
@@ -36,7 +36,7 @@
       }
     }
     .page-anchor-list {
-        padding-left: 4px;
+        padding-left: 8px;
         padding-right: 4px;
 
         li.link {
@@ -47,6 +47,7 @@
                     padding-left: 0px;
                 }
                 margin-top: 8px;
+                margin-left: -4px;
                 padding-left: 0px;
                 
             }

--- a/packages/vue-component-library/src/styles/ftva/_page-anchor.scss
+++ b/packages/vue-component-library/src/styles/ftva/_page-anchor.scss
@@ -1,9 +1,16 @@
 .ftva.page-anchor {
-    float: none;
 
     .page-anchor-content {
         padding: 4px;
     }
+
+    .dropdown-button {
+        span.caret {
+            position: relative;
+            top: 5px;
+        }
+    }
+
     li.link, .dropdown-button {
         @include ftva-subtitle-2;
         color: var(--ftva-medium-blue);
@@ -12,14 +19,15 @@
         justify-content: flex-start;
         letter-spacing: normal;
     }
+
     .page-anchor-list,
     .link a { 
         @include ftva-subtitle-2;
         color: $subtitle-grey;
+        text-align: left;
         text-transform: unset;
         align-items: flex-start;
         justify-content: flex-start;
-        padding-left: 4px;
         letter-spacing: normal;
     }
     .link {
@@ -28,13 +36,15 @@
       }
     }
     .page-anchor-list {
+        padding-left: 4px;
+        padding-right: 4px;
 
         li.link {
             padding: 4px;
             &:last-child {
                 a {
                     color: var(--ftva-medium-blue);
-                    padding-left: 0px;;
+                    padding-left: 0px;
                 }
                 margin-top: 8px;
                 padding-left: 0px;


### PR DESCRIPTION
Connected to [APPS-3263](https://jira.library.ucla.edu/browse/APPS-3263)

**Component Updated:** PageAnchor.vue

**Notes:**
- Updated positioning of FTVA anchor
- Adjusted alignment of icon/caret
- Updated/tested story with a longer title

**Preview:** https://deploy-preview-711--ucla-library-storybook.netlify.app/?path=/story/pageanchor--ftva-theme

**Local Nuxt previews:**

 - Before
![ftva-page-anchor-before](https://github.com/user-attachments/assets/4e241691-5a81-4bf1-9cfe-538369849088)

<br>

- After
![ftva-page-anchor-after](https://github.com/user-attachments/assets/feb1f084-3e0d-4aec-ba58-8e8fb31d3a36)

<br>

**Checklist:**

-   ~~[ ] I checked that it is working locally in the dev server~~
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3263]: https://uclalibrary.atlassian.net/browse/APPS-3263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ