### PR TITLE
feat: add section-title and section-summary

### DIFF
--- a/packages/vue-component-library/src/lib-components/FlexibleBlocks.vue
+++ b/packages/vue-component-library/src/lib-components/FlexibleBlocks.vue
@@ -222,7 +222,6 @@ function getComponent(name) {
   lang="scss"
   scoped
 >
-
 // default theme
 .flexible-blocks {
   .more-information {
@@ -244,7 +243,6 @@ function getComponent(name) {
         color: $medium-grey;
       }
     }
-  } 
+  }
 }
-
 </style>

--- a/packages/vue-component-library/src/lib-components/FlexibleBlocks.vue
+++ b/packages/vue-component-library/src/lib-components/FlexibleBlocks.vue
@@ -203,6 +203,7 @@ function getComponent(name) {
         :theme="block.theme"
         :section-title="sectionTitle(block)"
         :section-summary="sectionSummary(block)"
+        class="flexible-block-section-wrapper"
       >
         <component
           :is="getComponent(block.componentName)"
@@ -221,9 +222,29 @@ function getComponent(name) {
   lang="scss"
   scoped
 >
+
+// default theme
 .flexible-blocks {
   .more-information {
     @include visually-hidden;
   }
 }
+
+// ftva theme
+.ftva.flexible-blocks {
+  .flexible-block-section-wrapper {
+    // sections within flexible blocks have bold titles and medium grey summaries
+    :deep(.section-header) {
+      .section-title {
+          @include ftva-h5;
+          color: $accent-blue;
+        }
+      .section-summary {
+        @include ftva-body;
+        color: $medium-grey;
+      }
+    }
+  } 
+}
+
 </style>

--- a/packages/vue-component-library/src/lib-components/FlexibleBlocks.vue
+++ b/packages/vue-component-library/src/lib-components/FlexibleBlocks.vue
@@ -234,6 +234,7 @@ function getComponent(name) {
   .flexible-block-section-wrapper {
     // sections within flexible blocks have bold titles and medium grey summaries
     :deep(.section-header) {
+      margin-bottom: 12px;
       .section-title {
           @include ftva-h5;
           color: $accent-blue;

--- a/packages/vue-component-library/src/styles/ftva/_section-wrapper.scss
+++ b/packages/vue-component-library/src/styles/ftva/_section-wrapper.scss
@@ -1,4 +1,5 @@
 .ftva.section-wrapper {
+    
     // remove max-width from rich-text inside flexible-blocks for ftva
     &.flexible-blocks {
         :deep(.rich-text) {

--- a/packages/vue-component-library/src/styles/ftva/_section-wrapper.scss
+++ b/packages/vue-component-library/src/styles/ftva/_section-wrapper.scss
@@ -1,16 +1,4 @@
 .ftva.section-wrapper {
-    // ftva section-header & section-summary styling
-    .section-header { 
-        .section-title { 
-          @include ftva-h5;
-          color: $accent-blue;
-        }
-        .section-summary {
-          @include ftva-body;
-          color: $medium-grey;
-        }
-    }
-
     // remove max-width from rich-text inside flexible-blocks for ftva
     &.flexible-blocks {
         :deep(.rich-text) {
@@ -19,7 +7,6 @@
         }
     }
 
-    // section header specific styling for section teaser card
     .section-header:has(+ ul.section-teaser-card.ftva) {
         // Set to zero to remove margin under Section Title
         // Explore Other Series or Events or Related Collections and Recent Posts

--- a/packages/vue-component-library/src/styles/ftva/_section-wrapper.scss
+++ b/packages/vue-component-library/src/styles/ftva/_section-wrapper.scss
@@ -1,4 +1,15 @@
 .ftva.section-wrapper {
+    // ftva section-header & section-summary styling
+    .section-header { 
+        .section-title { 
+          @include ftva-h5;
+          color: $accent-blue;
+        }
+        .section-summary {
+          @include ftva-body;
+          color: $medium-grey;
+        }
+    }
 
     // remove max-width from rich-text inside flexible-blocks for ftva
     &.flexible-blocks {
@@ -8,6 +19,7 @@
         }
     }
 
+    // section header specific styling for section teaser card
     .section-header:has(+ ul.section-teaser-card.ftva) {
         // Set to zero to remove margin under Section Title
         // Explore Other Series or Events or Related Collections and Recent Posts

--- a/packages/vue-component-library/src/styles/ftva/_section-wrapper.scss
+++ b/packages/vue-component-library/src/styles/ftva/_section-wrapper.scss
@@ -1,5 +1,5 @@
 .ftva.section-wrapper {
-    
+
     // remove max-width from rich-text inside flexible-blocks for ftva
     &.flexible-blocks {
         :deep(.rich-text) {


### PR DESCRIPTION
Connected to [APPS-3260](https://jira.library.ucla.edu/browse/APPS-3260)

**Component Updated:** SectionWrapper.vue styles

**Notes:**

The ticket specified these styles at the `SectionWrapper` level however that will not work because we do not want SectionWrappers to have bold titles outside of `FlexibleBlock` components (confirmed by @tieserena in this [slack thread](https://uclalibrary.slack.com/archives/C014BPS0YBX/p1742406743756219)) - so they have been added to FlexibleBlock instead

- [X] Added styles for section header and summary within `SectionWrapper` component to `FlexibleBlocks` styles

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-3260]: https://uclalibrary.atlassian.net/browse/APPS-3260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ