### PR TITLE
fix:  APPS-3346 navbar reacts properly when screen size is small

### DIFF
--- a/packages/vue-component-library/src/stories/HeaderSticky.stories.js
+++ b/packages/vue-component-library/src/stories/HeaderSticky.stories.js
@@ -122,23 +122,27 @@ export function FTVAVersion() {
 export function FTVASticky() {
   return {
     setup() {
+      const globalStore = useGlobalStore()
+
+      const updateWinWidth = () => {
+        globalStore.winWidth = window.innerWidth
+      }
+
       onMounted(() => {
-        const globalStore = useGlobalStore()
-
-        const updateWinWidth = () => {
-          globalStore.winWidth = window.innerWidth
-        }
-
-        // Set initial winWidth
         updateWinWidth()
-
         window.addEventListener('resize', updateWinWidth)
-
-        // Clean up
-        onBeforeUnmount(() => {
-          window.removeEventListener('resize', updateWinWidth)
-        })
       })
+
+      onBeforeUnmount(() => {
+        window.removeEventListener('resize', updateWinWidth)
+      })
+
+      const showBrandBar = computed(() => globalStore.winWidth > 750) // mobile breakpoint
+
+      return {
+        showBrandBar,
+        globalStore,
+      }
     },
     data() {
       return {
@@ -152,12 +156,12 @@ export function FTVASticky() {
     },
     components: { HeaderSticky, SiteBrandBar },
     template: `
-        <site-brand-bar/>
-        <header-sticky
-            :style="{ position: 'sticky', willChange: 'top' }"
-            :primary-items="FTVAprimaryItems"
-        />
-        <h1>RANDOM TEXT TO SHOW OVERLAY</h1>
+      <site-brand-bar v-if="showBrandBar" />
+      <header-sticky
+          :style="{ position: 'sticky', willChange: 'top' }"
+          :primary-items="FTVAprimaryItems"
+      />
+      <h1>RANDOM TEXT TO SHOW OVERLAY</h1>
     `,
   }
 }

--- a/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
+++ b/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
@@ -258,6 +258,7 @@
         .menu {
             // closed menu
             display: none;
+            position: relative; 
             grid-column: 1 / span 3;
             width: 100%;
 


### PR DESCRIPTION
Connected to [APPS-3346](https://jira.library.ucla.edu/browse/APPS-3346)

**Component Created:** no component created, only changes to ftva SCSS added ~/src/styles/ftva/_nav-primary.scss

**Stories:** ~/stories/HeaderSticky.stories.js

**Spec:** ~/stories/HeaderSticky.spec.js

**Notes:**
The previous PR related to APPS-3346 did not take into account how mobile would be impacted by the changes. This PR allows for the mobile/small screen size to behave as expected when the nav-bar is expanded by adding `position: relative` as a property in the mobile SCSS. The stories have also been updated to remove nav-bar when the screen is small. 

**Preview:**

https://deploy-preview-761--ucla-library-storybook.netlify.app/?path=/story/global-header-sticky--ftva-sticky

**Photos** 
Before Stories: 
<img width="729" height="724" alt="Screenshot 2025-07-23 at 4 53 06 PM" src="https://github.com/user-attachments/assets/86cf084a-982b-43c4-802d-24618c661617" />

After Stories: 

<img width="687" height="729" alt="Screenshot 2025-07-23 at 4 40 42 PM" src="https://github.com/user-attachments/assets/43eab6ad-e443-4219-af6d-943d13c5bcc8" />

Before Nuxt:
<img width="252" height="484" alt="Screenshot 2025-07-23 at 4 39 50 PM" src="https://github.com/user-attachments/assets/3442dd1d-9f84-4c68-a9d5-1f7656901614" />

After Nuxt: 
<img width="637" height="782" alt="Screenshot 2025-07-23 at 4 39 02 PM" src="https://github.com/user-attachments/assets/506a1a60-9f59-4b6a-b677-532683e39162" />
<img width="1194" height="717" alt="Screenshot 2025-07-23 at 4 54 36 PM" src="https://github.com/user-attachments/assets/077d3ad6-1b22-40c4-9346-559f2411de5d" />

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3346]: https://uclalibrary.atlassian.net/browse/APPS-3346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ