### PR TITLE
feat: revert svgo changes

### DIFF
--- a/packages/vue-component-library/vite.config.ts
+++ b/packages/vue-component-library/vite.config.ts
@@ -19,19 +19,19 @@ export default defineConfig({
       },
     }),
     svgLoader({
-      svgo: true, // Enables SVGO optimization
-      svgoConfig: {
-        plugins: [
-          {
-            name: 'preset-default',
-            params: {
-              overrides: {
-                removeViewBox: false,
-              },
-            },
-          },
-        ]
-      }
+      svgo: false, // Enables SVGO optimization
+      // svgoConfig: {
+      //   plugins: [
+      //     {
+      //       name: 'preset-default',
+      //       params: {
+      //         overrides: {
+      //           removeViewBox: false,
+      //         },
+      //       },
+      //     },
+      //   ]
+      // }
     }),
     dts({
       tsconfigPath: './tsconfig.json',


### PR DESCRIPTION
Connected to [APPS-3281](https://jira.library.ucla.edu/browse/APPS-3281)

When I enabled svg optimization in vite.config.ts in this PR https://github.com/UCLALibrary/ucla-library-website-components/pull/710

The ftva main footer UCLA library image was hidden and we could only see a white rectangular box in storybook and on the ftva pages 
old: https://deploy-preview-710--ucla-library-storybook.netlify.app/?path=/story/footer-main--ftva-footer
fixed in this PR: https://deploy-preview-717--ucla-library-storybook.netlify.app/?path=/story/footer-main--ftva-footer

[APPS-3281]: https://uclalibrary.atlassian.net/browse/APPS-3281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ