### PR TITLE
fix: add git identity

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -19,7 +19,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+      - name: Git identity for commits
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Detect Changed Packages
         id: filter
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
failing at the git push step because there are no valid git credentials available to push commits/tags.