### PR TITLE
fix: APPS-3379 Fix FTVA Homepage Carousel mobile layout

### DIFF
--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -236,16 +236,29 @@
   }
 
   @media (max-width: 900px) {
+
+    
     .caption-block {
+      position: relative;
+      grid-column: col 1 / span 3;
+      grid-row: row 3;
+      min-height: -webkit-max-content;
+      min-height: -moz-max-content;
+      min-height: max-content;
       flex-direction: column;
       background: none;
-      max-height: unset;
-      height: unset;
+      
+      .media-counter {
+        position: relative;
+        top: -58px;
+        margin-bottom: 0;
+      }
 
       .caption-content {
-        top: 48px;
-        padding-top: 32px;
-        padding-bottom: 28px;
+        position: relative;
+        top: 0;
+        padding-top: 16px;
+        padding-bottom: 32px;
         grid-template-columns: 1fr;
         grid-template-rows: 1fr;
         grid-template-areas: 'label'
@@ -269,7 +282,7 @@
 
     .button-prev, .button-next {
       display: block;
-      top: 50%;
+      top: var(--counterWidth);
       bottom: unset;
       transform: translateY(-50%);
     }

--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -145,13 +145,13 @@
     align-items: center;
     width: 100%;
 
-    max-height: 300px;
+    max-height: 400px;
     height: 100%;
     background: linear-gradient(0deg, rgba(0,0,0,.75) 0%, rgba(0,0,0,0) 100%);
     
     .caption-content {
       position: absolute;
-      top: 10%;
+      top: 30%;
 
       display: grid;
       grid-template-columns: 1fr 400px;
@@ -245,6 +245,7 @@
       min-height: -webkit-max-content;
       min-height: -moz-max-content;
       min-height: max-content;
+      max-height: unset;
       flex-direction: column;
       background: none;
       


### PR DESCRIPTION
Connected to [APPS-3379](https://jira.library.ucla.edu/browse/APPS-3379)

**Component Updated:** NewLightbox.vue

**Notes:**

- Fix for a layout issue detected when implementing component on Nuxt site: in mobile view, carousel data is trapped in a scroll box
- Tested change locally

**Preview:**
- Before: https://deploy-preview-748--ucla-library-storybook.netlify.app/?path=/story/media-gallery-new-lightbox--ftva-homepage-carousel
- After: https://deploy-preview-753--ucla-library-storybook.netlify.app/?path=/story/media-gallery-new-lightbox--ftva-homepage-carousel

**Local Screenshots:**
- Before
![ftvahmpg-carousel-before](https://github.com/user-attachments/assets/bd5d509d-d371-44bc-9cf3-80511d42746f)

- After
![ftvahmpg-carousel-after](https://github.com/user-attachments/assets/78d8c5bf-a944-4c9f-98cb-9c5edc2e8791)


**Checklist:**

-   ~~[ ] I checked that it is working locally in the dev server~~
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I requested a review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3379]: https://uclalibrary.atlassian.net/browse/APPS-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ