### PR TITLE
fix: APPS-3208 make block card with image clickable

### DIFF
--- a/packages/vue-component-library/src/styles/ftva/_block-card-with-image.scss
+++ b/packages/vue-component-library/src/styles/ftva/_block-card-with-image.scss
@@ -22,7 +22,6 @@
     }
 
     :deep(.card-meta) {
-        position: relative;
         margin: 0px;
         padding: 25px 20px 15px 20px;
         min-height: 191px;


### PR DESCRIPTION
Connected to [APPS-3208](https://jira.library.ucla.edu/browse/APPS-3208)

**Component Created:** blockCardWithImage.vue

**Stories:** ~/stories/blockCardWithImage.stories.js

**Spec:** ~/stories/blockCardWithImage.spec.js

**Notes:**
The `position: relative` for the CardMeta component was causing issues with the default clickablitiy behavior already established by the default .scss file in blockCardWithImage. Removal of it doesn't affect any other part of the card.

**Links:** 
https://deploy-preview-811--ucla-library-storybook.netlify.app/?path=/story/block-card-with-image--ftva-article-blog-listing

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3208]: https://uclalibrary.atlassian.net/browse/APPS-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ