### PR TITLE
fix: reset querydropdownqueryFilterButtonDropDownStates when newQueryFilters is empty

### DIFF
--- a/packages/vue-component-library/src/lib-components/SearchGenericFilters.vue
+++ b/packages/vue-component-library/src/lib-components/SearchGenericFilters.vue
@@ -56,6 +56,9 @@ const openItemIndex = ref(-1) // -1 indicates that no item is open
 watch(() => props.queryFilters, (newQueryFilters) => {
   // Assuming newQueryFilters is always an object as per your default prop definition.
   console.log('In watch function props.queryFilters updated', JSON.stringify(newQueryFilters), JSON.stringify(props.filters))
+  if (newQueryFilters === null || newQueryFilters === undefined || Object.keys(newQueryFilters).length === 0)
+    queryFilterButtonDropDownStates.value = {}
+
   Object.entries(newQueryFilters).forEach(([key, value]) => {
     queryFilterButtonDropDownStates.value[key] = value
   })


### PR DESCRIPTION
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/dc41d5e8-6766-45a0-bab8-cf0043e995b2" />
