### PR TITLE
fix: APPS-3382 search bar disappears after search event occurs

### DIFF
--- a/packages/vue-component-library/src/lib-components/HeaderSticky.vue
+++ b/packages/vue-component-library/src/lib-components/HeaderSticky.vue
@@ -43,8 +43,9 @@ const themeSettings = computed(() => {
 <template>
   <header :class="classes">
     <NavPrimary :items="primaryItems" class="primary">
-      <template #additional-menu>
-        <NavSearch v-if="themeSettings.showSearch" />
+      <template #additional-menu="{ closeSlot }">
+        <NavSearch v-if="themeSettings.showSearch"  @search-complete="closeSlot"
+        />
       </template>
       <template v-if="themeSettings.showDonate" #additional-mobile-menu-items>
         <ButtonLink

--- a/packages/vue-component-library/src/lib-components/NavPrimary.vue
+++ b/packages/vue-component-library/src/lib-components/NavPrimary.vue
@@ -136,6 +136,13 @@ function clearActive() {
   activeMenuIndex.value = currentPathActiveIndex.value
 }
 
+// CLOSE SLOT
+function closeSlot() {
+  slotIsOpened.value = false
+}
+// expose if needed elsewhere too
+defineExpose({ closeSlot })
+
 // Replace globalStore logic for window width with useWindowSize
 const { width } = useWindowSize()
 
@@ -297,7 +304,7 @@ onMounted(() => {
         class="slot-container"
         :class="[{ 'is-opened': slotIsOpened, 'is-opened-mobile': mobileMenuIsOpened }]"
       >
-        <slot name="additional-menu" />
+        <slot name="additional-menu" :close-slot="closeSlot" />
       </div>
     </div>
 

--- a/packages/vue-component-library/src/lib-components/NavSearch.vue
+++ b/packages/vue-component-library/src/lib-components/NavSearch.vue
@@ -14,6 +14,10 @@ const { placeholder } = defineProps({
     default: 'Enter keywords to search this website',
   },
 })
+
+// Emitting events
+const emit = defineEmits(['search-complete'])
+
 const theme = useTheme()
 const router = useRouter()
 const route = useRoute()
@@ -41,6 +45,7 @@ function doSearch() {
     path: '/search',
     query: { q: searchWords.value },
   })
+  emit('search-complete')
 }
 </script>
 


### PR DESCRIPTION
Connected to [APPS-3382](https://jira.library.ucla.edu/browse/APPS-3382)

**Component Created:** NavSearch.vue, NavPrimary.vue, HeaderSticky.vue

**Stories:** ~/stories/HeaderSticky.stories.js

**Spec:** ~/stories/HeaderSticky.spec.js

**Notes:**

This fixes the previous behavior that would cause the search bar to stay open even after a search had been done. This is done by emitting a `search-complete` event after the search is done so that the NavPrimary component can `close-slot` search after it has received this event.

**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [ ] I used a conventional commit message
-   [ ] I assigned myself to this PR
