### PR TITLE
fix: APPS-3198 border-radius calendar events

### DIFF
--- a/packages/vue-component-library/src/stories/mock/CalendarEvents.js
+++ b/packages/vue-component-library/src/stories/mock/CalendarEvents.js
@@ -49,7 +49,25 @@ export const mockCalendarEvents = {
       image: null
     },
     {
-      imageCarousel: [],
+      imageCarousel: [
+        {
+          image: [
+            {
+              src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/Michael-Snow-old.jpg',
+              width: 2560,
+              alt: 'Michael Snow',
+              id: '3203248',
+              srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/Michael-Snow-old.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/Michael-Snow-old.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/Michael-Snow-old.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/Michael-Snow-old.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/Michael-Snow-old.jpg 2560w',
+              focalPoint: [
+                0.5,
+                0.5
+              ],
+              height: 1955
+            }
+          ],
+          creditText: null
+        }
+      ],
       typeHandle: 'ftvaEvent',
       title: 'Ministry of Ungentlemanly Warfare',
       uri: 'events/',
@@ -72,7 +90,25 @@ export const mockCalendarEvents = {
       image: null
     },
     {
-      imageCarousel: [],
+      imageCarousel: [
+        {
+          image: [
+            {
+              src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/stick_it_ver2.jpg',
+              width: 2560,
+              alt: null,
+              id: '3370311',
+              srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/stick_it_ver2.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/stick_it_ver2.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/stick_it_ver2.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/stick_it_ver2.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/stick_it_ver2.jpg 2560w',
+              focalPoint: [
+                0.5,
+                0.5
+              ],
+              height: 1924
+            }
+          ],
+          creditText: null
+        }
+      ],
       typeHandle: 'ftvaEvent',
       title: 'A Quiet Place: Day One',
       uri: 'events/',

--- a/packages/vue-component-library/src/styles/default/_base-calendar.scss
+++ b/packages/vue-component-library/src/styles/default/_base-calendar.scss
@@ -216,7 +216,8 @@
       }
 
       .card-meta {
-        height: unset;
+        height: unset; 
+        min-height: unset;
         padding: 28px;
 
         .block-tags {

--- a/packages/vue-component-library/src/styles/ftva/_base-calendar.scss
+++ b/packages/vue-component-library/src/styles/ftva/_base-calendar.scss
@@ -70,6 +70,10 @@
     .ftva.block-highlight {
       border-radius: 0;
 
+      .media {
+        border-radius: 4px 4px 0 0; //overwrrite card meta styles that interfere with event pop-up border-radius
+      }
+
       @media #{$has-hover} {
         &:hover {
             box-shadow: unset;

--- a/packages/vue-component-library/src/styles/ftva/_base-calendar.scss
+++ b/packages/vue-component-library/src/styles/ftva/_base-calendar.scss
@@ -64,6 +64,10 @@
 
 .v-overlay-container {
 
+  .v-menu > .v-overlay__content {
+    border-radius: 8px;
+  }
+
   .calendar-event-popup-wrapper {
     background-color: $page-blue;
 


### PR DESCRIPTION
Connected to [APPS-3198](https://jira.library.ucla.edu/browse/APPS-3198)

**Component Updated:** /styles/ftva/base-calendar.scss

**Notes:**

The border radius for calendar events in vuetify is 4px. These styles were clashing with our styles, so they have been overwritten at the calendar event level. 

Additionally, a border radius was applied to media elements that wasn't present with the placeholder image was used instead. Our stories only used placeholder images. I added images to the calendar story with events so any discrepancies will be easier to notice in the future.

<img width="527" height="512" alt="Screenshot 2025-08-13 at 2 47 39 PM" src="https://github.com/user-attachments/assets/4358c04c-9a36-4ee8-a4a9-049633577c2d" />
<img width="527" height="512" alt="Screenshot 2025-08-13 at 2 47 32 PM" src="https://github.com/user-attachments/assets/82e324bb-c5cf-4ae1-b630-fa6ecc631acd" />


**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   ~~[ ] I assigned this PR to someone on the dev team to review~~
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[APPS-3198]: https://uclalibrary.atlassian.net/browse/APPS-3198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ