### PR TITLE
feat: use a vite plugin to inject css at the begining of the bundled javascript files

### DIFF
--- a/packages/component-library-nuxt-module/src/module.ts
+++ b/packages/component-library-nuxt-module/src/module.ts
@@ -12,7 +12,7 @@ export default defineNuxtModule<ModuleOptions>({
   setup(_options, _nuxt) {
     const logger = useLogger('@ucla-library/component-library-nuxt-module')
 
-    _nuxt.options.css.push('@ucla-library-monorepo/ucla-library-website-components/style.css')
+    // _nuxt.options.css.push('@ucla-library-monorepo/ucla-library-website-components/style.css')
     Object.keys(VueComponentLibrary)
       .forEach((component) => {
         logger.info(`Adding component: ${component}`)

--- a/packages/vue-component-library/package.json
+++ b/packages/vue-component-library/package.json
@@ -85,6 +85,7 @@
     "video.js": "^8.5.2",
     "vite": "catalog:",
     "vite-plugin-dts": "^4.5.0",
+    "vite-plugin-css-injected-by-js": "^3.5.2",
     "vite-svg-loader": "^5.1.0",
     "vue": "catalog:",
     "vue-router": "^4.4.5",

--- a/packages/vue-component-library/vite.config.ts
+++ b/packages/vue-component-library/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import svgLoader from 'vite-svg-loader'
 import dts from 'vite-plugin-dts'
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -39,6 +40,7 @@ export default defineConfig({
       insertTypesEntry: true,
       rollupTypes: true,
     }),
+    cssInjectedByJsPlugin()
   ],
   build: {
     lib: {
@@ -72,6 +74,7 @@ export default defineConfig({
     preprocessorOptions: {
       // Additional Sass options go here
       scss: {
+        silenceDeprecations: ['legacy-js-api'],
         additionalData: `
                   @import "ucla-library-design-tokens/scss/fonts.scss";
                   @import "ucla-library-design-tokens/scss/_tokens-ftva";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 5.4.14(@types/node@18.19.80)(sass@1.85.1)(terser@5.39.0)
+      vite-plugin-css-injected-by-js:
+        specifier: ^3.5.2
+        version: 3.5.2(vite@5.4.14(@types/node@18.19.80)(sass@1.85.1)(terser@5.39.0))
       vite-plugin-dts:
         specifier: ^4.5.0
         version: 4.5.3(@types/node@18.19.80)(rollup@4.35.0)(typescript@5.8.2)(vite@5.4.14(@types/node@18.19.80)(sass@1.85.1)(terser@5.39.0))
@@ -9033,6 +9036,11 @@ packages:
         optional: true
       vue-tsc:
         optional: true
+
+  vite-plugin-css-injected-by-js@3.5.2:
+    resolution: {integrity: sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==}
+    peerDependencies:
+      vite: '>2.0.0-0'
 
   vite-plugin-dts@4.5.3:
     resolution: {integrity: sha512-P64VnD00dR+e8S26ESoFELqc17+w7pKkwlBpgXteOljFyT0zDwD8hH4zXp49M/kciy//7ZbVXIwQCekBJjfWzA==}
@@ -19746,6 +19754,10 @@ snapshots:
       optionator: 0.9.4
       typescript: 5.8.2
       vue-tsc: 2.2.8(typescript@5.8.2)
+
+  vite-plugin-css-injected-by-js@3.5.2(vite@5.4.14(@types/node@18.19.80)(sass@1.85.1)(terser@5.39.0)):
+    dependencies:
+      vite: 5.4.14(@types/node@18.19.80)(sass@1.85.1)(terser@5.39.0)
 
   vite-plugin-dts@4.5.3(@types/node@18.19.80)(rollup@4.35.0)(typescript@5.8.2)(vite@5.4.14(@types/node@18.19.80)(sass@1.85.1)(terser@5.39.0)):
     dependencies:


### PR DESCRIPTION


Connected to [APPS-3264](https://jira.library.ucla.edu/browse/APPS-3264)

https://github.com/marco-prontera/vite-plugin-css-injected-by-js/tree/main



[APPS-3264]: https://uclalibrary.atlassian.net/browse/APPS-3264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ