### PR TITLE
fix: APPS-3346 nav bar overlay

### DIFF
--- a/packages/vue-component-library/src/stories/HeaderSticky.stories.js
+++ b/packages/vue-component-library/src/stories/HeaderSticky.stories.js
@@ -122,23 +122,27 @@ export function FTVAVersion() {
 export function FTVASticky() {
   return {
     setup() {
+      const globalStore = useGlobalStore()
+
+      const updateWinWidth = () => {
+        globalStore.winWidth = window.innerWidth
+      }
+
       onMounted(() => {
-        const globalStore = useGlobalStore()
-
-        const updateWinWidth = () => {
-          globalStore.winWidth = window.innerWidth
-        }
-
-        // Set initial winWidth
         updateWinWidth()
-
         window.addEventListener('resize', updateWinWidth)
-
-        // Clean up
-        onBeforeUnmount(() => {
-          window.removeEventListener('resize', updateWinWidth)
-        })
       })
+
+      onBeforeUnmount(() => {
+        window.removeEventListener('resize', updateWinWidth)
+      })
+
+      const showBrandBar = computed(() => globalStore.winWidth > 750) // mobile breakpoint
+
+      return {
+        showBrandBar,
+        globalStore,
+      }
     },
     data() {
       return {
@@ -152,12 +156,12 @@ export function FTVASticky() {
     },
     components: { HeaderSticky, SiteBrandBar },
     template: `
-        <site-brand-bar/>
-        <header-sticky
-            :style="{ position: 'sticky', willChange: 'top' }"
-            :primary-items="FTVAprimaryItems"
-        />
-        <h1>RANDOM TEXT TO SHOW OVERLAY</h1>
+      <site-brand-bar v-if="showBrandBar" />
+      <header-sticky
+          :style="{ position: 'sticky', willChange: 'top' }"
+          :primary-items="FTVAprimaryItems"
+      />
+      <h1>RANDOM TEXT TO SHOW OVERLAY</h1>
     `,
   }
 }

--- a/packages/vue-component-library/src/stories/HeaderSticky.stories.js
+++ b/packages/vue-component-library/src/stories/HeaderSticky.stories.js
@@ -119,7 +119,6 @@ export function FTVAVersion() {
   }
 }
 
-
 export function FTVASticky() {
   return {
     setup() {

--- a/packages/vue-component-library/src/stories/HeaderSticky.stories.js
+++ b/packages/vue-component-library/src/stories/HeaderSticky.stories.js
@@ -3,6 +3,7 @@ import { computed, onBeforeUnmount, onMounted } from 'vue'
 import { useGlobalStore } from '@/stores/GlobalStore'
 import * as API from '@/stories/mock-api.json'
 import HeaderSticky from '@/lib-components/HeaderSticky'
+import SiteBrandBar from '@/lib-components/SiteBrandBar'
 
 // Storybook default settings
 export default {
@@ -114,6 +115,50 @@ export function FTVAVersion() {
         <header-sticky
             :primary-items="FTVAprimaryItems"
         />
+    `,
+  }
+}
+
+
+export function FTVASticky() {
+  return {
+    setup() {
+      onMounted(() => {
+        const globalStore = useGlobalStore()
+
+        const updateWinWidth = () => {
+          globalStore.winWidth = window.innerWidth
+        }
+
+        // Set initial winWidth
+        updateWinWidth()
+
+        window.addEventListener('resize', updateWinWidth)
+
+        // Clean up
+        onBeforeUnmount(() => {
+          window.removeEventListener('resize', updateWinWidth)
+        })
+      })
+    },
+    data() {
+      return {
+        FTVAprimaryItems,
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { HeaderSticky, SiteBrandBar },
+    template: `
+        <site-brand-bar/>
+        <header-sticky
+            :style="{ position: 'sticky', willChange: 'top' }"
+            :primary-items="FTVAprimaryItems"
+        />
+        <h1>RANDOM TEXT TO SHOW OVERLAY</h1>
     `,
   }
 }

--- a/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
+++ b/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
@@ -23,10 +23,29 @@
     }
 
     .menu {
-        grid-column-start: 1;
-        grid-column-end: 2;
+        left: 20px;
+        right: 80px;
+        position: absolute;
         display: flex;
 
+        // add css 'wings' to fill sides of large screen with menu bg color
+        &::after,
+        &::before {
+            display: block;
+            overflow: visible;
+            position: absolute;
+            left: -500px;
+            bottom: 0px;
+            content: '';
+            height: 100%;
+            max-height: 400px;
+            width: 500px;
+            background-color: $navy-blue;
+        }
+
+        &::after {
+            left: 100%;
+        }
         .section-name {
             font-size: 20px;
         }
@@ -82,6 +101,11 @@
                 stroke: white;
             }
         }
+
+        .search-button {
+            position: relative; // required for z-index to work
+            z-index: 1000;
+          }
 
         .slot-container {
             display: block;

--- a/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
+++ b/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
@@ -260,6 +260,7 @@
             display: none;
             grid-column: 1 / span 3;
             width: 100%;
+            position: relative;
 
             :deep(.nav-menu-item),
             :deep(.nav-menu-item.is-opened) {


### PR DESCRIPTION
Connected to [APPS-3346](https://jira.library.ucla.edu/browse/APPS-3346)

**Component Created:** no component created, only changes to ftva SCSS added ~/src/styles/ftva/_nav-primary.scss

**Stories:** ~/stories/HeaderSticky.stories.js

**Spec:** ~/stories/HeaderSticky.spec.js

**Notes:**
The previous PR related to APPS-3346 did not take into account how mobile would be impacted by the changes. This PR allows for the mobile/small screen size to behave as expected when the nav-bar is expanded by adding `position: relative` as a property in the mobile SCSS. The stories have also been updated to remove nav-bar when the screen is small. 

**Photos** 
Before: 
<img width="687" height="729" alt="Screenshot 2025-07-23 at 4 40 42 PM" src="https://github.com/user-attachments/assets/43eab6ad-e443-4219-af6d-943d13c5bcc8" />

After: 

Before:
<img width="252" height="484" alt="Screenshot 2025-07-23 at 4 39 50 PM" src="https://github.com/user-attachments/assets/3442dd1d-9f84-4c68-a9d5-1f7656901614" />

After: 
<img width="637" height="782" alt="Screenshot 2025-07-23 at 4 39 02 PM" src="https://github.com/user-attachments/assets/506a1a60-9f59-4b6a-b677-532683e39162" />

**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [ ] I used a conventional commit message
-   [ ] I assigned myself to this PR
