### PR TITLE
fix: clear filters when clear btn is clicked

### DIFF
--- a/packages/vue-component-library/src/lib-components/FiltersDropdown.vue
+++ b/packages/vue-component-library/src/lib-components/FiltersDropdown.vue
@@ -50,6 +50,7 @@ function isSelected(searchField: string, option: string) {
 function clearFilters() {
   for (const group of filterGroups)
     selectedFilters.value[group.searchField] = []
+  emit('update-display', selectedFilters.value)
 }
 // Done Button Click / emit selected filters to parent
 function onDoneClick() {


### PR DESCRIPTION
Connected to [APPS-3185](https://jira.library.ucla.edu/browse/APPS-3185)

**Component Updated:** FiltersDropdown.vue

**Notes:**
- Fixed `clear` button event handler to emit emptied filters object to parent

**Previews:**
- Before: https://deploy-preview-755--ucla-library-storybook.netlify.app/?path=/story/filters-dropdown--ftva-filters-update-done-click
  - Select `clear` button
  - Even though labels are toggled/deselected the `Selected filters display` object is still populated with the filters
- After: https://deploy-preview-756--ucla-library-storybook.netlify.app/?path=/story/filters-dropdown--ftva-filters-update-done-click
  - Select `clear` button 
  - `Selected filters display` object is emptied

**Local:**

https://github.com/user-attachments/assets/724ec7d0-1d66-4998-b675-14b5adb7f30b


**Checklist:**

-   ~~[ ] I checked that it is working locally in the dev server~~
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3185]: https://uclalibrary.atlassian.net/browse/APPS-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ