### PR TITLE
fix: APPS-3358 Fix typeMedia parsing error in FlexMediaWithText

### DIFF
--- a/packages/vue-component-library/src/lib-components/Flexible/MediaWithText.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaWithText.vue
@@ -33,7 +33,7 @@ const parsedContent = computed(() => {
       // item[0].src & buttonUrl can return as null - neither are required
       parsedButtonUrl:
         obj.item && obj.typeMedia === 'other'
-          ? obj.item[0].src
+          ? obj.item[0]?.src
           : obj.buttonUrl,
     }
   })

--- a/packages/vue-component-library/src/stories/BlockMediaWithText.stories.js
+++ b/packages/vue-component-library/src/stories/BlockMediaWithText.stories.js
@@ -155,6 +155,7 @@ export function FTVADefault() {
             :button-text="buttonText"
             :button-url="buttonUrl"
             :cover-image="coverImage"
+            :type-media="typeMedia"
         />
     `,
   }

--- a/packages/vue-component-library/src/stories/mock/BlockMediaWithText.js
+++ b/packages/vue-component-library/src/stories/mock/BlockMediaWithText.js
@@ -50,5 +50,7 @@ export const mockFTVA = {
     }
   ],
   buttonText: 'Linked Destination Lorem Ipsum Dolor Sit Amet',
-  buttonUrl: 'events/la-région-centrale-03-08-24'
+  buttonUrl: 'events/la-région-centrale-03-08-24',
+  item: [],
+  typeMedia: null
 }

--- a/packages/vue-component-library/src/stories/mock/FTVAMedia.js
+++ b/packages/vue-component-library/src/stories/mock/FTVAMedia.js
@@ -811,7 +811,9 @@ export const mockFlexibleBlocks = [
               0.5
             ],
           }
-        ]
+        ],
+        item: [],
+        typeMedia: null
       },
       {
         id: '13670',
@@ -832,7 +834,9 @@ export const mockFlexibleBlocks = [
               0.5
             ],
           }
-        ]
+        ],
+        item: [],
+        typeMedia: 'other'
       }
     ]
   },

--- a/packages/vue-component-library/src/stories/mock/Flexible_MediaWithText.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_MediaWithText.js
@@ -314,7 +314,9 @@ export const mockFTVA = {
             0.5
           ],
         }
-      ]
+      ],
+      item: [],
+      typeMedia: null
     },
     {
       id: '13670',
@@ -335,7 +337,9 @@ export const mockFTVA = {
             0.5
           ],
         }
-      ]
+      ],
+      item: [],
+      typeMedia: 'other'
     }
   ]
 }


### PR DESCRIPTION
Connected to [APPS-3358](https://jira.library.ucla.edu/browse/APPS-3358)

**Component Updated:** Flexible/MediaWithText.vue

**Storybook Previews:**
- No regressions
  - https://deploy-preview-755--ucla-library-storybook.netlify.app/?path=/story/flexible-media-with-text--ftva-default
  - https://deploy-preview-755--ucla-library-storybook.netlify.app/?path=/story/flexible-blocks--ftva-flexible-blocks

**Notes:**
- In Craft, if `other` was selected as a media type in the FlexibleMediaWithText block the page would break/error out; [see ticket for screenshots](https://jira.library.ucla.edu/browse/APPS-3358)
- Fix: Added null check to block content parsing in FlexibleMediawithText
- Updated mock data and stories with additional [missing] fields for testing
- Tested against updated Craft data and local Nuxt website; see screenshot below

**Local Previews:**

<img width="515" height="1000" alt="Fix-FlexMediaWithText" src="https://github.com/user-attachments/assets/f13f51e6-b0b5-48dc-a5fb-063508d3a745" />

**Checklist:**

-   ~~[ ] I checked that it is working locally in the dev server~~
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I assigned this PR to the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3358]: https://uclalibrary.atlassian.net/browse/APPS-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ