### PR TITLE
fix: APPS-3031 Update category color and font-size for staff-article-list

### DIFF
--- a/packages/vue-component-library/src/stories/BlockStaffArticleList.stories.js
+++ b/packages/vue-component-library/src/stories/BlockStaffArticleList.stories.js
@@ -174,6 +174,7 @@ const mockDateRange2 = {
   to: 'series/a-film-series-for-you-celebrating-giant-robot-äôs-30th-anniversary',
   title: 'A Film Series for You',
   image: API.image,
+  category: 'Ullamco',
   description: 'This deep into the post-print era it may be hard for some to understand.',
   startDate: '2024-11-01T19:30:00',
   endDate: '2024-11-17T19:30:00',
@@ -258,7 +259,7 @@ export function FtvaCategory() {
       <block-staff-article-list
           :image="image"
           :to="to"
-          category=ULLAMCO
+          :category="category"
           :title="title"
           :description="description"
           

--- a/packages/vue-component-library/src/stories/BlockStaffArticleList.stories.js
+++ b/packages/vue-component-library/src/stories/BlockStaffArticleList.stories.js
@@ -228,6 +228,54 @@ export function FtvaDateRange() {
   }
 }
 
+export function FtvaCategory() {
+  return {
+
+    data() {
+      return { ...mockDateRange2 }
+    },
+    methods: {
+      parseDate(sectionHandle, startDate, endDate, ongoing) {
+        console.log(sectionHandle, startDate, endDate, ongoing)
+
+        if (ongoing)
+          return 'Ongoing'
+        if (sectionHandle === 'ftvaEvent')
+          return formatDates(startDate, startDate, 'shortWithYear')
+        if (sectionHandle === 'ftvaEventSeries')
+          return formatSeriesDates(startDate, endDate, 'shortWithYear')
+
+        return null
+      }
+    },
+    provide() {
+      return {
+        theme: computed(() => 'ftva'),
+      }
+    },
+    components: { BlockStaffArticleList },
+    template: `
+      <block-staff-article-list
+          :image="image"
+          :to="to"
+          category=ULLAMCO
+          :title="title"
+          :description="description"
+          
+      >
+      <template
+            v-if="parseDate(sectionHandle ?? '', startDate ?? '', endDate ?? '', ongoing ?? false)"
+            #customFTVADate
+          >
+            <span class="ftva-date">
+              {{ parseDate(sectionHandle ?? '', startDate ?? '', endDate ?? '', ongoing ?? false) }}
+            </span>
+          </template>
+      </block-staff-article-list>
+  `,
+  }
+}
+
 export function FtvaSameStartEndDate() {
   return {
     data() {

--- a/packages/vue-component-library/src/styles/ftva/_block-staff-article-item.scss
+++ b/packages/vue-component-library/src/styles/ftva/_block-staff-article-item.scss
@@ -15,6 +15,12 @@
 
   }
 
+  .category {
+    @include ftva-subtitle-1;
+    font-size: 20px;
+    color: $accent-blue;
+  }
+
   .title {
     @include ftva-card-title-1;
     color: $heading-grey;


### PR DESCRIPTION
Connected to ~~[APPS-3031](https://jira.library.ucla.edu/browse/APPS-3031)~~ [APPS-3210](https://jira.library.ucla.edu/browse/APPS-3210)

**Component Created:** no components created only changed SCSS _block-staff-article-item.scss

**Stories:** ~/stories/blockStaffArticleList.stories.js

**Spec:** ~/stories/blocStaffArticleList.spec.js

**Notes:**

The font-size and color properties for the category were added to the FTVA-specific SCSS file. 

**Preview:** 
https://deploy-preview-764--ucla-library-storybook.netlify.app/?path=/story/block-staff-article-list--ftva-category

**Screenshots:**
Before:
<img width="1009" height="732" alt="Screenshot 2025-07-30 at 9 25 26 AM" src="https://github.com/user-attachments/assets/6f206344-1749-4b18-9341-cf3de4801d8b" />

After: 
<img width="855" height="660" alt="Screenshot 2025-07-30 at 9 20 13 AM" src="https://github.com/user-attachments/assets/ead87996-cc56-4b53-bf27-1defb204e352" />

**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3031]: https://uclalibrary.atlassian.net/browse/APPS-3031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APPS-3210]: https://uclalibrary.atlassian.net/browse/APPS-3210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ