### PR TITLE
fix: APPS-3324 dropdown matches width of share button

### DIFF
--- a/packages/vue-component-library/src/styles/ftva/_mobile-drawer.scss
+++ b/packages/vue-component-library/src/styles/ftva/_mobile-drawer.scss
@@ -19,5 +19,13 @@
         border-right-width: 1px;
         border-bottom-width: 1px;
         border-color: $medium-grey;
+        min-width: 194px;
+        width: 100%;
+    }
+
+    .button-dropdown-modal-wrapper.is-expanded {
+        position: absolute;
+        width: auto;
+        margin: 0;
     }
 }


### PR DESCRIPTION
Connected to [APPS-3324](https://jira.library.ucla.edu/browse/APPS-3324)

**Component Edited:**ftva/ _mobile-drawer.scss

**Stories:** ~/stories/MobileDrawer.stories.js

**Spec:** ~/stories/MobileDrawer.spec.js

**Notes:**
Various scss properties were added to get the button to expand properly. The width comes from the width set for the "Share" button itself. 

**Photos:** 
Before:
<img width="205" height="314" alt="Screenshot 2025-08-05 at 10 08 11 PM" src="https://github.com/user-attachments/assets/7be71c77-b5b2-4b78-92a8-928a3a2dde51" />
<img width="250" height="379" alt="Screenshot 2025-08-06 at 9 15 02 AM" src="https://github.com/user-attachments/assets/fc941545-7d62-4dfe-be65-8bc736822deb" />

After: 
<img width="205" height="311" alt="Screenshot 2025-08-05 at 10 06 58 PM" src="https://github.com/user-attachments/assets/5e46e57f-f5ca-4f96-9c12-573bbc94a965" />
<img width="286" height="397" alt="Screenshot 2025-08-06 at 9 15 17 AM" src="https://github.com/user-attachments/assets/3886075c-d641-46ca-8682-3d18d53d9ed4" />

**Link:**

https://deploy-preview-769--ucla-library-storybook.netlify.app/?path=/story/button-dropdown--ftva-share

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3324]: https://uclalibrary.atlassian.net/browse/APPS-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ