### PR TITLE
feat: selcted letter needs to reset to empty string after the filter is removed from search-generic search filters

### DIFF
--- a/packages/vue-component-library/src/lib-components/AlphabeticalBrowseBy.vue
+++ b/packages/vue-component-library/src/lib-components/AlphabeticalBrowseBy.vue
@@ -107,6 +107,10 @@ export default {
         return this.alphabet.filter(item => (item.letter !== 'All') || (item.letter === 'All' && this.displayAll)).map((item) => {
           let letterClass = 'letter'
           // Set the class for the letter when initially loaded
+
+          if (this.selectedLetterProp === '')
+            this.selectedLetter = ''
+
           if (
             item.letter === this.selectedLetterProp
             && this.selectedLetter === ''


### PR DESCRIPTION
Connected to [APPS-2314](https://jira.library.ucla.edu/browse/APPS-2314)
 if the selectedprop is empty also reset selectedletter data in the component to empty string

[APPS-2314]: https://uclalibrary.atlassian.net/browse/APPS-2314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ