### PR TITLE
fix: APPS-3396 change text below search bar

### DIFF
--- a/packages/vue-component-library/src/lib-components/NavSearch.vue
+++ b/packages/vue-component-library/src/lib-components/NavSearch.vue
@@ -25,7 +25,7 @@ const route = useRoute()
 // DEFAULT CONTENT
 // if this component ever needs to be reused with different content,
 // we can pass these as default props instead
-const defaultBottomText = 'Looking for something else? Search the Film & Television Archive Catalog at '
+const defaultBottomText = 'Looking for a specific collection item? Search the UCLA Film & Television Archive Catalog at '
 const defaultBottomLink = {
   label: 'UC LIBRARY SEARCH >',
   to: 'https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&tab=Articles_books_more_slot&search_scope=ArticlesBooksMore&lang=en&query=any,contains,',


### PR DESCRIPTION
Connected to [APPS-3396](https://jira.library.ucla.edu/browse/APPS-3396)

**Component Created:** NavSearch.vue

**Stories:** ~/stories/NavSearch.stories.js

**Spec:** ~/stories/NavSearch.spec.js

**Photos:**
Before:
<img width="1299" height="162" alt="image-20250902-170802" src="https://github.com/user-attachments/assets/ac47e737-6d83-48bc-b036-a0c57b9ba2fd" />

After:
<img width="1154" height="173" alt="Screenshot 2025-09-02 at 1 30 26 PM" src="https://github.com/user-attachments/assets/5aed5489-8f10-4a85-91ef-4acc8ad2e682" />

**Links:**
https://deploy-preview-812--ucla-library-storybook.netlify.app/?path=/story/nav-search--ftva

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3396]: https://uclalibrary.atlassian.net/browse/APPS-3396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ