### PR TITLE
fix: APPS-3399 make sitebrand route to correct URL for ftva

### DIFF
--- a/packages/vue-component-library/src/lib-components/SectionStaffArticleList.vue
+++ b/packages/vue-component-library/src/lib-components/SectionStaffArticleList.vue
@@ -97,7 +97,7 @@ function getNonFTVADate(date: string) {
             #customFTVADate
           >
             {{ parseDate(item.sectionHandle ?? '', item.startDate ?? '', item.endDate ?? '', item.ongoing ?? false,
-              item.date ?? '') }}
+                         item.date ?? '') }}
           </template>
         </BlockStaffArticleList>
       </ul>

--- a/packages/vue-component-library/src/lib-components/SectionStaffArticleList.vue
+++ b/packages/vue-component-library/src/lib-components/SectionStaffArticleList.vue
@@ -54,6 +54,14 @@ function parsedTextAll(description: string) {
     ? removeHtmlTruncate(description, 250)
     : ''
 }
+function getNonFTVADescription(description: string) {
+  console.log('theme', theme.value)
+  return theme.value === 'ftva' ? '' : description
+}
+function getNonFTVADate(date: string) {
+  console.log('theme', theme.value)
+  return theme.value === 'ftva' ? '' : date
+}
 </script>
 
 <template>
@@ -73,9 +81,9 @@ function parsedTextAll(description: string) {
           :to="item.to"
           :category="item.category"
           :title="item.title"
-          :date="theme === 'ftva' ? '' : item.date"
+          :date="getNonFTVADate(item.date ?? '')"
           :authors="item.authors"
-          :description="theme === 'ftva' ? '' : item.description"
+          :description="getNonFTVADescription(item.description ?? '')"
           :external-resource-url="item.externalResourceUrl"
         >
           <template

--- a/packages/vue-component-library/src/lib-components/SectionStaffArticleList.vue
+++ b/packages/vue-component-library/src/lib-components/SectionStaffArticleList.vue
@@ -55,12 +55,12 @@ function parsedTextAll(description: string) {
     : ''
 }
 function getNonFTVADescription(description: string) {
-  console.log('theme', theme.value)
-  return theme.value === 'ftva' ? '' : description
+  console.log('theme', theme?.value)
+  return theme?.value === 'ftva' ? '' : description
 }
 function getNonFTVADate(date: string) {
-  console.log('theme', theme.value)
-  return theme.value === 'ftva' ? '' : date
+  console.log('theme', theme?.value)
+  return theme?.value === 'ftva' ? '' : date
 }
 </script>
 
@@ -97,7 +97,7 @@ function getNonFTVADate(date: string) {
             #customFTVADate
           >
             {{ parseDate(item.sectionHandle ?? '', item.startDate ?? '', item.endDate ?? '', item.ongoing ?? false,
-                         item.date ?? '') }}
+              item.date ?? '') }}
           </template>
         </BlockStaffArticleList>
       </ul>

--- a/packages/vue-component-library/src/lib-components/SiteBrandBar.vue
+++ b/packages/vue-component-library/src/lib-components/SiteBrandBar.vue
@@ -17,6 +17,7 @@ const parsedHeaderThemeSettings = computed(() => {
       headerText: 'UCLA Film & Television Archive',
       buttonText: 'Donate',
       buttonLink: '/donate',
+      homepage: '/'
     }
   }
   // default
@@ -27,7 +28,7 @@ const parsedHeaderThemeSettings = computed(() => {
 <template>
   <div :class="classes">
     <a
-      href="https://www.ucla.edu"
+      :href="parsedHeaderThemeSettings.homepage || 'https://www.ucla.edu'"
       target="_blank"
     >
       <span v-if="!parsedHeaderThemeSettings?.useLogo && parsedHeaderThemeSettings.headerText" class="ucla-text">{{


### PR DESCRIPTION
Connected to [APPS-3399](https://jira.library.ucla.edu/browse/APPS-3399)

**Component Created:** siteBrandBar.vue

**Stories:** ~/stories/siteBrandBar..stories.js

**Spec:** ~/stories/siteBrandBar..spec.js

**Notes:**

For the FTVA theme the brand will now route to '/' or whatever the local homepage is

**Links:**

https://deploy-preview-793--ucla-library-storybook.netlify.app/?path=/story/global-site-brand-bar--ftva-version

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3399]: https://uclalibrary.atlassian.net/browse/APPS-3399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ