### PR TITLE
fix: APPS-3193 make arrows on calendar 20 pixels from calendar edges

### DIFF
--- a/packages/vue-component-library/src/styles/default/_base-calendar.scss
+++ b/packages/vue-component-library/src/styles/default/_base-calendar.scss
@@ -4,7 +4,7 @@
 
   .calendar-wrapper {
     display: grid;
-    grid-template-columns: 40px 1fr 40px;
+    grid-template-columns: 76px 1fr 76px;
   }
 
   .calendar-body {
@@ -54,7 +54,7 @@
   }
 
   .v-calendar-header > button:nth-of-type(2) {
-    left: 0%;
+    left: 36px;
 
     i.v-icon {
       z-index: 1;
@@ -65,7 +65,7 @@
   }
 
   .v-calendar-header > button:nth-of-type(3) {
-    left: 100%;
+    right: 0;
 
     i.v-icon {
       z-index: 1;
@@ -274,4 +274,3 @@
    // Slot styles
   .calendar-slot-wrapper{}
 }
-

--- a/packages/vue-component-library/src/styles/ftva/_base-calendar.scss
+++ b/packages/vue-component-library/src/styles/ftva/_base-calendar.scss
@@ -16,9 +16,12 @@
   .v-calendar-header > button:nth-of-type(3) {
     background-color: $navy-blue;
     color: white;
+    position: absolute;
   }
 
   .v-calendar-header > button:nth-of-type(2) {
+    margin-left: -20px;
+
     i.v-icon {
       &::before {
           content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-left_icon.svg');
@@ -27,6 +30,8 @@
   }
 
   .v-calendar-header > button:nth-of-type(3) {
+    margin-left: 20px;
+
     i.v-icon {
       &::before {
           content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-right_icon.svg');

--- a/packages/vue-component-library/src/styles/ftva/_base-calendar.scss
+++ b/packages/vue-component-library/src/styles/ftva/_base-calendar.scss
@@ -16,12 +16,9 @@
   .v-calendar-header > button:nth-of-type(3) {
     background-color: $navy-blue;
     color: white;
-    position: absolute;
   }
 
   .v-calendar-header > button:nth-of-type(2) {
-    margin-left: -20px;
-
     i.v-icon {
       &::before {
           content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-left_icon.svg');
@@ -30,8 +27,6 @@
   }
 
   .v-calendar-header > button:nth-of-type(3) {
-    margin-left: 20px;
-
     i.v-icon {
       &::before {
           content: url('ucla-library-design-tokens/assets/svgs/icon-ftva-right_icon.svg');


### PR DESCRIPTION
Connected to [APPS-3193](https://jira.library.ucla.edu/browse/APPS-3193)

**Component Created:** _base-calendar.scss

**Stories:** ~BaseCalendars.stories.js

**Spec:** ~/stories/BaseCalendars.spec.js

**Photos:**
Before:
<img width="1122" height="665" alt="Screenshot 2025-09-15 at 7 10 09 AM" src="https://github.com/user-attachments/assets/213687be-958e-4f07-9d40-9b89198aebd0" />

After: 
<img width="1161" height="593" alt="Screenshot 2025-09-15 at 7 10 23 AM" src="https://github.com/user-attachments/assets/d1f9c553-8c69-4183-9b01-b509d0979263" />

**Notes:**

The buttons needs to be 20 px away from the edge of the calendar.

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3193]: https://uclalibrary.atlassian.net/browse/APPS-3193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ