### PR TITLE
feat: APPS-2805 Update Lightbox Theme for FTVA Homepage

### DIFF
--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -71,15 +71,17 @@ const paginationCounterRef = ref()
 onMounted(() => {
   lightbox.value?.focus()
 
-  // Function sets placement of arrows for FTVA Homepage Carousel; conditional to prevent getBoundingClientRect error when there is no pagination counter, i.e., only single item in the carousel
-
-  if (items.length > 1 && theme.value === 'ftva')
-    setFTVAHomepageNavigationArrows()
+  // Sets placement of arrows for FTVA Homepage Carousel
+  setFTVAHomepageNavigationArrows()
 })
 
 // For FTVA Homepage Carousel:
 // Offset placement of navigation arrows based on width of pagination counter
 function setFTVAHomepageNavigationArrows() {
+  // Prevent getBoundingClientRect error when there is no pagination counter, i.e., only single item in the carousel
+  if (items.length < 2)
+    return null
+
   const coordinates = paginationCounterRef.value.getBoundingClientRect()
 
   prevBtnRef.value.style.setProperty('--counterWidth', `${coordinates.width}px`)

--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -9,6 +9,8 @@ import SvgIconCaretRight from 'ucla-library-design-tokens/assets/svgs/icon-caret
 import SvgIconClose from 'ucla-library-design-tokens/assets/svgs/icon-close-large.svg'
 import SvgIconMoleculeBullet from 'ucla-library-design-tokens/assets/svgs/icon-molecule-bullet-filled.svg'
 import SmartLink from '../../SmartLink.vue'
+
+// import RichText from '../RichText.vue'
 import type { MediaGalleryItemType } from '@/types/types'
 import MediaItem from '@/lib-components/Media/Item.vue'
 
@@ -63,18 +65,21 @@ const parsedObjectFit = computed(() => {
 
 const lightbox = ref<HTMLElement | null>(null) // replacing this.$refs.lightbox
 
+onMounted(() => {
+  lightbox.value?.focus()
+
+  // Conditional to prevent getBoundingClientRect error when there is no pagination counter, i.e., only single item in the carousel
+  // Function sets placement of arrows for FTVA Homepage Inline Lightbox
+  if (items.length > 1 && theme.value === 'ftva')
+    setFTVAHomepageNavigationArrows()
+})
+
+// For FTVA Homepage Inline Lightbox:
+// Offset placement of navigation arrows based on width of pagination counter
 const prevBtnRef = ref()
 const nextBtnRef = ref()
 const paginationCounterRef = ref()
 
-onMounted(() => {
-  lightbox.value?.focus()
-
-  setFTVAHomepageNavigationArrows()
-})
-
-// For FTVA Homepage Inline Lightbox
-// Offset placement of navigation arrows based on width of pagination counter
 function setFTVAHomepageNavigationArrows() {
   const coordinates = paginationCounterRef.value.getBoundingClientRect()
 
@@ -138,12 +143,12 @@ function setCurrentSlide(currentSlide: number) {
           <!-- additional blocktags/labels/simple elements can be slotted in here by parent -->
         </div>
         <h4 v-if="captionTitle" class="media-object-title" v-text="captionTitle[selectionIndex]" />
+
         <p v-if="captionText" class="media-object-caption" v-text="captionText[selectionIndex]" />
 
-        <!-- Credit text as part of caption area -->
-        <!-- <p v-if="items && items[selectionIndex] && items[selectionIndex].credit" class="media-object-credit">
+        <p v-if="items && items[selectionIndex] && items[selectionIndex].credit" class="media-object-credit">
           {{ items[selectionIndex].credit }}
-        </p> -->
+        </p>
         <SmartLink
           v-if="items && items[selectionIndex] && items[selectionIndex].linkUrl
             && items[selectionIndex].linkText

--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -63,6 +63,11 @@ const parsedObjectFit = computed(() => {
 
 const lightbox = ref<HTMLElement | null>(null) // replacing this.$refs.lightbox
 
+// For FTVA Homepage Carousel:
+const prevBtnRef = ref()
+const nextBtnRef = ref()
+const paginationCounterRef = ref()
+
 onMounted(() => {
   lightbox.value?.focus()
 
@@ -74,10 +79,6 @@ onMounted(() => {
 
 // For FTVA Homepage Carousel:
 // Offset placement of navigation arrows based on width of pagination counter
-const prevBtnRef = ref()
-const nextBtnRef = ref()
-const paginationCounterRef = ref()
-
 function setFTVAHomepageNavigationArrows() {
   const coordinates = paginationCounterRef.value.getBoundingClientRect()
 

--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -74,6 +74,10 @@ function closeModal() {
 function setCurrentSlide(currentSlide: number) {
   selectionIndex.value = currentSlide
 }
+
+const prevBtnRef = ref()
+const nextBtnRef = ref()
+const paginationWidth = ref()
 </script>
 
 <template>
@@ -96,11 +100,11 @@ function setCurrentSlide(currentSlide: number) {
     </Carousel>
 
     <!-- Navigation -->
-    <button v-if="items.length > 1" class="button-prev" :disabled="selectionIndex <= 0" @click="selectionIndex -= 1">
+    <button v-if="items.length > 1" ref="prevBtnRef" class="button-prev" :disabled="selectionIndex <= 0" @click="selectionIndex -= 1">
       <SvgIconCaretLeft aria-label="Show previous image" />
     </button>
     <button
-      v-if="items.length > 1" class="button-next" :disabled="selectionIndex >= items.length - 1"
+      v-if="items.length > 1" ref="nextBtnRef" class="button-next" :disabled="selectionIndex >= items.length - 1"
       @click="selectionIndex += 1"
     >
       <SvgIconCaretRight aria-label="Show next image" />
@@ -108,7 +112,7 @@ function setCurrentSlide(currentSlide: number) {
 
     <!-- Pagination -->
     <div class="caption-block">
-      <div v-if="items.length > 1" class="media-counter" role="tablist">
+      <div v-if="items.length > 1" ref="paginationWidth" class="media-counter" role="tablist">
         <button
           v-for="index in items.length" :key="`caption-block-${index}`" :disabled="index - 1 === selectionIndex"
           class="media-counter-item" @click="setCurrentSlide(index - 1)"
@@ -118,12 +122,15 @@ function setCurrentSlide(currentSlide: number) {
       </div>
       <!-- Captions -->
       <div class="caption-content">
-        <slot :selection-index="selectionIndex" /><!-- additional blocktags etc, can be slotted in here by parent -->
+        <div class="media-object-caption-slot">
+          <slot :selection-index="selectionIndex" />
+          <!-- additional blocktags/labels/simple elements can be slotted in here by parent -->
+        </div>
         <h4 v-if="captionTitle" class="media-object-title" v-text="captionTitle[selectionIndex]" />
         <p v-if="captionText" class="media-object-caption" v-text="captionText[selectionIndex]" />
-        <p v-if="items && items[selectionIndex] && items[selectionIndex].credit" class="media-object-credit">
+        <!-- <p v-if="items && items[selectionIndex] && items[selectionIndex].credit" class="media-object-credit">
           {{ items[selectionIndex].credit }}
-        </p>
+        </p> -->
         <SmartLink
           v-if="items && items[selectionIndex] && items[selectionIndex].linkUrl
             && items[selectionIndex].linkText

--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -147,6 +147,7 @@ function setCurrentSlide(currentSlide: number) {
         <p v-if="items && items[selectionIndex] && items[selectionIndex].credit" class="media-object-credit">
           {{ items[selectionIndex].credit }}
         </p>
+
         <SmartLink
           v-if="items && items[selectionIndex] && items[selectionIndex].linkUrl
             && items[selectionIndex].linkText

--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -139,6 +139,8 @@ function setCurrentSlide(currentSlide: number) {
         </div>
         <h4 v-if="captionTitle" class="media-object-title" v-text="captionTitle[selectionIndex]" />
         <p v-if="captionText" class="media-object-caption" v-text="captionText[selectionIndex]" />
+
+        <!-- Credit text as part of caption area -->
         <!-- <p v-if="items && items[selectionIndex] && items[selectionIndex].credit" class="media-object-credit">
           {{ items[selectionIndex].credit }}
         </p> -->

--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -66,13 +66,13 @@ const lightbox = ref<HTMLElement | null>(null) // replacing this.$refs.lightbox
 onMounted(() => {
   lightbox.value?.focus()
 
-  // Conditional to prevent getBoundingClientRect error when there is no pagination counter, i.e., only single item in the carousel
-  // Function sets placement of arrows for FTVA Homepage Inline Lightbox
+  // Function sets placement of arrows for FTVA Homepage Carousel; conditional to prevent getBoundingClientRect error when there is no pagination counter, i.e., only single item in the carousel
+
   if (items.length > 1 && theme.value === 'ftva')
     setFTVAHomepageNavigationArrows()
 })
 
-// For FTVA Homepage Inline Lightbox:
+// For FTVA Homepage Carousel:
 // Offset placement of navigation arrows based on width of pagination counter
 const prevBtnRef = ref()
 const nextBtnRef = ref()

--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -63,9 +63,24 @@ const parsedObjectFit = computed(() => {
 
 const lightbox = ref<HTMLElement | null>(null) // replacing this.$refs.lightbox
 
+const prevBtnRef = ref()
+const nextBtnRef = ref()
+const paginationCounterRef = ref()
+
 onMounted(() => {
   lightbox.value?.focus()
+
+  setFTVAHomepageNavigationArrows()
 })
+
+// For FTVA Homepage Inline Lightbox
+// Offset placement of navigation arrows based on width of pagination counter
+function setFTVAHomepageNavigationArrows() {
+  const coordinates = paginationCounterRef.value.getBoundingClientRect()
+
+  prevBtnRef.value.style.setProperty('--counterWidth', `${coordinates.width}px`)
+  nextBtnRef.value.style.setProperty('--counterWidth', `${coordinates.width}px`)
+}
 
 function closeModal() {
   emit('closeModal')
@@ -74,10 +89,6 @@ function closeModal() {
 function setCurrentSlide(currentSlide: number) {
   selectionIndex.value = currentSlide
 }
-
-const prevBtnRef = ref()
-const nextBtnRef = ref()
-const paginationWidth = ref()
 </script>
 
 <template>
@@ -112,7 +123,7 @@ const paginationWidth = ref()
 
     <!-- Pagination -->
     <div class="caption-block">
-      <div v-if="items.length > 1" ref="paginationWidth" class="media-counter" role="tablist">
+      <div v-if="items.length > 1" ref="paginationCounterRef" class="media-counter" role="tablist">
         <button
           v-for="index in items.length" :key="`caption-block-${index}`" :disabled="index - 1 === selectionIndex"
           class="media-counter-item" @click="setCurrentSlide(index - 1)"

--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -9,8 +9,6 @@ import SvgIconCaretRight from 'ucla-library-design-tokens/assets/svgs/icon-caret
 import SvgIconClose from 'ucla-library-design-tokens/assets/svgs/icon-close-large.svg'
 import SvgIconMoleculeBullet from 'ucla-library-design-tokens/assets/svgs/icon-molecule-bullet-filled.svg'
 import SmartLink from '../../SmartLink.vue'
-
-// import RichText from '../RichText.vue'
 import type { MediaGalleryItemType } from '@/types/types'
 import MediaItem from '@/lib-components/Media/Item.vue'
 

--- a/packages/vue-component-library/src/stories/Flexible_MediaGallery.spec.js
+++ b/packages/vue-component-library/src/stories/Flexible_MediaGallery.spec.js
@@ -14,7 +14,7 @@ describe('FLEXIBLE / Media Gallery', () => {
     cy.get('.caption-block')
       .should('contain', 'View catalog record')
       .and('contain', 'photo by someone')
-    cy.get('.button-close').click({ force: true })
+    cy.get('.button-close').click()
 
     cy.contains('.thumbnail-card', 'Edison Studios in credit field').should(
       'be.visible'

--- a/packages/vue-component-library/src/stories/Flexible_MediaGallery.spec.js
+++ b/packages/vue-component-library/src/stories/Flexible_MediaGallery.spec.js
@@ -14,7 +14,7 @@ describe('FLEXIBLE / Media Gallery', () => {
     cy.get('.caption-block')
       .should('contain', 'View catalog record')
       .and('contain', 'photo by someone')
-    cy.get('.button-close').click()
+    cy.get('.button-close').click({ force: true })
 
     cy.contains('.thumbnail-card', 'Edison Studios in credit field').should(
       'be.visible'

--- a/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
+++ b/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
@@ -78,7 +78,7 @@ export function FTVA_DefaultLightbox() {
   }
 }
 
-export function FTVA_EventDetailCarousel() {
+export function FTVA_InlineCarousel() {
   return {
     data() {
       return {
@@ -99,7 +99,7 @@ export function FTVA_EventDetailCarousel() {
 // mockdata for blocktags in parent
 const mockTags = ['tag1', 'tag2', 'tag3']
 // TODO: for part 2 of carousel homepage styling
-export function FTVA_Homepage() {
+export function FTVA_HomepageCarousel() {
   return {
     setup() {
       return {

--- a/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
+++ b/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
@@ -4,6 +4,8 @@ import FlexibleMediaGalleryNewLightbox from '@/lib-components/Flexible/MediaGall
 import BlockTag from '@/lib-components/BlockTag.vue'
 import { Gallery as MEDIA_GALLERY_MOCK } from '@/stories/mock/Media'
 
+// import { mockFTVAHomepageCarousel } from '@/stories/mock/FTVAMedia'
+
 // Storybook default settings
 export default {
   title: 'Media Gallery / New Lightbox',
@@ -39,7 +41,7 @@ export function SingleItem() {
 const mockFTVAGalleryRawData = [
   {
     image: [MEDIA_GALLERY_MOCK.mediaGallery[0].item],
-    creditText: 'Credit text'
+    creditText: 'Credit text 1'
   },
   {
     image: [MEDIA_GALLERY_MOCK.mediaGallery[1].item],
@@ -95,32 +97,46 @@ export function FTVA_InlineCarousel() {
   }
 }
 
-const mockFTVAGalleryComputedData2 = computed(() => {
-  // map image to item, map creditText to credit
-  return mockFTVAGalleryRawData.map((rawItem) => {
+function parseFTVACarouselImage(imgObj) {
+  return [{
+    ...imgObj[0],
+    src: imgObj[0]?.url,
+    kind: 'image', // This key is expected by the Media component
+  }]
+}
+
+function parseFTVATypeHandles(str) {
+  switch (str) {
+    case 'ftvaEvent':
+      return 'Event'
+    case 'ftvaArticle':
+      return 'Article'
+    case 'eventSeries':
+      return 'Series'
+    default:
+      return null
+  }
+}
+
+const parsedMockHomepagCarousel = computed(() => {
+  return FTVAMedia.mockFTVAHomepageCarousel.map((rawItem) => {
     return {
-      item: rawItem.image[0],
+      item: parseFTVACarouselImage(rawItem.ftvaImage),
       credit: rawItem.creditText,
-      captionText: 'This short is a compilation of two Swedish commercials shown in Stockholm theaters, showing Garbo (still Gustafsson at the time) modeling hats for a department store and eating pastries at a café.', // TODO get homepage carousel data sample to make more accurate
-      captionTitle: 'The Saga of Gösta Berling If the Title Continues to the Second Line' // TODO get homepage carousel data sample to make more accurate
+      tag: parseFTVATypeHandles(rawItem.typeHandle),
+      captionText: rawItem.ftvaHomepageDescription,
+      captionTitle: rawItem.ftvaHomepageTitle
+      // eventDate
+      // eventTime
     }
   })
 })
 
-// TODO finish example showing homepage implementation with slots
-// mockdata for blocktags in parent
-const mockTags = ['taglabel1', 'tag2', 'tag3']
-// TODO: for part 2 of carousel homepage styling
 export function FTVA_HomepageCarousel() {
   return {
-    setup() {
-      return {
-        mockTags
-      }
-    },
     data() {
       return {
-        items: mockFTVAGalleryComputedData2
+        items: parsedMockHomepagCarousel
       }
     },
     provide() {
@@ -129,6 +145,6 @@ export function FTVA_HomepageCarousel() {
       }
     },
     components: { FlexibleMediaGalleryNewLightbox, BlockTag },
-    template: '<flexible-media-gallery-new-lightbox class="homepage" :items="items" :inline=true><template v-slot="slotProps"><BlockTag :label="mockTags[slotProps.selectionIndex]" /> Text Random </template></ flexible-media-gallery-new-lightbox>',
+    template: '<flexible-media-gallery-new-lightbox class="homepage" :items="items" :inline=true><template v-slot="slotProps"><BlockTag :label="items[slotProps.selectionIndex].tag" /> Text Random </template></ flexible-media-gallery-new-lightbox>',
   }
 }

--- a/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
+++ b/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
@@ -1,10 +1,11 @@
 import { computed } from 'vue'
+import format from 'date-fns/format'
 import * as FTVAMedia from './mock/FTVAMedia'
 import FlexibleMediaGalleryNewLightbox from '@/lib-components/Flexible/MediaGallery/NewLightbox.vue'
 import BlockTag from '@/lib-components/BlockTag.vue'
 import { Gallery as MEDIA_GALLERY_MOCK } from '@/stories/mock/Media'
-
-// import { mockFTVAHomepageCarousel } from '@/stories/mock/FTVAMedia'
+import formatEventDates from '@/utils/formatEventDates'
+import formatSeriesDates from '@/utils/formatEventSeriesDates'
 
 // Storybook default settings
 export default {
@@ -105,6 +106,7 @@ function parseFTVACarouselImage(imgObj) {
   }]
 }
 
+// Add extra typehandles as needed
 function parseFTVATypeHandles(str) {
   switch (str) {
     case 'ftvaEvent':
@@ -118,6 +120,22 @@ function parseFTVATypeHandles(str) {
   }
 }
 
+function formatEventTime(date) {
+  const formattedTime = format(new Date(date), 'h:mm aaa')
+  return formattedTime.toUpperCase()
+}
+
+function parseDatesAndTimes(typeHandle, startDate, endDate, startDateWithTime, ongoing) {
+  if (ongoing)
+    return 'Ongoing'
+  if (typeHandle === 'ftvaEvent')
+    return `${formatEventDates(startDateWithTime, startDateWithTime, 'longWithYear')} - ${formatEventTime(startDateWithTime)}`
+  if (typeHandle === 'eventSeries')
+    return formatSeriesDates(startDate, endDate, 'longWithYear')
+
+  return null
+}
+
 const parsedMockHomepagCarousel = computed(() => {
   return FTVAMedia.mockFTVAHomepageCarousel.map((rawItem) => {
     return {
@@ -125,9 +143,8 @@ const parsedMockHomepagCarousel = computed(() => {
       credit: rawItem.creditText,
       tag: parseFTVATypeHandles(rawItem.typeHandle),
       captionText: rawItem.ftvaHomepageDescription,
-      captionTitle: rawItem.ftvaHomepageTitle
-      // eventDate
-      // eventTime
+      captionTitle: rawItem.ftvaHomepageTitle,
+      itemDate: parseDatesAndTimes(rawItem.typeHandle, rawItem.startDate, rawItem.endDate, rawItem.startDateWithTime, rawItem.ongoing)
     }
   })
 })
@@ -145,6 +162,6 @@ export function FTVA_HomepageCarousel() {
       }
     },
     components: { FlexibleMediaGalleryNewLightbox, BlockTag },
-    template: '<flexible-media-gallery-new-lightbox class="homepage" :items="items" :inline=true><template v-slot="slotProps"><BlockTag :label="items[slotProps.selectionIndex].tag" /> Text Random </template></ flexible-media-gallery-new-lightbox>',
+    template: '<flexible-media-gallery-new-lightbox class="homepage" :items="items" :inline=true><template v-slot="slotProps"><BlockTag :label="items[slotProps.selectionIndex].tag" /> {{items[slotProps.selectionIndex].itemDate}} </template></ flexible-media-gallery-new-lightbox>',
   }
 }

--- a/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
+++ b/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
@@ -64,7 +64,7 @@ const mockFTVAGalleryComputedData = computed(() => {
   })
 })
 
-export function FTVA_DefaultLightbox() {
+export function FTVA_Default() {
   return {
     data() {
       return {
@@ -98,6 +98,7 @@ export function FTVA_InlineCarousel() {
   }
 }
 
+// Helper functions to parse data for FTVA Homepage Carousel
 function parseFTVACarouselImage(imgObj) {
   return [{
     ...imgObj[0],
@@ -106,8 +107,8 @@ function parseFTVACarouselImage(imgObj) {
   }]
 }
 
-// Add extra typehandles as needed
 function parseFTVATypeHandles(str) {
+  // Add extra typehandles as needed
   switch (str) {
     case 'ftvaEvent':
       return 'Event'

--- a/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
+++ b/packages/vue-component-library/src/stories/MediaGallery_NewLightbox.stories.js
@@ -95,9 +95,21 @@ export function FTVA_InlineCarousel() {
   }
 }
 
+const mockFTVAGalleryComputedData2 = computed(() => {
+  // map image to item, map creditText to credit
+  return mockFTVAGalleryRawData.map((rawItem) => {
+    return {
+      item: rawItem.image[0],
+      credit: rawItem.creditText,
+      captionText: 'This short is a compilation of two Swedish commercials shown in Stockholm theaters, showing Garbo (still Gustafsson at the time) modeling hats for a department store and eating pastries at a café.', // TODO get homepage carousel data sample to make more accurate
+      captionTitle: 'The Saga of Gösta Berling If the Title Continues to the Second Line' // TODO get homepage carousel data sample to make more accurate
+    }
+  })
+})
+
 // TODO finish example showing homepage implementation with slots
 // mockdata for blocktags in parent
-const mockTags = ['tag1', 'tag2', 'tag3']
+const mockTags = ['taglabel1', 'tag2', 'tag3']
 // TODO: for part 2 of carousel homepage styling
 export function FTVA_HomepageCarousel() {
   return {
@@ -108,7 +120,7 @@ export function FTVA_HomepageCarousel() {
     },
     data() {
       return {
-        items: mockFTVAGalleryComputedData
+        items: mockFTVAGalleryComputedData2
       }
     },
     provide() {
@@ -117,6 +129,6 @@ export function FTVA_HomepageCarousel() {
       }
     },
     components: { FlexibleMediaGalleryNewLightbox, BlockTag },
-    template: '<flexible-media-gallery-new-lightbox class="homepage" :items="items" :inline=true><template v-slot="slotProps"><BlockTag :label="mockTags[slotProps.selectionIndex]" /></template></ flexible-media-gallery-new-lightbox>',
+    template: '<flexible-media-gallery-new-lightbox class="homepage" :items="items" :inline=true><template v-slot="slotProps"><BlockTag :label="mockTags[slotProps.selectionIndex]" /> Text Random </template></ flexible-media-gallery-new-lightbox>',
   }
 }

--- a/packages/vue-component-library/src/stories/mock/FTVAMedia.js
+++ b/packages/vue-component-library/src/stories/mock/FTVAMedia.js
@@ -857,7 +857,7 @@ export const mockFlexibleBlocks = [
   },
 ]
 
-export const mockHomepageCarousel = [
+export const mockFTVAHomepageCarousel = [
   {
     uri: 'events/la-région-centrale-03-08-24',
     typeHandle: 'ftvaEvent',
@@ -890,16 +890,9 @@ export const mockHomepageCarousel = [
         ]
       }
     ],
-    ftvaHomepageTitle: null,
-    ftvaHomepageDescription: null,
+    ftvaHomepageTitle: 'The Saga of Gösta Berling If the Title Continues to the Second Line',
+    ftvaHomepageDescription: 'This short is a compilation of two Swedish commercials shown in Stockholm theaters, showing Garbo (still Gustafsson at the time) modeling hats for a department store and eating pastries at a café.',
     startDateWithTime: '2025-07-19T07:00:00+00:00'
-  },
-  {
-    uri: 'collections/test-get-used-to-it',
-    typeHandle: 'ftvaCollection',
-    ftvaImage: [],
-    ftvaHomepageTitle: null,
-    ftvaHomepageDescription: null
   },
   {
     uri: 'articles/test-tom-reeds-for-members-only-black-perspectives-on-local-l-a-tv',

--- a/packages/vue-component-library/src/stories/mock/FTVAMedia.js
+++ b/packages/vue-component-library/src/stories/mock/FTVAMedia.js
@@ -872,8 +872,9 @@ export const mockFTVAHomepageCarousel = [
         ]
       }
     ],
+    creditText: 'Lorem ipsum dolor sit amet',
     ftvaHomepageTitle: 'La région centrale',
-    ftvaHomepageDescription: '<p>Snow had the idea in 1964 to create a film where a camera moved "in every direction and on every plane of a sphere".</p>',
+    ftvaHomepageDescription: 'Snow had the idea in 1964 to create a film where a camera moved "in every direction and on every plane of a sphere".',
     startDateWithTime: '2024-03-09T03:30:00+00:00'
   },
   {
@@ -890,6 +891,7 @@ export const mockFTVAHomepageCarousel = [
         ]
       }
     ],
+    creditText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
     ftvaHomepageTitle: 'The Saga of Gösta Berling If the Title Continues to the Second Line',
     ftvaHomepageDescription: 'This short is a compilation of two Swedish commercials shown in Stockholm theaters, showing Garbo (still Gustafsson at the time) modeling hats for a department store and eating pastries at a café.',
     startDateWithTime: '2025-07-19T07:00:00+00:00'
@@ -908,8 +910,9 @@ export const mockFTVAHomepageCarousel = [
         ]
       }
     ],
+    creditText: 'Lorem ipsum dolor sit amet',
     ftvaHomepageTitle: 'TEST - Tom Reed’s “For Members Only”',
-    ftvaHomepageDescription: '<p>The UCLA Film &amp; Television Archive is pleased to announce a preservation and access initiative to offer free online research viewing of the African American news and magazine television program For Members Only.</p>'
+    ftvaHomepageDescription: 'The UCLA Film & Television Archive is pleased to announce a preservation and access initiative to offer free online research viewing of the African American news and magazine television program For Members Only.'
   },
   {
     uri: 'series/test-series',
@@ -925,8 +928,9 @@ export const mockFTVAHomepageCarousel = [
         ]
       }
     ],
+    creditText: 'Lorem ipsum dolor sit amet',
     ftvaHomepageTitle: '舞',
-    ftvaHomepageDescription: '<p>脇によって</p>',
+    ftvaHomepageDescription: '脇によって',
     startDate: null,
     endDate: null,
     ongoing: true
@@ -945,6 +949,7 @@ export const mockFTVAHomepageCarousel = [
         ]
       }
     ],
+    creditText: 'Lorem ipsum dolor sit amet',
     ftvaHomepageTitle: null,
     ftvaHomepageDescription: null,
     startDate: '2025-11-06T08:00:00+00:00',

--- a/packages/vue-component-library/src/stories/mock/FTVAMedia.js
+++ b/packages/vue-component-library/src/stories/mock/FTVAMedia.js
@@ -856,3 +856,106 @@ export const mockFlexibleBlocks = [
     ],
   },
 ]
+
+export const mockHomepageCarousel = [
+  {
+    uri: 'events/la-région-centrale-03-08-24',
+    typeHandle: 'ftvaEvent',
+    ftvaImage: [
+      {
+        id: '3131255',
+        url: 'https://static.library.ucla.edu/craftassetstest/FTVA/laregioncentrale-crop_0.jpeg',
+        altText: 'Upside down of a rocky landscape.',
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ],
+    ftvaHomepageTitle: 'La région centrale',
+    ftvaHomepageDescription: '<p>Snow had the idea in 1964 to create a film where a camera moved "in every direction and on every plane of a sphere".</p>',
+    startDateWithTime: '2024-03-09T03:30:00+00:00'
+  },
+  {
+    uri: 'events/step-up-3-07-19-25',
+    typeHandle: 'ftvaEvent',
+    ftvaImage: [
+      {
+        id: '3144389',
+        url: 'https://static.library.ucla.edu/craftassetstest/FTVA/TheSalesman_Image6_0.jpg',
+        altText: 'The Salesman',
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ],
+    ftvaHomepageTitle: null,
+    ftvaHomepageDescription: null,
+    startDateWithTime: '2025-07-19T07:00:00+00:00'
+  },
+  {
+    uri: 'collections/test-get-used-to-it',
+    typeHandle: 'ftvaCollection',
+    ftvaImage: [],
+    ftvaHomepageTitle: null,
+    ftvaHomepageDescription: null
+  },
+  {
+    uri: 'articles/test-tom-reeds-for-members-only-black-perspectives-on-local-l-a-tv',
+    typeHandle: 'ftvaArticle',
+    ftvaImage: [
+      {
+        id: '3144386',
+        url: 'https://static.library.ucla.edu/craftassetstest/FTVA/guzman.jpg',
+        altText: 'Patricio Guzmán (2010)',
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ],
+    ftvaHomepageTitle: 'TEST - Tom Reed’s “For Members Only”',
+    ftvaHomepageDescription: '<p>The UCLA Film &amp; Television Archive is pleased to announce a preservation and access initiative to offer free online research viewing of the African American news and magazine television program For Members Only.</p>'
+  },
+  {
+    uri: 'series/test-series',
+    typeHandle: 'eventSeries',
+    ftvaImage: [
+      {
+        id: '3144388',
+        url: 'https://static.library.ucla.edu/craftassetstest/FTVA/fop2011.jpg',
+        altText: 'UCLA Festival of Preservation (2011)',
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ],
+    ftvaHomepageTitle: '舞',
+    ftvaHomepageDescription: '<p>脇によって</p>',
+    startDate: null,
+    endDate: null,
+    ongoing: true
+  },
+  {
+    uri: 'series/todd-solondz-series',
+    typeHandle: 'eventSeries',
+    ftvaImage: [
+      {
+        id: '3157237',
+        url: 'https://static.library.ucla.edu/craftassetstest/FTVA/Todd-Solondz_2024-07-04-073854_jbqd.jpg',
+        altText: null,
+        focalPoint: [
+          0.5,
+          0.5
+        ]
+      }
+    ],
+    ftvaHomepageTitle: null,
+    ftvaHomepageDescription: null,
+    startDate: '2025-11-06T08:00:00+00:00',
+    endDate: '2025-12-13T08:00:00+00:00',
+    ongoing: false
+  }
+]

--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -171,30 +171,55 @@
   .caption-block {
     display: flex;
     flex-direction: column-reverse;
-    // flex-direction: column;
     align-items: center;
     width: 100%;
-
-    .media-counter {
-      // display: inline-flex;
-    }
     
     .caption-content {
-      display: block;
-      background-color: blue;
-      max-width: 928px; // find var-container width
+      display: grid;
+      grid-template-columns: 1fr 400px;
+      grid-template-rows: auto 1fr;
+      grid-template-areas: 'label caption'
+      'title caption';
+      gap: 16px 36px;
+      max-width: 1160px;
       width: 100%;
-      padding-bottom: 60px;
+      padding: 0 16px 60px 16px;
+    }
+
+    .media-object-title {
+      @include ftva-h1;
+      @include truncate(3);
+      grid-area: title;
+    }
+
+    .media-object-caption {
+      @include ftva-body;
+      grid-area: caption;
+      align-self: center;
+    }
+
+    .media-object-caption-slot {
+      grid-area: label;
+      display: flex;
+      -moz-column-gap: 12px;
+          column-gap: 12px;
+      align-items: center;
+      @include ftva-body;
+
+      :deep(.label) {
+        text-transform: uppercase;
+      }
     }
   }
 
-  .media-container {
-    .credit-text {
-      display: none;
-    }
-  }
+  // .media-container {
+  //   .credit-text {
+  //     display: none;
+  //   }
+  // }
 
   .button-prev, .button-next {
+    z-index: 1;
     bottom: 25px;
     top: unset;
     transform: unset;
@@ -219,16 +244,19 @@
   @media #{$small} {
     .caption-block {
       flex-direction: column;
-      // width: 100%;
-      // background: red;
 
       .caption-content {
         position: absolute;
         top: 48px;
-        background-color: red;
-        // width: inherit;
-        padding-top: 20px;
-        padding-bottom: 16px;
+        padding-top: 32px;
+        padding-bottom: 28px;
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr;
+        grid-template-areas: 'label'
+        'title'
+        'caption';
+        -moz-column-gap: 0;
+            column-gap: 0;
       }
     }
 

--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -173,6 +173,8 @@
     flex-direction: column-reverse;
     align-items: center;
     width: 100%;
+
+    background: linear-gradient(0deg, rgba(0, 0, 0, .75) 0%, rgba(255, 255, 255, 0) 100%);
     
     .caption-content {
       display: grid;
@@ -212,6 +214,7 @@
     }
   }
 
+  // Disables bottom-right credit text
   // .media-container {
   //   .credit-text {
   //     display: none;
@@ -223,6 +226,17 @@
     bottom: -16px;
     top: 50%;
     transform: translate(50%, -50%);
+
+    background-color: rgba(0, 0, 0, 0.4);
+    border: none;
+
+    :deep(.svg__fill--primary-blue-03) {
+      fill: var(--color-white);
+    }
+  
+    :deep(.svg__stroke--primary-blue-03) {
+      stroke: var(--color-white);
+    }
   }
 
   .button-prev {
@@ -245,6 +259,7 @@
   @media #{$small} {
     .caption-block {
       flex-direction: column;
+      background: none;
 
       .caption-content {
         position: absolute;

--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -178,7 +178,7 @@
     
     .caption-content {
       display: grid;
-      grid-template-columns: 1fr 400px;
+      grid-template-columns: 1fr 1fr; // 1fr 400px
       grid-template-rows: auto 1fr;
       grid-template-areas: 'label caption'
       'title caption';

--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -135,35 +135,6 @@
       margin-left: -2px;
     }
   }
-
-  // // Homepage Lightbox Theme
-  // &.homepage {
-  //   .caption-block {
-  //     display: flex;
-  //     flex-direction: column-reverse;
-  //     align-items: center;
-
-  //     div.media-counter {
-  //       display: inline-flex;
-  //     }
-      
-  //     div.caption-content {
-  //       display: block;
-  //     }
-  //   }
-
-  //   .media-container {
-  //     .credit-text {
-  //       display: none;
-  //     }
-  //   }
-
-  //   .button-prev, .button-next {
-  //     bottom: 25px;
-  //     top: unset;
-  //     transform: unset;
-  //   }
-  // }
 } 
 
   // Homepage Carousel Theme
@@ -174,30 +145,39 @@
     align-items: center;
     width: 100%;
 
-    background: linear-gradient(0deg, rgba(0, 0, 0, .75) 0%, rgba(255, 255, 255, 0) 100%);
+    max-height: 300px;
+    height: 100%;
+    background: linear-gradient(0deg, rgba(0,0,0,.75) 0%, rgba(0,0,0,0) 100%);
     
     .caption-content {
+      position: absolute;
+      top: 10%;
+
       display: grid;
-      grid-template-columns: 1fr 1fr; // 1fr 400px
+      grid-template-columns: 1fr 400px;
       grid-template-rows: auto 1fr;
-      grid-template-areas: 'label caption'
+      grid-template-areas: 'label label'
       'title caption';
-      gap: 16px 36px;
+      gap: 4px 36px;
       max-width: 1160px;
       width: 100%;
-      padding: 0 16px 60px 16px;
+      padding: 0 16px 0 40px;
+    }
+
+    .media-counter {
+      margin-bottom: 32px;
     }
 
     .media-object-title {
       @include ftva-h1;
       @include truncate(3);
       grid-area: title;
+      margin-bottom: 0;
     }
 
     .media-object-caption {
       @include ftva-body;
       grid-area: caption;
-      align-self: center;
     }
 
     .media-object-caption-slot {
@@ -207,23 +187,30 @@
           column-gap: 12px;
       align-items: center;
       @include ftva-body;
+      font-weight: 600;
 
       :deep(.label) {
         text-transform: uppercase;
+        letter-spacing: 1px;
       }
+    }
+
+    // Caption-box credit text
+    .media-object-credit {
+      display: none;
     }
   }
 
-  // Disables bottom-right credit text
-  // .media-container {
-  //   .credit-text {
-  //     display: none;
-  //   }
-  // }
+  // Bottom-right credit text
+  .media-container {
+    .credit-text {
+      display: block
+    }
+  }
 
   .button-prev, .button-next {
     z-index: 1;
-    bottom: -16px;
+    bottom: -8px;
     top: 50%;
     transform: translate(50%, -50%);
 
@@ -248,21 +235,14 @@
     right: calc(50% - var(--counterWidth));
   }
 
-  @media #{$medium} {
-    .caption-block {
-      .caption-content {
-        padding: 0 16px 60px 16px;
-      }
-    }
-  }
-
-  @media #{$small} {
+  @media (max-width: 900px) {
     .caption-block {
       flex-direction: column;
       background: none;
+      max-height: unset;
+      height: unset;
 
       .caption-content {
-        position: absolute;
         top: 48px;
         padding-top: 32px;
         padding-bottom: 28px;
@@ -271,8 +251,11 @@
         grid-template-areas: 'label'
         'title'
         'caption';
-        -moz-column-gap: 0;
-            column-gap: 0;
+        gap: 10px 0;
+      }
+
+      .media-object-caption-slot {
+        font-weight: 400;
       }
     }
 

--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -220,17 +220,18 @@
 
   .button-prev, .button-next {
     z-index: 1;
-    bottom: 25px;
-    top: unset;
-    transform: unset;
+    bottom: -16px;
+    top: 50%;
+    transform: translate(50%, -50%);
   }
 
   .button-prev {
-    left: 35%;
+    left: unset;
+    right: calc(50% + var(--counterWidth));
   }
   
   .button-next {
-    right: 35%;
+    right: calc(50% - var(--counterWidth));
   }
 
   @media #{$medium} {

--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -41,29 +41,30 @@
   grid-gap: 0px;
 
   .media-container {
-      grid-column: col 1 / span 3;
-      // todo make these styles a mixin?
-      .credit-text {
-          display: inline-block;
-          position: absolute;
-          font-family: var(--font-secondary);
-          bottom: 0;
-          right: 0;
-          color: var(--color-white);
-          font-size: 16px;
-          max-width: 100%;
-          overflow: hidden;
-          text-overflow: ellipsis;
-  
-          span {
-              background-color: rgba(0, 0, 0, 0.64);
-              padding: 4px 23px 4px 18px;
-              // enforce 1 line, 50 char limit
-              height: 32px;
-              max-width: 385px;
-              white-space: pre;
-          }
+    grid-column: col 1 / span 3;
+    
+    // todo make these styles a mixin?
+    .credit-text {
+      display: inline-block;
+      position: absolute;
+      font-family: var(--font-secondary);
+      bottom: 0;
+      right: 0;
+      color: var(--color-white);
+      font-size: 16px;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      span {
+        background-color: rgba(0, 0, 0, 0.64);
+        padding: 4px 23px 4px 18px;
+        // enforce 1 line, 50 char limit
+        height: 32px;
+        max-width: 385px;
+        white-space: pre;
       }
+    }
   }
 
   .caption-block {
@@ -71,17 +72,19 @@
     // unset grid positioning from default theme
     grid-row: unset;
     grid-column: unset;
-
     bottom: 0px;
     left: 50%;
     transform: translateX(-50%);
+
     .media-counter {
       background-color: $heading-grey;
       border-radius: 20px;
       padding: 0px 15px;
+
       .media-counter-item {
         padding: 1px;
         margin: 0 -5px;
+
         svg {
           height: 22px;
           width: 27px;
@@ -90,69 +93,158 @@
     }
   }
 
-    // hide captions beneath images and close button
-    .caption-content, .button-close {
-      display: none;
-    } 
-    .button-prev, .button-next {
-      top: 50%;
-      transform: translateY(-50%);
-      width: 43px;
+  // hide captions beneath images and close button
+  .caption-content, .button-close {
+    display: none;
+  }
 
-      background-color: $navy-blue;
-      border: 1px solid $grey-blue;
-      border-radius: 8px;
-      padding: 2px 0px;
-      // unset grid positioning from default theme
-      grid-row: unset;
-      grid-column: unset;
-      justify-self: auto;
-      :deep(.svg__fill--primary-blue-03) {
-        fill: $grey-blue;
-      }
-      :deep(.svg__stroke--primary-blue-03) {
-        stroke: $grey-blue;
-      }
+  .button-prev, .button-next {
+    top: 50%;
+    transform: translateY(-50%);
+    width: 43px;
+    background-color: $navy-blue;
+    border: 1px solid $grey-blue;
+    border-radius: 8px;
+    padding: 2px 0px;
+    // unset grid positioning from default theme
+    grid-row: unset;
+    grid-column: unset;
+    justify-self: auto;
+
+    :deep(.svg__fill--primary-blue-03) {
+      fill: $grey-blue;
     }
-    .button-prev {
-      left: 30px;
-      svg {
-        margin-left: -4px;  
-      }
+    
+    :deep(.svg__stroke--primary-blue-03) {
+      stroke: $grey-blue;
     }
-    .button-next {
-      right: 35px;
-      svg {
-        margin-left: -2px;
-      }
+  }
+
+  .button-prev {
+    left: 30px;
+
+    svg {
+      margin-left: -4px;  
     }
+  }
+
+  .button-next {
+    right: 35px;
+
+    svg {
+      margin-left: -2px;
+    }
+  }
+
+  // // Homepage Lightbox Theme
+  // &.homepage {
+  //   .caption-block {
+  //     display: flex;
+  //     flex-direction: column-reverse;
+  //     align-items: center;
+
+  //     div.media-counter {
+  //       display: inline-flex;
+  //     }
+      
+  //     div.caption-content {
+  //       display: block;
+  //     }
+  //   }
+
+  //   .media-container {
+  //     .credit-text {
+  //       display: none;
+  //     }
+  //   }
+
+  //   .button-prev, .button-next {
+  //     bottom: 25px;
+  //     top: unset;
+  //     transform: unset;
+  //   }
+  // }
+} 
 
   // Homepage Lightbox Theme
-    &.homepage {
-      .caption-block {
-            display: flex;
-            flex-direction: column-reverse;
-            align-items: center;
-  
-            div.media-counter {
-                display: inline-flex;
-            }
-            div.caption-content {
-                display: block;
-            }
-      }
+.ftva.inline.lightbox.homepage {
+  .caption-block {
+    display: flex;
+    flex-direction: column-reverse;
+    // flex-direction: column;
+    align-items: center;
+    width: 100%;
 
+    .media-counter {
+      // display: inline-flex;
+    }
+    
+    .caption-content {
+      display: block;
+      background-color: blue;
+      max-width: 928px; // find var-container width
+      width: 100%;
+      padding-bottom: 60px;
+    }
+  }
+
+  .media-container {
+    .credit-text {
+      display: none;
+    }
+  }
+
+  .button-prev, .button-next {
+    bottom: 25px;
+    top: unset;
+    transform: unset;
+  }
+
+  .button-prev {
+    left: 35%;
+  }
   
-      .media-container {
-        .credit-text {
-          display: none;
-        }
+  .button-next {
+    right: 35%;
+  }
+
+  @media #{$medium} {
+    .caption-block {
+      .caption-content {
+        padding: 0 16px 60px 16px;
       }
-      .button-prev,
-      .button-next {
-        bottom: 25px;
-        top: unset;
-        transform: unset;
+    }
+  }
+
+  @media #{$small} {
+    .caption-block {
+      flex-direction: column;
+      // width: 100%;
+      // background: red;
+
+      .caption-content {
+        position: absolute;
+        top: 48px;
+        background-color: red;
+        // width: inherit;
+        padding-top: 20px;
+        padding-bottom: 16px;
       }
-   }
-  } 
+    }
+
+    .button-prev {
+      left: 8%;
+    }
+  
+    .button-next {
+      right: 8%;
+    }
+
+    .button-prev, .button-next {
+      display: block;
+      top: 50%;
+      bottom: unset;
+      transform: translateY(-50%);
+    }
+  }
+}

--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -166,7 +166,7 @@
   // }
 } 
 
-  // Homepage Lightbox Theme
+  // Homepage Carousel Theme
 .ftva.inline.lightbox.homepage {
   .caption-block {
     display: flex;


### PR DESCRIPTION
Connected to [APPS-2805](https://jira.library.ucla.edu/browse/APPS-2805)

**Component Updated:** NewLightbox.vue

**Notes:**

- Set up/updated inline Lightbox/carousel styling for FTVA homepage
- Added logic to code to set/control placement of carousel navigation arrows
- Added mock data for carousel
- Updated carousel story
  - Included helper functions to parse data (_[similar] helpers will need to be replicated at page level_)

**Preview:**
- https://deploy-preview-748--ucla-library-storybook.netlify.app/?path=/story/media-gallery-new-lightbox--ftva-homepage-carousel

![ftva-hmpg-carousel-desk](https://github.com/user-attachments/assets/5c5a3972-0d01-4f6e-8d7a-990255edeb15)

![ftva-hmpg-carousel-mob](https://github.com/user-attachments/assets/3bc0bae7-b743-4bb3-99c1-d19e95507ac1)

**Checklist:**

-   ~~[ ] I checked that it is working locally in the dev server~~
-   [x] I checked that it is working locally in the storybook
-   ~~[ ] I checked that it is working locally in the library/ftva-website-nuxt dev server~~
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-2805]: https://uclalibrary.atlassian.net/browse/APPS-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ