### PR TITLE
fix: for forked PR's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
+      deployments: write
     runs-on: ubuntu-latest
     steps:
       - name: Download storybook artifact
@@ -116,6 +117,7 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
+      deployments: write
     steps:
       - name: Download storybook artifact
         uses: actions/download-artifact@v4
@@ -155,6 +157,7 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
+      deployments: write
 
     steps:
       - name: Download storybook artifact
@@ -186,12 +189,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: "pnpm"
-      - run: corepack enable
-
       # Your workspace setup must NOT require secrets for forks
       - uses: ./.github/workflows/setup-workspace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,19 +66,12 @@ jobs:
         with:
           path: storybook-static
           key: storybook-${{ github.sha }}
-
-      - name: Build Storybook
-        run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components run build-storybook
-
-      # (optional) sanity check so you can see the files
-      - name: List Storybook output
-        run: ls -la packages/vue-component-library/storybook-static || true
-
-      # ✅ Upload from inside the package so the artifact is flat
-      - name: Upload storybook artifact (flat)
+      - run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components run build-storybook
+      - name: Upload storybook artifact
         uses: actions/upload-artifact@v4
         with:
-          name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
+          # Works for PRs (has PR number) and pushes (falls back to run_id)
+          name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
           path: packages/vue-component-library/storybook-static
           if-no-files-found: error
           retention-days: 3
@@ -98,15 +91,15 @@ jobs:
       - name: Download storybook artifact
         uses: actions/download-artifact@v4
         with:
-          name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
-          path: packages/vue-component-library
+          name: storybook-static-${{ github.run_id }}-${{ github.sha }}
+          path: storybook-static
       - name: Deploy to Netlify (merged)
         uses: nwtgck/actions-netlify@v2 # v1.2.3
         with:
           production-deploy: true
           deploy-message: https://github.com/UCLALibrary/ucla-library-website-component/commit/${{ github.sha }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          publish-dir: "./packages/vue-component-library/storybook-static"
+          publish-dir: "./storybook-static"
           fails-without-credentials: true
           github-deployment-environment: test
         env:
@@ -130,7 +123,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
-          path: packages/vue-component-library
+          path: storybook-static
       - name: Deploy to Netlify (preview, internal)
         uses: nwtgck/actions-netlify@v2 # v1.2.3
         with:
@@ -139,7 +132,7 @@ jobs:
           alias: deploy-preview-${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           overwrites-pull-request-comment: true
-          publish-dir: "./packages/vue-component-library/storybook-static"
+          publish-dir: "./storybook-static"
           fails-without-credentials: true
           github-deployment-environment: storybook--${{ github.event_name }}-${{ github.event.number }}
         env:
@@ -171,7 +164,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
-          path: packages/vue-component-library
+          path: storybook-static
 
       - name: Deploy to Netlify (preview, fork - gated)
         id: netlify
@@ -182,7 +175,7 @@ jobs:
           alias: deploy-preview-${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           overwrites-pull-request-comment: true
-          publish-dir: "./packages/vue-component-library/storybook-static"
+          publish-dir: "./storybook-static"
           fails-without-credentials: true
           github-deployment-environment: storybook--${{ github.event_name }}-${{ github.event.number }}
         env:
@@ -204,14 +197,36 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
-          path: packages/vue-component-library
+          path: packages/vue-component-library/_artifact
 
-      # Verify Cypress is installed (devDependency) in the filtered package
+      - name: Normalize to packages/vue-component-library/storybook-static
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd packages/vue-component-library/_artifact
+
+          target="../storybook-static"
+          rm -rf "$target"
+          # no dir; maybe files are at root of the artifact → move all contents
+          mkdir -p "$target"
+          shopt -s dotglob nullglob
+          # Only move if there is something to move to avoid errors
+          files=( * )
+          if (( ${#files[@]} )); then
+            mv "${files[@]}" "$target"/
+          fi
+
+          cd ..
+          rm -rf _artifact
+          echo "Normalized contents:"
+          ls -la storybook-static
+
+      # 2) Verify Cypress is installed (devDependency) in the filtered package
       - name: Verify Cypress Installation
         shell: bash
         run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec cypress --version
 
-      # Run Cypress against the static Storybook
+      # 3) Run Cypress against the static Storybook
       - name: Cypress test for Storybook Components
         uses: cypress-io/github-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,13 @@ jobs:
             # ⬇️ put files into the package folder
           path: packages/vue-component-library
 
+          # (Optional) sanity check
+      - name: List served files
+        working-directory: packages/vue-component-library
+        run: |
+          pwd
+          ls -la storybook-static | sed 's/^/storybook-static: /'
+
       # 2) Verify Cypress is installed (devDependency) in the filtered package
       - name: Verify Cypress Installation
         shell: bash
@@ -213,5 +220,5 @@ jobs:
         with:
           install: false
           working-directory: packages/vue-component-library
-          start: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec http-server ./storybook-static -p 6006
+          start: pnpm  exec http-server ./storybook-static -p 6006
           wait-on: http://localhost:6006

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           # Works for PRs (has PR number) and pushes (falls back to run_id)
           name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
-          path: packages/vue-component-library/storybook-static
+          path: storybook-static
           if-no-files-found: error
           retention-days: 3
 
@@ -92,14 +92,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: storybook-static-${{ github.run_id }}-${{ github.sha }}
-          path: storybook-static
+          path: packages/vue-component-library
       - name: Deploy to Netlify (merged)
         uses: nwtgck/actions-netlify@v2 # v1.2.3
         with:
           production-deploy: true
           deploy-message: https://github.com/UCLALibrary/ucla-library-website-component/commit/${{ github.sha }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          publish-dir: "./storybook-static"
+          publish-dir: "./packages/vue-component-library/storybook-static"
           fails-without-credentials: true
           github-deployment-environment: test
         env:
@@ -123,7 +123,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
-          path: storybook-static
+          path: packages/vue-component-library
       - name: Deploy to Netlify (preview, internal)
         uses: nwtgck/actions-netlify@v2 # v1.2.3
         with:
@@ -132,7 +132,7 @@ jobs:
           alias: deploy-preview-${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           overwrites-pull-request-comment: true
-          publish-dir: "./storybook-static"
+          publish-dir: "./packages/vue-component-library/storybook-static"
           fails-without-credentials: true
           github-deployment-environment: storybook--${{ github.event_name }}-${{ github.event.number }}
         env:
@@ -164,7 +164,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
-          path: storybook-static
+          path: packages/vue-component-library
 
       - name: Deploy to Netlify (preview, fork - gated)
         id: netlify
@@ -175,7 +175,7 @@ jobs:
           alias: deploy-preview-${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           overwrites-pull-request-comment: true
-          publish-dir: "./storybook-static"
+          publish-dir: "./packages/vue-component-library/storybook-static"
           fails-without-credentials: true
           github-deployment-environment: storybook--${{ github.event_name }}-${{ github.event.number }}
         env:
@@ -197,41 +197,41 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
-          path: packages/vue-component-library/_artifact
+          path: packages/vue-component-library
 
-      - name: Normalize to packages/vue-component-library/storybook-static
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd packages/vue-component-library/_artifact
+      #- name: Normalize to packages/vue-component-library/storybook-static
+      # shell: bash
+      #run: |
+      # set -euo pipefail
+      #cd packages/vue-component-library/_artifact
 
-          target="../storybook-static"
-          rm -rf "$target"
+      #target="../storybook-static"
+      #rm -rf "$target"
 
-          if [[ -d "storybook-static" ]]; then
-            # Case 1: the dir is right here
-            mv "storybook-static" "$target"
-          else
-            # Case 2: find it somewhere under _artifact
-            cand="$(find . -type d -name storybook-static -print -quit || true)"
-            if [[ -n "${cand}" ]]; then
-              mv "${cand}" "$target"
-            else
-              # Case 3: no dir; maybe files are at root of the artifact → move all contents
-              mkdir -p "$target"
-              shopt -s dotglob nullglob
-              # Only move if there is something to move to avoid errors
-              files=( * )
-              if (( ${#files[@]} )); then
-                mv "${files[@]}" "$target"/
-              fi
-            fi
-          fi
+      #if [[ -d "storybook-static" ]]; then
+      # Case 1: the dir is right here
+      # mv "storybook-static" "$target"
+      #else
+      # Case 2: find it somewhere under _artifact
+      # cand="$(find . -type d -name storybook-static -print -quit || true)"
+      #if [[ -n "${cand}" ]]; then
+      # mv "${cand}" "$target"
+      #else
+      # Case 3: no dir; maybe files are at root of the artifact → move all contents
+      # mkdir -p "$target"
+      #shopt -s dotglob nullglob
+      # Only move if there is something to move to avoid errors
+      #files=( * )
+      #if (( ${#files[@]} )); then
+      # mv "${files[@]}" "$target"/
+      #fi
+      #fi
+      #fi
 
-          cd ..
-          rm -rf _artifact
-          echo "Normalized contents:"
-          ls -la storybook-static
+      #cd ..
+      #rm -rf _artifact
+      #echo "Normalized contents:"
+      #ls -la storybook-static
 
       # 2) Verify Cypress is installed (devDependency) in the filtered package
       - name: Verify Cypress Installation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,10 @@ jobs:
 
       - name: Find Storybook path
         id: find_storybook
-        run: echo "dir=$(find packages/vue-component-library -type d -name storybook-static | head -n1)" >> $GITHUB_OUTPUT
+        run: |
+          dir=$(find packages/vue-component-library -type d -name storybook-static | head -n1)
+          echo "Found Storybook path: $dir"   # This will print to console
+          echo "dir=$dir" >> $GITHUB_OUTPUT   # This will set the step output
 
       # 2) Verify Cypress is installed (devDependency) in the filtered package
       - name: Verify Cypress Installation
@@ -224,5 +227,5 @@ jobs:
         with:
           install: false
           working-directory: ${{ steps.find_storybook.outputs.dir }}
-          start: pnpm  exec http-server ./storybook-static -p 6006
+          start: pnpm  exec http-server . -p 6006
           wait-on: http://localhost:6006

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,17 @@ jobs:
           path: storybook-static
           key: storybook-${{ github.sha }}
       - run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components run build-storybook
-      - name: Upload storybook artifact
+
+      # (optional) sanity check so you can see the files
+      - name: List Storybook output
+        run: ls -la packages/vue-component-library/storybook-static || true
+
+      # ✅ Upload from inside the package so the artifact is flat
+      - name: Upload storybook artifact (flat)
+        working-directory: packages/vue-component-library
         uses: actions/upload-artifact@v4
         with:
-          # Works for PRs (has PR number) and pushes (falls back to run_id)
-          name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+          name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
           path: storybook-static
           if-no-files-found: error
           retention-days: 3
@@ -91,7 +97,7 @@ jobs:
       - name: Download storybook artifact
         uses: actions/download-artifact@v4
         with:
-          name: storybook-static-${{ github.run_id }}-${{ github.sha }}
+          name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
           path: packages/vue-component-library
       - name: Deploy to Netlify (merged)
         uses: nwtgck/actions-netlify@v2 # v1.2.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v4
       # Your workspace setup must NOT require secrets for forks
       - uses: ./.github/workflows/setup-workspace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         with:
           path: storybook-static
           key: storybook-${{ github.sha }}
+
+      - name: Build Storybook
       - run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components run build-storybook
 
       # (optional) sanity check so you can see the files
@@ -74,11 +76,10 @@ jobs:
 
       # ✅ Upload from inside the package so the artifact is flat
       - name: Upload storybook artifact (flat)
-        working-directory: packages/vue-component-library
         uses: actions/upload-artifact@v4
         with:
           name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
-          path: storybook-static
+          path: packages/vue-component-library/storybook-static
           if-no-files-found: error
           retention-days: 3
 
@@ -205,46 +206,12 @@ jobs:
           name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
           path: packages/vue-component-library
 
-      #- name: Normalize to packages/vue-component-library/storybook-static
-      # shell: bash
-      #run: |
-      # set -euo pipefail
-      #cd packages/vue-component-library/_artifact
-
-      #target="../storybook-static"
-      #rm -rf "$target"
-
-      #if [[ -d "storybook-static" ]]; then
-      # Case 1: the dir is right here
-      # mv "storybook-static" "$target"
-      #else
-      # Case 2: find it somewhere under _artifact
-      # cand="$(find . -type d -name storybook-static -print -quit || true)"
-      #if [[ -n "${cand}" ]]; then
-      # mv "${cand}" "$target"
-      #else
-      # Case 3: no dir; maybe files are at root of the artifact → move all contents
-      # mkdir -p "$target"
-      #shopt -s dotglob nullglob
-      # Only move if there is something to move to avoid errors
-      #files=( * )
-      #if (( ${#files[@]} )); then
-      # mv "${files[@]}" "$target"/
-      #fi
-      #fi
-      #fi
-
-      #cd ..
-      #rm -rf _artifact
-      #echo "Normalized contents:"
-      #ls -la storybook-static
-
-      # 2) Verify Cypress is installed (devDependency) in the filtered package
+      # Verify Cypress is installed (devDependency) in the filtered package
       - name: Verify Cypress Installation
         shell: bash
         run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec cypress --version
 
-      # 3) Run Cypress against the static Storybook
+      # Run Cypress against the static Storybook
       - name: Cypress test for Storybook Components
         uses: cypress-io/github-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,28 +193,32 @@ jobs:
       # Your workspace setup must NOT require secrets for forks
       - uses: ./.github/workflows/setup-workspace
 
-      # 1) Get the static build produced earlier
-      - name: Download storybook artifact
+      - name: Download Storybook artifact
         uses: actions/download-artifact@v4
         with:
-          name:
-            storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
-            # ⬇️ put files into the package folder
-          path: packages/vue-component-library
+          name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+          path: packages/vue-component-library/_artifact
 
-          # (Optional) sanity check
-      - name: List served files
-        working-directory: packages/vue-component-library
+      - name: Normalize to packages/vue-component-library/storybook-static
+        shell: bash
         run: |
-          pwd
-          ls -la storybook-static | sed 's/^/storybook-static: /'
-
-      - name: Find Storybook path
-        id: find_storybook
-        run: |
-          dir=$(find packages/vue-component-library -type d -name storybook-static | head -n1)
-          echo "Found Storybook path: $dir"   # This will print to console
-          echo "dir=$dir" >> $GITHUB_OUTPUT   # This will set the step output
+          set -euo pipefail
+          cd packages/vue-component-library/_artifact
+          target="../storybook-static"
+          rm -rf "$target"
+          if [[ -d storybook-static ]]; then
+            mv storybook-static "$target"
+          elif cand=$(find . -type d -name storybook-static -print -quit); then
+            mv "$cand" "$target"
+          else
+            mkdir -p "$target"
+            shopt -s dotglob
+            mv * "$target"/ || true
+          fi
+          cd ..
+          rm -rf _artifact
+          echo "Normalized:"
+          ls -la storybook-static
 
       # 2) Verify Cypress is installed (devDependency) in the filtered package
       - name: Verify Cypress Installation
@@ -227,5 +231,5 @@ jobs:
         with:
           install: false
           working-directory: ${{ steps.find_storybook.outputs.dir }}
-          start: pnpm  exec http-server . -p 6006
+          start: pnpm  exec http-server ./storybook-static -p 6006
           wait-on: http://localhost:6006

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,10 @@ jobs:
       - name: Download storybook artifact
         uses: actions/download-artifact@v4
         with:
-          name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
-          path: storybook-static
+          name:
+            storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+            # ⬇️ put files into the package folder
+          path: packages/vue-component-library
 
       # 2) Verify Cypress is installed (devDependency) in the filtered package
       - name: Verify Cypress Installation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,10 @@ jobs:
           pwd
           ls -la storybook-static | sed 's/^/storybook-static: /'
 
+      - name: Find Storybook path
+        id: find_storybook
+        run: echo "dir=$(find packages/vue-component-library -type d -name storybook-static | head -n1)" >> $GITHUB_OUTPUT
+
       # 2) Verify Cypress is installed (devDependency) in the filtered package
       - name: Verify Cypress Installation
         shell: bash
@@ -219,6 +223,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           install: false
-          working-directory: packages/vue-component-library
+          working-directory: ${{ steps.find_storybook.outputs.dir }}
           start: pnpm  exec http-server ./storybook-static -p 6006
           wait-on: http://localhost:6006

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # Works for PRs (has PR number) and pushes (falls back to run_id)
-          name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+          name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
           path: packages/vue-component-library/storybook-static
           if-no-files-found: error
           retention-days: 3
@@ -91,7 +91,7 @@ jobs:
       - name: Download storybook artifact
         uses: actions/download-artifact@v4
         with:
-          name: storybook-static-${{ github.run_id }}-${{ github.sha }}
+          name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
           path: storybook-static
       - name: Deploy to Netlify (merged)
         uses: nwtgck/actions-netlify@v2 # v1.2.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: Comment with percy instructions
         uses: bubkoo/auto-comment@v1
@@ -35,18 +38,12 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.PAT_SEMENTIC_RELEASE_AND_ESLINT }} # non-github token Parinita's personal access token will expire ever 90 days
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/setup-workspace
       - run: pnpm -r run lint
-      - uses: EndBug/add-and-commit@v9
-        with:
-          message: "chore: linter autofixes"
-          default_author: github_actions
 
   vite:
     runs-on: ubuntu-latest
@@ -56,11 +53,12 @@ jobs:
       - uses: ./.github/workflows/setup-workspace
       - run: pnpm run build
 
-  storybook:
+  # --- Build Storybook once (no secrets) and publish artifact ---
+  storybook-build:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/setup-workspace
       - name: Cache Storybook Build
         id: cache-storybook
@@ -69,8 +67,26 @@ jobs:
           path: storybook-static
           key: storybook-${{ github.sha }}
       - run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components run build-storybook
+      - name: Upload storybook artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: packages/vue-component-library/storybook-static
+          if-no-files-found: error
+          retention-days: 3
+
+  # --- Deploy (merged) on main/vue3.x pushes (uses secrets) ---
+  storybook-merged-deploy:
+    if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'vue3.x')
+    needs: storybook-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download storybook artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: storybook-static
       - name: Deploy to Netlify (merged)
-        if: github.ref_name == 'main' || github.ref_name == 'vue3.x'
         uses: nwtgck/actions-netlify@v2 # v1.2.3
         with:
           production-deploy: true
@@ -82,8 +98,24 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_STORYBOOK_VUE3X }}
-      - name: Deploy to Netlify (preview)
-        if: github.event_name == 'pull_request'
+
+  # --- Deploy preview for INTERNAL PRs (no approval needed) ---
+  storybook-preview-internal:
+    if: github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: storybook-build
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download storybook artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: storybook-static
+      - name: Deploy to Netlify (preview, internal)
+        if: github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: nwtgck/actions-netlify@v2 # v1.2.3
         with:
           production-deploy: false
@@ -98,16 +130,72 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_STORYBOOK_VUE3X }}
 
-      - name: Verify Cypress Installation
-        shell: bash
-        run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec cypress --version
+    # --- Deploy preview for FORK PRs (requires approval via Environment) ---
+  storybook-preview-fork:
+    if: github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    needs: storybook-build
+    runs-on: ubuntu-latest
 
-      - name: Cypress test for Storybook Components
-        uses: cypress-io/github-action@v5
+    # This is the protected environment you created in Settings → Environments
+    environment:
+      name: netlify-preview
+      # Optional: show the URL on the PR after deploy
+      url: ${{ steps.netlify.outputs.NETLIFY_URL }}
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download storybook artifact
+        uses: actions/download-artifact@v4
         with:
-          install: false
-          working-directory: packages/vue-component-library
-          start: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec http-server ./storybook-static -p 6006
-          wait-on: http://localhost:6006
+          name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          path: storybook-static
+
+      - name: Deploy to Netlify (preview, fork - gated)
+        id: netlify
+        uses: nwtgck/actions-netlify@v2
+        with:
+          production-deploy: false
+          deploy-message: https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+          alias: deploy-preview-${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          overwrites-pull-request-comment: true
+          publish-dir: "./packages/vue-component-library/storybook-static"
+          fails-without-credentials: true
+          github-deployment-environment: storybook--${{ github.event_name }}-${{ github.event.number }}
         env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_STORYBOOK_VUE3X }}
+          # These come from the protected Environment, only after approval
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_STORYBOOK_VUE3X }}
+
+  storybook-cypress:
+  needs: storybook-build
+  runs-on: ubuntu-latest
+  permissions:
+    contents: read
+  steps:
+    # Your workspace setup must NOT require secrets for forks
+    - uses: ./.github/workflows/setup-workspace
+
+    # 1) Get the static build produced earlier
+    - name: Download storybook artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+        path: storybook-static
+
+    # 2) Verify Cypress is installed (devDependency) in the filtered package
+    - name: Verify Cypress Installation
+      shell: bash
+      run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec cypress --version
+
+    # 3) Run Cypress against the static Storybook
+    - name: Cypress test for Storybook Components
+      uses: cypress-io/github-action@v5
+      with:
+        install: false
+        working-directory: packages/vue-component-library
+        start: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec http-server ./storybook-static -p 6006
+        wait-on: http://localhost:6006

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
   storybook-merged-deploy:
     if: github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'vue3.x')
     needs: storybook-build
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - name: Download storybook artifact
@@ -107,7 +112,10 @@ jobs:
     needs: storybook-build
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
+      issues: write
+      statuses: write
     steps:
       - name: Download storybook artifact
         uses: actions/download-artifact@v4
@@ -143,7 +151,10 @@ jobs:
       url: ${{ steps.netlify.outputs.NETLIFY_URL }}
 
     permissions:
+      contents: write
       pull-requests: write
+      issues: write
+      statuses: write
 
     steps:
       - name: Download storybook artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           key: storybook-${{ github.sha }}
 
       - name: Build Storybook
-      - run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components run build-storybook
+        run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components run build-storybook
 
       # (optional) sanity check so you can see the files
       - name: List Storybook output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/setup-workspace
       - run: pnpm run build
 
@@ -70,7 +70,8 @@ jobs:
       - name: Upload storybook artifact
         uses: actions/upload-artifact@v4
         with:
-          name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          # Works for PRs (has PR number) and pushes (falls back to run_id)
+          name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
           path: packages/vue-component-library/storybook-static
           if-no-files-found: error
           retention-days: 3
@@ -84,7 +85,7 @@ jobs:
       - name: Download storybook artifact
         uses: actions/download-artifact@v4
         with:
-          name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          name: storybook-static-${{ github.run_id }}-${{ github.sha }}
           path: storybook-static
       - name: Deploy to Netlify (merged)
         uses: nwtgck/actions-netlify@v2 # v1.2.3
@@ -92,7 +93,7 @@ jobs:
           production-deploy: true
           deploy-message: https://github.com/UCLALibrary/ucla-library-website-component/commit/${{ github.sha }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          publish-dir: "./packages/vue-component-library/storybook-static"
+          publish-dir: "./storybook-static"
           fails-without-credentials: true
           github-deployment-environment: test
         env:
@@ -111,11 +112,9 @@ jobs:
       - name: Download storybook artifact
         uses: actions/download-artifact@v4
         with:
-          name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
           path: storybook-static
       - name: Deploy to Netlify (preview, internal)
-        if: github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
         uses: nwtgck/actions-netlify@v2 # v1.2.3
         with:
           production-deploy: false
@@ -123,14 +122,14 @@ jobs:
           alias: deploy-preview-${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           overwrites-pull-request-comment: true
-          publish-dir: "./packages/vue-component-library/storybook-static"
+          publish-dir: "./storybook-static"
           fails-without-credentials: true
           github-deployment-environment: storybook--${{ github.event_name }}-${{ github.event.number }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_STORYBOOK_VUE3X }}
 
-    # --- Deploy preview for FORK PRs (requires approval via Environment) ---
+  # --- Deploy preview for FORK PRs (requires approval via Environment) ---
   storybook-preview-fork:
     if: github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
@@ -150,7 +149,7 @@ jobs:
       - name: Download storybook artifact
         uses: actions/download-artifact@v4
         with:
-          name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          name: storybook-static-${{ github.event.pull_request.number }}-${{ github.sha }}
           path: storybook-static
 
       - name: Deploy to Netlify (preview, fork - gated)
@@ -162,7 +161,7 @@ jobs:
           alias: deploy-preview-${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           overwrites-pull-request-comment: true
-          publish-dir: "./packages/vue-component-library/storybook-static"
+          publish-dir: "./storybook-static"
           fails-without-credentials: true
           github-deployment-environment: storybook--${{ github.event_name }}-${{ github.event.number }}
         env:
@@ -171,31 +170,37 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_STORYBOOK_VUE3X }}
 
   storybook-cypress:
-  needs: storybook-build
-  runs-on: ubuntu-latest
-  permissions:
-    contents: read
-  steps:
-    # Your workspace setup must NOT require secrets for forks
-    - uses: ./.github/workflows/setup-workspace
+    needs: storybook-build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+      - run: corepack enable
 
-    # 1) Get the static build produced earlier
-    - name: Download storybook artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: storybook-static-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
-        path: storybook-static
+      # Your workspace setup must NOT require secrets for forks
+      - uses: ./.github/workflows/setup-workspace
 
-    # 2) Verify Cypress is installed (devDependency) in the filtered package
-    - name: Verify Cypress Installation
-      shell: bash
-      run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec cypress --version
+      # 1) Get the static build produced earlier
+      - name: Download storybook artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook-static-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}
+          path: storybook-static
 
-    # 3) Run Cypress against the static Storybook
-    - name: Cypress test for Storybook Components
-      uses: cypress-io/github-action@v5
-      with:
-        install: false
-        working-directory: packages/vue-component-library
-        start: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec http-server ./storybook-static -p 6006
-        wait-on: http://localhost:6006
+      # 2) Verify Cypress is installed (devDependency) in the filtered package
+      - name: Verify Cypress Installation
+        shell: bash
+        run: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec cypress --version
+
+      # 3) Run Cypress against the static Storybook
+      - name: Cypress test for Storybook Components
+        uses: cypress-io/github-action@v5
+        with:
+          install: false
+          working-directory: packages/vue-component-library
+          start: pnpm --filter @ucla-library-monorepo/ucla-library-website-components exec http-server ./storybook-static -p 6006
+          wait-on: http://localhost:6006

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,20 +204,33 @@ jobs:
         run: |
           set -euo pipefail
           cd packages/vue-component-library/_artifact
+
           target="../storybook-static"
           rm -rf "$target"
-          if [[ -d storybook-static ]]; then
-            mv storybook-static "$target"
-          elif cand=$(find . -type d -name storybook-static -print -quit); then
-            mv "$cand" "$target"
+
+          if [[ -d "storybook-static" ]]; then
+            # Case 1: the dir is right here
+            mv "storybook-static" "$target"
           else
-            mkdir -p "$target"
-            shopt -s dotglob
-            mv * "$target"/ || true
+            # Case 2: find it somewhere under _artifact
+            cand="$(find . -type d -name storybook-static -print -quit || true)"
+            if [[ -n "${cand}" ]]; then
+              mv "${cand}" "$target"
+            else
+              # Case 3: no dir; maybe files are at root of the artifact → move all contents
+              mkdir -p "$target"
+              shopt -s dotglob nullglob
+              # Only move if there is something to move to avoid errors
+              files=( * )
+              if (( ${#files[@]} )); then
+                mv "${files[@]}" "$target"/
+              fi
+            fi
           fi
+
           cd ..
           rm -rf _artifact
-          echo "Normalized:"
+          echo "Normalized contents:"
           ls -la storybook-static
 
       # 2) Verify Cypress is installed (devDependency) in the filtered package
@@ -230,6 +243,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           install: false
-          working-directory: ${{ steps.find_storybook.outputs.dir }}
+          working-directory: packages/vue-component-library
           start: pnpm  exec http-server ./storybook-static -p 6006
           wait-on: http://localhost:6006


### PR DESCRIPTION
Connected to [APPS-3404](https://jira.library.ucla.edu/browse/APPS-3404)

## **Summary**
This PR updates the `Run CI Suite` workflow to:
- Separate Storybook build, deploy, and Cypress test steps for **internal PRs**, **forked PRs**, and **merged branches**.
- Introduce a **protected Netlify preview environment** for forked PRs, requiring manual approval from maintainers before secrets are exposed.
- Keep internal PR previews running automatically without approval.
- Build Storybook only once per run and share the artifact across deploy/test jobs to reduce redundancy.

---

## **Key Changes**
1. **Storybook Build Job**
   - Builds Storybook once.
   - Uploads the static build as an artifact.
   - Makes artifact available for all deploy/test jobs.
   
2. **Deploy Jobs**
   - **Merged Deploy (`main` / `vue3.x`)** → Deploys to production Netlify site.
   - **Internal PR Preview** → Deploys preview automatically (no approval).
   - **Fork PR Preview** → Deploys only after approval via protected `netlify-preview` environment.

3. **Security Improvements**
   - Forked PRs **cannot access secrets** until a maintainer approves in the Environment review step.
   - Uses `github.event.pull_request.head.repo.full_name` to distinguish internal vs fork PRs.

4. **Cypress Testing**
   - Runs Cypress tests against the built Storybook artifact without rebuilding.
   - No secrets required for fork PR Cypress runs.

5. **Permissions**
   - Scoped permissions (`contents: read`, `pull-requests: write`) to follow GitHub security best practices.

---

## **Benefits**
- **Security** → Secrets for Netlify deploys are never exposed to forks without approval.
- **Efficiency** → Build Storybook once, reuse in deploy/test steps.
- **Maintainability** → Clearly separated logic for internal vs fork PRs.
- **Transparency** → Fork preview deploys are gated and explicitly approved.

---

## **Testing Notes**
- **Internal PRs** → Should auto-deploy preview after PR is opened.
- **Fork PRs** → Workflow should pause at the environment approval step before deploying preview.
- **Push to `main`/`vue3.x`** → Should deploy to production Netlify.
- **Cypress** → Should run successfully against Storybook static build.

## **Maintainer Approval Guide for Fork Deploys**

When a forked pull request is opened, the Storybook preview deploy will **pause** until a maintainer approves secret access.  
Follow these steps to approve and trigger the deploy:

---

### **1. Go to the GitHub Actions Run**
- Open the **Actions** tab in the repository.
- Find the workflow run for the forked PR (look for "Run CI Suite" with the PR number).
- Click the run to open the workflow details.

---

### **2. Locate the Paused Job**
- Scroll to find the **`storybook-preview-fork`** job.
- It will show a status like **"Waiting for approval to deploy to environment: `netlify-preview`"**.

---

### **3. Approve the Deployment**
- Click **"Review deployments"** in the yellow banner at the top of the workflow page.
- In the popup:
  1. Verify the PR is safe to run with secrets.
  2. Click **"Approve and deploy"**.

---

### **4. Wait for Deploy**
- The job will continue and run the Netlify preview deploy using the protected `NETLIFY_*` secrets.
- Once complete, the preview URL will be posted as a comment on the PR.

---

### **Tips**
- You only need to approve **once per workflow run** for a given PR.
- If a new commit is pushed to the forked branch, you will need to approve again.
- Always verify the contributor and changes before approving secret access.

---

✅ **Result:** The Storybook preview for forked PRs is deployed securely without exposing secrets to untrusted contributors.


[APPS-3404]: https://uclalibrary.atlassian.net/browse/APPS-3404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ