### PR TITLE
feat: APPS-3376 create image slider component

### DIFF
--- a/packages/vue-component-library/src/index.ts
+++ b/packages/vue-component-library/src/index.ts
@@ -81,6 +81,7 @@ export { default as HeaderMainResponsive } from './lib-components/HeaderMainResp
 export { default as HeaderSmart } from './lib-components/HeaderSmart.vue'
 export { default as HeaderSticky } from './lib-components/HeaderSticky.vue'
 export { default as IconWithLink } from './lib-components/IconWithLink.vue'
+export { default as ImageSlider } from './lib-components/ImageSlider.vue'
 export { default as ImpactNumberCard } from './lib-components/ImpactNumberCard.vue'
 export { default as ImpactNumbersCarousel } from './lib-components/ImpactNumbersCarousel.vue'
 export { default as ImpactRichText } from './lib-components/ImpactRichText.vue'

--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import ResponsiveImage from './ResponsiveImage.vue'
 
 const { beforeImage, afterImage } = defineProps({
   beforeImage: {
@@ -30,12 +29,16 @@ function handleSliderInput(event: Event) {
 <template>
   <div ref="sliderContainer" class="image-slider">
     <div class="image-container">
-      <img class="before-image slider-image"
+      <img
+        class="before-image slider-image"
         src="https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80"
-        alt="color photo" />
-      <img ref="afterImageElement" class="after-image slider-image"
+        alt="color photo"
+      >
+      <img
+        ref="afterImageElement" class="after-image slider-image"
         src="https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80"
-        alt="black and white" />
+        alt="black and white"
+      >
       <!-- <ResponsiveImage :media="beforeImage" class="slider-image before-image" />
       <ResponsiveImage :media="afterImage" class="slider-image after-image" /> -->
       <!-- <div class="image-labels">
@@ -43,8 +46,10 @@ function handleSliderInput(event: Event) {
                 <span class="after-label"><slot name="afterLabel">After</slot></span>
             </div> -->
     </div>
-    <input ref="slider" type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown"
-      class="slider" @input="(e) => handleSliderInput(e)">
+    <input
+      ref="slider" type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown"
+      class="slider" @input="(e) => handleSliderInput(e)"
+    >
     <div class="slider-line" aria-hidden="true" />
     <div class="slider-button" aria-hidden="true">
       <span class="button-text">Slide to Compare</span>
@@ -84,7 +89,7 @@ function handleSliderInput(event: Event) {
         overflow: hidden;
         aspect-ratio: 2/1;
         // padding-bottom: 25%;
-    
+
         :deep(img) {
           display: block;
           max-width: 100%;

--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -1,5 +1,7 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
+import SvgIconCaretLeft from 'ucla-library-design-tokens/assets/svgs/icon-caret-left.svg'
+import SvgIconCaretRight from 'ucla-library-design-tokens/assets/svgs/icon-caret-right.svg'
 
 const { beforeImage, afterImage } = defineProps({
   beforeImage: {
@@ -12,47 +14,42 @@ const { beforeImage, afterImage } = defineProps({
   }
 })
 
+
+
 const sliderContainer = ref<HTMLElement | null>(null)
 const slider = ref<HTMLInputElement | null>(null)
 const afterImageElement = ref<HTMLImageElement | null>(null)
 
 function handleSliderInput(event: Event) {
   const target = event.target as HTMLInputElement
-  console.log('Slider input event:', target.value)
-  // if (sliderContainer.value) {
-  //   // sliderContainer.value.style.setProperty('--position', `${target.value}%`)
-  //   afterImageElement.value.style.clip = `rect(0, ${offsetX}px, ${sliderRect.height}px, 0)`;
-  // }
+  // console.log('Slider input event:', target.value)
+  if (sliderContainer.value && slider.value && afterImageElement.value) {
+    sliderContainer.value.style.setProperty('--position', `${target.value}%`)
+    // NOT NEEDED
+    // slider.value.value = target.value // Update the slider value
+    // afterImageElement.value.style.clipPath = `polygon(0 0, ${target.value}% 0, ${target.value}% 100%, 0 100%);`;
+  }
 }
 </script>
 
 <template>
   <div ref="sliderContainer" class="image-slider">
     <div class="image-container">
-      <img
-        class="before-image slider-image"
-        src="https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80"
-        alt="color photo"
-      >
-      <img
-        ref="afterImageElement" class="after-image slider-image"
-        src="https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80"
-        alt="black and white"
-      >
-      <!-- <ResponsiveImage :media="beforeImage" class="slider-image before-image" />
-      <ResponsiveImage :media="afterImage" class="slider-image after-image" /> -->
+      <img class="before-image slider-image" :src="beforeImage.src" alt="color photo" />
+      <img ref="afterImageElement" class="after-image slider-image" :src="afterImage.src" alt="black and white" />
       <!-- <div class="image-labels">
                 <span class="before-label"><slot name="beforeLabel">Before</slot></span>
                 <span class="after-label"><slot name="afterLabel">After</slot></span>
             </div> -->
     </div>
-    <input
-      ref="slider" type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown"
-      class="slider" @input="(e) => handleSliderInput(e)"
-    >
+    <input ref="slider" type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown"
+      class="slider" @input="(e) => handleSliderInput(e)">
     <div class="slider-line" aria-hidden="true" />
     <div class="slider-button" aria-hidden="true">
-      <span class="button-text">Slide to Compare</span>
+      <span class="button-text">
+        <SvgIconCaretLeft class="button-icon" />
+        <SvgIconCaretRight class="button-icon" />
+      </span>
     </div>
   </div>
 </template>
@@ -76,19 +73,13 @@ function handleSliderInput(event: Event) {
     place-content: center;
     position: relative;
     overflow: hidden;
-    // border-radius: 1rem;
     --position: 50%; // Initial position of the slider
     .image-container {
-        // position: relative;
         width: 100%;
-        // height: 100%;
-        // max-height: 90vh;
-        // aspect-ratio: 1/1;
         max-width: 1160px;
         max-height: 90vh;
         overflow: hidden;
         aspect-ratio: 2/1;
-        // padding-bottom: 25%;
 
         :deep(img) {
           display: block;
@@ -99,25 +90,20 @@ function handleSliderInput(event: Event) {
 }
 
 .slider-image {
+  position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    resize: horizontal;
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: left;
+    object-position: center; // was left
 }
 
+// TODO remove and make actual grey scale version of the image
 .before-image {
-    // position: absolute;
-    // inset: 0;
-    // width: var(--position);
     filter: grayscale(100%)
-}
-
-.before-image, .after-image {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
-  resize: horizontal;
 }
 
 .after-image {
@@ -125,8 +111,7 @@ function handleSliderInput(event: Event) {
   top: 0;
   left: 0;
   width: 100%;
-  // clip: rect(0, 400px, 300px, 0);
-  clip-path: polygon(0 0, 50% 0, 50% 100%, 0 100%); // WORKS!
+  clip-path: polygon(0 0, var(--position) 0, var(--position) 100%, 0 100%);
   /* Adjust the width of the visible area */
 }
 
@@ -135,6 +120,7 @@ function handleSliderInput(event: Event) {
     inset: 0;
     cursor: pointer;
     opacity: 0;
+    z-index: 10; // keep this element on top of the images
     /* for Firefox */
     width: 100%;
     height: 100%;
@@ -161,8 +147,9 @@ function handleSliderInput(event: Event) {
     position: absolute;
     background-color: #fff;
     color: black;
-    padding: .5rem;
     border-radius: 100vw;
+    min-width: 75px; // set minimum width to prevent icons wrapping near slider edges
+    padding: .25rem 0 0 0;
     display: grid;
     place-items: center;
     top: 50%;
@@ -170,6 +157,5 @@ function handleSliderInput(event: Event) {
     transform: translate(-50%, -50%);
     pointer-events: none;
     z-index: 100;
-    box-shadow: 1px 1px 1px hsl(0, 50%, 2%, .5);
 }
 </style>

--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -1,0 +1,126 @@
+<script lang="ts" setup>
+import ResponsiveImage from './ResponsiveImage.vue';
+
+const { beforeImage, afterImage } = defineProps({
+    beforeImage: {
+        type: Object,
+        required: true
+    },
+    afterImage: {
+        type: Object,
+        required: true
+    }
+})
+
+// const container = document.querySelector('.container');
+// document.querySelector('.slider').addEventListener('input', (e) => {
+//     container.style.setProperty('--position', `${e.target.value}%`);
+// })
+const sliderContainer = ref<HTMLElement | null>(null);
+
+</script>
+<template>
+    <div ref="sliderContainer" class="image-slider">
+        <div class="image-container">
+            <ResponsiveImage :media="beforeImage" class="slider-image before-image" />
+            <ResponsiveImage :media="afterImage" class="slider-image after-image" />
+            <!-- <div class="image-labels">
+                <span class="before-label"><slot name="beforeLabel">Before</slot></span>
+                <span class="after-label"><slot name="afterLabel">After</slot></span>
+            </div> -->
+        </div>
+        <input type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown" class="slider" />
+        <div class="slider-line" aria-hidden="true"></div>
+        <div class="slider-button" aria-hidden="true">
+            <span class="button-text">Slide to Compare</span>
+        </div>
+    </div>
+</template>
+<style lang="scss" scoped>
+/* Add your styles here */
+// *,
+// *::after,
+// *::before {
+//     margin: 0;
+//     padding: 0;
+//     box-sizing: border-box;
+// }
+
+// .image-slider {
+//     display: grid;
+//     // width: 100%;
+//     width: 100vw;
+//     place-content: center;
+//     position: relative;
+//     overflow: hidden;
+//     border-radius: 1rem;
+//     --position: 50%;
+// }
+// .image-container {
+//     width: 100%;
+//     max-width: 1160px;
+//     max-height: 90vh;
+//     aspect-ratio: 1/1;
+//     :deep(img) {
+//         display: block;
+//         max-width: 100%;
+//     }
+// }
+
+// .slider-image {
+//     width: 100%;
+//     height: 100%;
+//     object-fit: cover;
+//     object-position: left;
+// }
+
+// .image-before {
+//     position: absolute;
+//     inset: 0;
+//     width: var(--position);
+//     filter: grayscale(100%)
+// }
+
+// .slider {
+//     position: absolute;
+//     inset: 0;
+//     cursor: pointer;
+//     opacity: 0;
+//     /* for Firefox */
+//     width: 100%;
+//     height: 100%;
+// }
+
+// .slider:focus-visible~.slider-button {
+//     outline: 5px solid black;
+//     outline-offset: 3px;
+// }
+
+// .slider-line {
+//     position: absolute;
+//     inset: 0;
+//     width: .2rem;
+//     height: 100%;
+//     background-color: #fff;
+//     /* z-index: 10; */
+//     left: var(--position);
+//     transform: translateX(-50%);
+//     pointer-events: none;
+// }
+
+// .slider-button {
+//     position: absolute;
+//     background-color: #fff;
+//     color: black;
+//     padding: .5rem;
+//     border-radius: 100vw;
+//     display: grid;
+//     place-items: center;
+//     top: 50%;
+//     left: var(--position);
+//     transform: translate(-50%, -50%);
+//     pointer-events: none;
+//     /* z-index: 100; */
+//     box-shadow: 1px 1px 1px hsl(0, 50%, 2%, .5);
+// }
+</style>

--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -20,7 +20,6 @@ const afterImageElement = ref<HTMLImageElement | null>(null)
 
 function handleSliderInput(event: Event) {
   const target = event.target as HTMLInputElement
-  // console.log('Slider input event:', target.value)
   if (sliderContainer.value && slider.value && afterImageElement.value)
     sliderContainer.value.style.setProperty('--position', `${target.value}%`)
 }
@@ -118,7 +117,7 @@ function handleSliderInput(event: Event) {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: center; // was left
+    object-position: center;
 }
 
 .after-image {
@@ -126,8 +125,7 @@ function handleSliderInput(event: Event) {
   top: 0;
   left: 0;
   width: 100%;
-  clip-path: polygon(0 0, var(--position) 0, var(--position) 100%, 0 100%);
-  /* Adjust the width of the visible area */
+  clip-path: polygon(0 0, var(--position) 0, var(--position) 100%, 0 100%); // Adjust the width of the visible area
 }
 
 .caption {

--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -15,35 +15,36 @@ const { beforeImage, afterImage } = defineProps({
 
 const sliderContainer = ref<HTMLElement | null>(null)
 const slider = ref<HTMLInputElement | null>(null)
+const afterImageElement = ref<HTMLImageElement | null>(null)
 
 function handleSliderInput(event: Event) {
   const target = event.target as HTMLInputElement
   console.log('Slider input event:', target.value)
-  if (sliderContainer.value)
-    sliderContainer.value.style.setProperty('--position', `${target.value}%`)
+  // if (sliderContainer.value) {
+  //   // sliderContainer.value.style.setProperty('--position', `${target.value}%`)
+  //   afterImageElement.value.style.clip = `rect(0, ${offsetX}px, ${sliderRect.height}px, 0)`;
+  // }
 }
 </script>
 
 <template>
   <div ref="sliderContainer" class="image-slider">
     <div class="image-container">
-      <ResponsiveImage :media="beforeImage" class="slider-image before-image" />
-      <ResponsiveImage :media="afterImage" class="slider-image after-image" />
+      <img class="before-image slider-image"
+        src="https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80"
+        alt="color photo" />
+      <img ref="afterImageElement" class="after-image slider-image"
+        src="https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1470&q=80"
+        alt="black and white" />
+      <!-- <ResponsiveImage :media="beforeImage" class="slider-image before-image" />
+      <ResponsiveImage :media="afterImage" class="slider-image after-image" /> -->
       <!-- <div class="image-labels">
                 <span class="before-label"><slot name="beforeLabel">Before</slot></span>
                 <span class="after-label"><slot name="afterLabel">After</slot></span>
             </div> -->
     </div>
-    <input
-      ref="slider"
-      type="range"
-      min="0"
-      max="100"
-      value="50"
-      aria-label="Percentage of before photo shown"
-      class="slider"
-      @input="(e) => handleSliderInput(e)"
-    >
+    <input ref="slider" type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown"
+      class="slider" @input="(e) => handleSliderInput(e)">
     <div class="slider-line" aria-hidden="true" />
     <div class="slider-button" aria-hidden="true">
       <span class="button-text">Slide to Compare</span>
@@ -62,26 +63,34 @@ function handleSliderInput(event: Event) {
 }
 
 .image-slider {
+    position: relative;
     display: grid;
     width: 100%;
+    height: 400px;
     max-width: 1160px;
-    // width: 100vw;
     place-content: center;
     position: relative;
     overflow: hidden;
-    border-radius: 1rem;
-    --position: 50%;
-}
-.image-container {
-    position: relative;
-    width: 100%;
-    max-height: 90vh;
-    aspect-ratio: 1/1;
-    :deep(img) {
-        display: block;
-        max-width: 100%;
-    }
-    background: red;
+    // border-radius: 1rem;
+    --position: 50%; // Initial position of the slider
+    .image-container {
+        // position: relative;
+        width: 100%;
+        // height: 100%;
+        // max-height: 90vh;
+        // aspect-ratio: 1/1;
+        max-width: 1160px;
+        max-height: 90vh;
+        overflow: hidden;
+        aspect-ratio: 2/1;
+        // padding-bottom: 25%;
+    
+        :deep(img) {
+          display: block;
+          max-width: 100%;
+
+        }
+      }
 }
 
 .slider-image {
@@ -92,10 +101,28 @@ function handleSliderInput(event: Event) {
 }
 
 .before-image {
-    position: absolute;
-    inset: 0;
-    width: var(--position);
+    // position: absolute;
+    // inset: 0;
+    // width: var(--position);
     filter: grayscale(100%)
+}
+
+.before-image, .after-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  resize: horizontal;
+}
+
+.after-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  // clip: rect(0, 400px, 300px, 0);
+  clip-path: polygon(0 0, 50% 0, 50% 100%, 0 100%); // WORKS!
+  /* Adjust the width of the visible area */
 }
 
 .slider {
@@ -119,7 +146,7 @@ function handleSliderInput(event: Event) {
     width: .2rem;
     height: 100%;
     background-color: #fff;
-    /* z-index: 10; */
+    z-index: 10;
     left: var(--position);
     transform: translateX(-50%);
     pointer-events: none;
@@ -137,7 +164,7 @@ function handleSliderInput(event: Event) {
     left: var(--position);
     transform: translate(-50%, -50%);
     pointer-events: none;
-    /* z-index: 100; */
+    z-index: 100;
     box-shadow: 1px 1px 1px hsl(0, 50%, 2%, .5);
 }
 </style>

--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -14,8 +14,6 @@ const { beforeImage, afterImage } = defineProps({
   }
 })
 
-
-
 const sliderContainer = ref<HTMLElement | null>(null)
 const slider = ref<HTMLInputElement | null>(null)
 const afterImageElement = ref<HTMLImageElement | null>(null)
@@ -23,17 +21,16 @@ const afterImageElement = ref<HTMLImageElement | null>(null)
 function handleSliderInput(event: Event) {
   const target = event.target as HTMLInputElement
   // console.log('Slider input event:', target.value)
-  if (sliderContainer.value && slider.value && afterImageElement.value) {
+  if (sliderContainer.value && slider.value && afterImageElement.value)
     sliderContainer.value.style.setProperty('--position', `${target.value}%`)
-  }
 }
 </script>
 
 <template>
   <div ref="sliderContainer" class="image-slider">
     <div class="image-container">
-      <img class="before-image slider-image" :src="beforeImage.src" alt="color photo" />
-      <img ref="afterImageElement" class="after-image slider-image" :src="afterImage.src" alt="black and white" />
+      <img class="before-image slider-image" :src="beforeImage.src" alt="color photo">
+      <img ref="afterImageElement" class="after-image slider-image" :src="afterImage.src" alt="black and white">
       <div class="image-labels">
         <span class="before-label slider-label">
           <slot name="beforeLabel">Before</slot>
@@ -43,8 +40,10 @@ function handleSliderInput(event: Event) {
         </span>
       </div>
     </div>
-    <input ref="slider" type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown"
-      class="slider" @input="(e) => handleSliderInput(e)">
+    <input
+      ref="slider" type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown"
+      class="slider" @input="(e) => handleSliderInput(e)"
+    >
     <div class="slider-line" aria-hidden="true" />
     <div class="slider-button" aria-hidden="true">
       <span class="button-text">
@@ -53,7 +52,9 @@ function handleSliderInput(event: Event) {
       </span>
     </div>
   </div>
-  <div class="caption"><slot name="captionText"></slot></div>
+  <div class="caption">
+    <slot name="captionText" />
+  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -25,9 +25,6 @@ function handleSliderInput(event: Event) {
   // console.log('Slider input event:', target.value)
   if (sliderContainer.value && slider.value && afterImageElement.value) {
     sliderContainer.value.style.setProperty('--position', `${target.value}%`)
-    // NOT NEEDED
-    // slider.value.value = target.value // Update the slider value
-    // afterImageElement.value.style.clipPath = `polygon(0 0, ${target.value}% 0, ${target.value}% 100%, 0 100%);`;
   }
 }
 </script>
@@ -37,10 +34,14 @@ function handleSliderInput(event: Event) {
     <div class="image-container">
       <img class="before-image slider-image" :src="beforeImage.src" alt="color photo" />
       <img ref="afterImageElement" class="after-image slider-image" :src="afterImage.src" alt="black and white" />
-      <!-- <div class="image-labels">
-                <span class="before-label"><slot name="beforeLabel">Before</slot></span>
-                <span class="after-label"><slot name="afterLabel">After</slot></span>
-            </div> -->
+      <div class="image-labels">
+        <span class="before-label slider-label">
+          <slot name="beforeLabel">Before</slot>
+        </span>
+        <span class="after-label slider-label">
+          <slot name="afterLabel">After</slot>
+        </span>
+      </div>
     </div>
     <input ref="slider" type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown"
       class="slider" @input="(e) => handleSliderInput(e)">
@@ -52,6 +53,7 @@ function handleSliderInput(event: Event) {
       </span>
     </div>
   </div>
+  <div class="caption"><slot name="captionText"></slot></div>
 </template>
 
 <style lang="scss" scoped>
@@ -89,6 +91,23 @@ function handleSliderInput(event: Event) {
       }
 }
 
+.image-labels {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  z-index: 9;
+  padding: 1rem;
+  span.slider-label {
+    text-transform: uppercase;
+    color: black;
+    background-color: white;
+    padding: .25rem .5rem;
+  }
+}
+
 .slider-image {
   position: absolute;
     top: 0;
@@ -101,11 +120,6 @@ function handleSliderInput(event: Event) {
     object-position: center; // was left
 }
 
-// TODO remove and make actual grey scale version of the image
-.before-image {
-    filter: grayscale(100%)
-}
-
 .after-image {
   position: absolute;
   top: 0;
@@ -113,6 +127,14 @@ function handleSliderInput(event: Event) {
   width: 100%;
   clip-path: polygon(0 0, var(--position) 0, var(--position) 100%, 0 100%);
   /* Adjust the width of the visible area */
+}
+
+.caption {
+  @include ftva-caption;
+  padding-top: 15px;
+  width: 100%;
+  text-align: center;
+  color: #737373;
 }
 
 .slider {

--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -1,148 +1,143 @@
 <script lang="ts" setup>
-import ResponsiveImage from './ResponsiveImage.vue';
-import { ref, watch } from 'vue';
+import { ref } from 'vue'
+import ResponsiveImage from './ResponsiveImage.vue'
 
 const { beforeImage, afterImage } = defineProps({
-    beforeImage: {
-        type: Object,
-        required: true
-    },
-    afterImage: {
-        type: Object,
-        required: true
-    }
+  beforeImage: {
+    type: Object,
+    required: true
+  },
+  afterImage: {
+    type: Object,
+    required: true
+  }
 })
 
-
-const sliderContainer = ref<HTMLElement | null>(null);
-const slider = ref<HTMLInputElement | null>(null);
+const sliderContainer = ref<HTMLElement | null>(null)
+const slider = ref<HTMLInputElement | null>(null)
 
 function handleSliderInput(event: Event) {
-    const target = event.target as HTMLInputElement;
-    console.log('Slider input event:', target.value);
-    if (sliderContainer.value) {
-        sliderContainer.value.style.setProperty('--position', `${target.value}%`);
-    }
+  const target = event.target as HTMLInputElement
+  console.log('Slider input event:', target.value)
+  if (sliderContainer.value)
+    sliderContainer.value.style.setProperty('--position', `${target.value}%`)
 }
-// watch(() => slider.value?._value, (newValue) => {
-//     console.log('Slider value changed:', newValue);
-//     if (sliderContainer.value) {
-//         sliderContainer.value.style.setProperty('--position', `${newValue}%`);
-//     }
-// });
-
 </script>
+
 <template>
-    <div ref="sliderContainer" class="image-slider">
-        <div class="image-container">
-            <ResponsiveImage :media="beforeImage" class="slider-image before-image" />
-            <ResponsiveImage :media="afterImage" class="slider-image after-image" />
-            <!-- <div class="image-labels">
+  <div ref="sliderContainer" class="image-slider">
+    <div class="image-container">
+      <ResponsiveImage :media="beforeImage" class="slider-image before-image" />
+      <ResponsiveImage :media="afterImage" class="slider-image after-image" />
+      <!-- <div class="image-labels">
                 <span class="before-label"><slot name="beforeLabel">Before</slot></span>
                 <span class="after-label"><slot name="afterLabel">After</slot></span>
             </div> -->
-        </div>
-        <input
-            ref="slider"
-            type="range"
-            min="0"
-            max="100"
-            value="50"
-            aria-label="Percentage of before photo shown"
-            class="slider"
-            @input="(e) => handleSliderInput(e)"
-        />
-        <div class="slider-line" aria-hidden="true"></div>
-        <div class="slider-button" aria-hidden="true">
-            <span class="button-text">Slide to Compare</span>
-        </div>
     </div>
+    <input
+      ref="slider"
+      type="range"
+      min="0"
+      max="100"
+      value="50"
+      aria-label="Percentage of before photo shown"
+      class="slider"
+      @input="(e) => handleSliderInput(e)"
+    >
+    <div class="slider-line" aria-hidden="true" />
+    <div class="slider-button" aria-hidden="true">
+      <span class="button-text">Slide to Compare</span>
+    </div>
+  </div>
 </template>
+
 <style lang="scss" scoped>
 /* Add your styles here */
-// *,
-// *::after,
-// *::before {
-//     margin: 0;
-//     padding: 0;
-//     box-sizing: border-box;
-// }
+*,
+*::after,
+*::before {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
 
-// .image-slider {
-//     display: grid;
-//     // width: 100%;
-//     width: 100vw;
-//     place-content: center;
-//     position: relative;
-//     overflow: hidden;
-//     border-radius: 1rem;
-//     --position: 50%;
-// }
-// .image-container {
-//     width: 100%;
-//     max-width: 1160px;
-//     max-height: 90vh;
-//     aspect-ratio: 1/1;
-//     :deep(img) {
-//         display: block;
-//         max-width: 100%;
-//     }
-// }
+.image-slider {
+    display: grid;
+    width: 100%;
+    max-width: 1160px;
+    // width: 100vw;
+    place-content: center;
+    position: relative;
+    overflow: hidden;
+    border-radius: 1rem;
+    --position: 50%;
+}
+.image-container {
+    position: relative;
+    width: 100%;
+    max-height: 90vh;
+    aspect-ratio: 1/1;
+    :deep(img) {
+        display: block;
+        max-width: 100%;
+    }
+    background: red;
+}
 
-// .slider-image {
-//     width: 100%;
-//     height: 100%;
-//     object-fit: cover;
-//     object-position: left;
-// }
+.slider-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: left;
+}
 
-// .image-before {
-//     position: absolute;
-//     inset: 0;
-//     width: var(--position);
-//     filter: grayscale(100%)
-// }
+.before-image {
+    position: absolute;
+    inset: 0;
+    width: var(--position);
+    filter: grayscale(100%)
+}
 
-// .slider {
-//     position: absolute;
-//     inset: 0;
-//     cursor: pointer;
-//     opacity: 0;
-//     /* for Firefox */
-//     width: 100%;
-//     height: 100%;
-// }
+.slider {
+    position: absolute;
+    inset: 0;
+    cursor: pointer;
+    opacity: 0;
+    /* for Firefox */
+    width: 100%;
+    height: 100%;
+}
 
-// .slider:focus-visible~.slider-button {
-//     outline: 5px solid black;
-//     outline-offset: 3px;
-// }
+.slider:focus-visible~.slider-button {
+    outline: 5px solid black;
+    outline-offset: 3px;
+}
 
-// .slider-line {
-//     position: absolute;
-//     inset: 0;
-//     width: .2rem;
-//     height: 100%;
-//     background-color: #fff;
-//     /* z-index: 10; */
-//     left: var(--position);
-//     transform: translateX(-50%);
-//     pointer-events: none;
-// }
+.slider-line {
+    position: absolute;
+    inset: 0;
+    width: .2rem;
+    height: 100%;
+    background-color: #fff;
+    /* z-index: 10; */
+    left: var(--position);
+    transform: translateX(-50%);
+    pointer-events: none;
+}
 
-// .slider-button {
-//     position: absolute;
-//     background-color: #fff;
-//     color: black;
-//     padding: .5rem;
-//     border-radius: 100vw;
-//     display: grid;
-//     place-items: center;
-//     top: 50%;
-//     left: var(--position);
-//     transform: translate(-50%, -50%);
-//     pointer-events: none;
-//     /* z-index: 100; */
-//     box-shadow: 1px 1px 1px hsl(0, 50%, 2%, .5);
-// }
+.slider-button {
+    position: absolute;
+    background-color: #fff;
+    color: black;
+    padding: .5rem;
+    border-radius: 100vw;
+    display: grid;
+    place-items: center;
+    top: 50%;
+    left: var(--position);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    /* z-index: 100; */
+    box-shadow: 1px 1px 1px hsl(0, 50%, 2%, .5);
+}
 </style>

--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import ResponsiveImage from './ResponsiveImage.vue';
+import { ref, watch } from 'vue';
 
 const { beforeImage, afterImage } = defineProps({
     beforeImage: {
@@ -12,11 +13,23 @@ const { beforeImage, afterImage } = defineProps({
     }
 })
 
-// const container = document.querySelector('.container');
-// document.querySelector('.slider').addEventListener('input', (e) => {
-//     container.style.setProperty('--position', `${e.target.value}%`);
-// })
+
 const sliderContainer = ref<HTMLElement | null>(null);
+const slider = ref<HTMLInputElement | null>(null);
+
+function handleSliderInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    console.log('Slider input event:', target.value);
+    if (sliderContainer.value) {
+        sliderContainer.value.style.setProperty('--position', `${target.value}%`);
+    }
+}
+// watch(() => slider.value?._value, (newValue) => {
+//     console.log('Slider value changed:', newValue);
+//     if (sliderContainer.value) {
+//         sliderContainer.value.style.setProperty('--position', `${newValue}%`);
+//     }
+// });
 
 </script>
 <template>
@@ -29,7 +42,16 @@ const sliderContainer = ref<HTMLElement | null>(null);
                 <span class="after-label"><slot name="afterLabel">After</slot></span>
             </div> -->
         </div>
-        <input type="range" min="0" max="100" value="50" aria-label="Percentage of before photo shown" class="slider" />
+        <input
+            ref="slider"
+            type="range"
+            min="0"
+            max="100"
+            value="50"
+            aria-label="Percentage of before photo shown"
+            class="slider"
+            @input="(e) => handleSliderInput(e)"
+        />
         <div class="slider-line" aria-hidden="true"></div>
         <div class="slider-button" aria-hidden="true">
             <span class="button-text">Slide to Compare</span>

--- a/packages/vue-component-library/src/stories/ImageSlider.spec.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.spec.js
@@ -1,0 +1,9 @@
+describe('ImageSlider', () => {
+    it('Default', () => {
+      cy.visit('/iframe.html?id=image-slider--default&args=&viewMode=story')
+      cy.get('.image-slider').should('exist')
+
+      cy.percySnapshot('ImageSlider: Default')
+    })
+  })
+  

--- a/packages/vue-component-library/src/stories/ImageSlider.spec.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.spec.js
@@ -1,9 +1,8 @@
 describe('ImageSlider', () => {
-    it('Default', () => {
-      cy.visit('/iframe.html?id=image-slider--default&args=&viewMode=story')
-      cy.get('.image-slider').should('exist')
+  it('Default', () => {
+    cy.visit('/iframe.html?id=image-slider--default&args=&viewMode=story')
+    cy.get('.image-slider').should('exist')
 
-      cy.percySnapshot('ImageSlider: Default')
-    })
+    cy.percySnapshot('ImageSlider: Default')
   })
-  
+})

--- a/packages/vue-component-library/src/stories/ImageSlider.stories.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.stories.js
@@ -1,5 +1,6 @@
 // import { computed } from 'vue'
 import ImageSlider from '../lib-components/ImageSlider'
+
 // import ScrollWrapper from '../lib-components/ScrollWrapper'
 
 export default {

--- a/packages/vue-component-library/src/stories/ImageSlider.stories.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.stories.js
@@ -1,18 +1,47 @@
 // import { computed } from 'vue'
 import ImageSlider from '../lib-components/ImageSlider'
-import * as API from '@/stories/mock-api.json'
 
 export default {
   title: 'Image Slider',
   component: ImageSlider,
 }
 
+const mockImage = [
+  {
+    id: '3512399',
+    src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg',
+    height: 1748,
+    width: 2560,
+    srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 2560w',
+    alt: null,
+    focalPoint: [
+      0.5,
+      0.5
+    ]
+  }
+]
+
+const mockBeforeImage = [
+  {
+    id: '3280520',
+    src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/hot_air_balloon.jpg',
+    height: 1748,
+    width: 2560,
+    srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/hot_air_balloon.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/hot_air_balloon.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/hot_air_balloon.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/hot_air_balloon.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/hot_air_balloon.jpg 2560w',
+    alt: 'Hot air balloon',
+    focalPoint: [
+      0.5,
+      0.5
+    ]
+  }
+]
+
 // Mock data for the ImageSlider carousel, which is a carousel of ImageSlider components
 const mockBeforeAfterImageCarousel = [{
-    id: '37072',
-    caption: 'Before and After Image Slider caption #1',
-    beforeImage: API.image,
-    afterImage: API.image
+  id: '37072',
+  caption: 'Before and After Image Slider caption #1',
+  beforeImage: mockBeforeImage[0],
+  afterImage: mockImage[0]
 }]
 
 export function Default() {

--- a/packages/vue-component-library/src/stories/ImageSlider.stories.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.stories.js
@@ -41,7 +41,7 @@ const mockBeforeAfterImageCarousel = [{
   id: '37072',
   caption: 'Before and After Image Slider caption #1',
   beforeImage: mockBeforeImage[0],
-  afterImage: mockImage[0]
+  afterImage: mockBeforeImage[0]
 }]
 
 export function Default() {

--- a/packages/vue-component-library/src/stories/ImageSlider.stories.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.stories.js
@@ -1,0 +1,34 @@
+// import { computed } from 'vue'
+import ImageSlider from '../lib-components/ImageSlider'
+import * as API from '@/stories/mock-api.json'
+
+export default {
+  title: 'Image Slider',
+  component: ImageSlider,
+}
+
+// Mock data for the ImageSlider carousel, which is a carousel of ImageSlider components
+const mockBeforeAfterImageCarousel = [{
+    id: '37072',
+    caption: 'Before and After Image Slider caption #1',
+    beforeImage: API.image,
+    afterImage: API.image
+}]
+
+export function Default() {
+  return {
+    data() {
+      return {
+        ...mockBeforeAfterImageCarousel[0],
+      }
+    },
+    components: { ImageSlider },
+    template: `
+        <image-slider
+            :before-image="beforeImage"
+            :after-image="afterImage"
+            :caption="caption"
+        />
+    `,
+  }
+}

--- a/packages/vue-component-library/src/stories/ImageSlider.stories.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.stories.js
@@ -53,11 +53,13 @@ export function Default() {
     },
     components: { ImageSlider },
     template: `
+        <div style="padding: 1rem; max-width: 1160px;">
         <image-slider
             :before-image="beforeImage"
             :after-image="afterImage"
             :caption="caption"
         />
+        </div>
     `,
   }
 }

--- a/packages/vue-component-library/src/stories/ImageSlider.stories.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.stories.js
@@ -1,27 +1,9 @@
-// import { computed } from 'vue'
 import ImageSlider from '../lib-components/ImageSlider'
-
-// import ScrollWrapper from '../lib-components/ScrollWrapper'
 
 export default {
   title: 'Image Slider',
   component: ImageSlider,
 }
-
-// const mockImage = [
-//   {
-//     id: '3512399',
-//     src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg',
-//     height: 1748,
-//     width: 2560,
-//     srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 2560w',
-//     alt: null,
-//     focalPoint: [
-//       0.5,
-//       0.5
-//     ]
-//   }
-// ]
 
 const mockBeforeImage = [
   {
@@ -104,24 +86,3 @@ export function WithCustomLabels() {
     `,
   }
 }
-
-// export function WithScrollWrapperCarousel() {
-//   return {
-//     data() {
-//       return {
-//         ...mockBeforeAfterImageCarousel[0],
-//       }
-//     },
-//     components: { ImageSlider },
-//     template: `
-//         <div style="padding: 1rem; max-width: 1160px;">
-//           <ScrollWrapper>
-//         <image-slider
-//             :before-image="beforeImage"
-//             :after-image="afterImage"
-//         />
-//              </ScrollWrapper>
-//         </div>
-//     `,
-//   }
-// }

--- a/packages/vue-component-library/src/stories/ImageSlider.stories.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.stories.js
@@ -1,25 +1,26 @@
 // import { computed } from 'vue'
 import ImageSlider from '../lib-components/ImageSlider'
+// import ScrollWrapper from '../lib-components/ScrollWrapper'
 
 export default {
   title: 'Image Slider',
   component: ImageSlider,
 }
 
-const mockImage = [
-  {
-    id: '3512399',
-    src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg',
-    height: 1748,
-    width: 2560,
-    srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 2560w',
-    alt: null,
-    focalPoint: [
-      0.5,
-      0.5
-    ]
-  }
-]
+// const mockImage = [
+//   {
+//     id: '3512399',
+//     src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg',
+//     height: 1748,
+//     width: 2560,
+//     srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Ericka-Beckman-Hiatus-1999.-Image-courtesy-the-artists.jpg 2560w',
+//     alt: null,
+//     focalPoint: [
+//       0.5,
+//       0.5
+//     ]
+//   }
+// ]
 
 const mockBeforeImage = [
   {
@@ -53,13 +54,73 @@ export function Default() {
     },
     components: { ImageSlider },
     template: `
+    <component is="style" type="text/css">
+.before-image {
+    filter: grayscale(100%)
+}
+    </component>
         <div style="padding: 1rem; max-width: 1160px;">
         <image-slider
             :before-image="beforeImage"
             :after-image="afterImage"
-            :caption="caption"
-        />
+        >
+            <template #captionText>
+               {{ caption }}
+            </template>
+        </image-slider>
         </div>
     `,
   }
 }
+
+export function WithCustomLabels() {
+  return {
+    data() {
+      return {
+        ...mockBeforeAfterImageCarousel[0],
+      }
+    },
+    components: { ImageSlider },
+    template: `
+        <component is="style" type="text/css">
+.before-image {
+    filter: grayscale(100%)
+}
+    </component>
+        <div style="padding: 1rem; max-width: 1160px;">
+        <image-slider
+            :before-image="beforeImage"
+            :after-image="afterImage"
+        >
+            <template #beforeLabel>
+               Color
+            </template>
+            <template #afterLabel>
+              Black and White
+            </template>
+        </image-slider>
+        </div>
+    `,
+  }
+}
+
+// export function WithScrollWrapperCarousel() {
+//   return {
+//     data() {
+//       return {
+//         ...mockBeforeAfterImageCarousel[0],
+//       }
+//     },
+//     components: { ImageSlider },
+//     template: `
+//         <div style="padding: 1rem; max-width: 1160px;">
+//           <ScrollWrapper>
+//         <image-slider
+//             :before-image="beforeImage"
+//             :after-image="afterImage"
+//         />
+//              </ScrollWrapper>
+//         </div>
+//     `,
+//   }
+// }


### PR DESCRIPTION
Connected to [APPS-3376](https://jira.library.ucla.edu/browse/APPS-3376)

**Component Created:** imageSlider.vue

**Stories:** ~/stories/imageSlider.stories.js

**Spec:** ~/stories/imageSlider.spec.js

**Notes:**

- I had originally used a slightly different solution for the slider, but it didn't work on sliders that needed to be rectangular rather and square. So I rewrote the styles to be more responsive and make use of `clip-path` property.
- Slots were added for Before & After label text and the caption
- I started scaffolding out a story with a ScrollWrapper carousel, but ultimately carousel work was split off into a separate ticket 

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   ~~[ ] I assigned this PR to someone on the dev team to review~~
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR

<img width="801" alt="Screenshot 2025-07-03 at 2 24 42 PM" src="https://github.com/user-attachments/assets/7287c1a8-2cfe-4944-b1b3-8a4a7c4380ad" />

[APPS-3376]: https://uclalibrary.atlassian.net/browse/APPS-3376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ