### PR TITLE
fix: APPS-3395 make underline on menu only occur during hover and menu open

### DIFF
--- a/packages/vue-component-library/src/styles/default/_nav-menu-item.scss
+++ b/packages/vue-component-library/src/styles/default/_nav-menu-item.scss
@@ -7,6 +7,10 @@
     display: inline-block;
     vertical-align: top;
 
+    &:focus-within:not(.is-opened)>.section-name::after {
+        opacity: 1;
+    }
+    
     &:focus-within:not(.is-opened)>.sub-menu {
         opacity: 0.9;
         max-height: 100vh;

--- a/packages/vue-component-library/src/styles/default/_nav-menu-item.scss
+++ b/packages/vue-component-library/src/styles/default/_nav-menu-item.scss
@@ -133,18 +133,14 @@
             opacity: 1;
         }
     }
-
-    // underline on hover
-    @media (hover: hover) {
-        &:hover {
-        .section-name::after {
-            opacity: 1;
-        }
-        }
-    }
     
     // Hover
     @media #{$has-hover} {
+        // underline on hover
+        .nav-menu-item:hover .section-name::after {
+            opacity: 1;
+        }
+
         .sub-menu-item:hover {
             background-color: rgba(#ffffff, 0.1);
             text-decoration: underline;

--- a/packages/vue-component-library/src/styles/default/_nav-menu-item.scss
+++ b/packages/vue-component-library/src/styles/default/_nav-menu-item.scss
@@ -7,10 +7,6 @@
     display: inline-block;
     vertical-align: top;
 
-    &:focus-within:not(.is-opened)>.section-name::after {
-        opacity: 1;
-    }
-
     &:focus-within:not(.is-opened)>.sub-menu {
         opacity: 0.9;
         max-height: 100vh;
@@ -118,10 +114,10 @@
         outline-style: solid;
     }
 
-    // States
-    &.is-active {
+    // underline only on active and open item
+    &.is-opened.is-active {
         .section-name::after {
-            opacity: 1;
+        opacity: 1;
         }
     }
 
@@ -138,6 +134,15 @@
         }
     }
 
+    // underline on hover
+    @media (hover: hover) {
+        &:hover {
+        .section-name::after {
+            opacity: 1;
+        }
+        }
+    }
+    
     // Hover
     @media #{$has-hover} {
         .sub-menu-item:hover {


### PR DESCRIPTION
Connected to [APPS-3395](https://jira.library.ucla.edu/browse/APPS-3395)

**Component Created:** navMenuItem.vue

**Stories:** ~/stories/HeaderSticky.stories.js
~/stories/NavPrimary.stories.js

**Spec:** ~/stories/HeaderSticky.spec.js
~/stories/NavPrimary.spec.js

**Notes:**
The underline on a specific item was occuring any time the state of the specific item in the nav bar was active. This is only activated now when the cursor is hovering over it or when the menu is open. 

**Videos:**
Before:

https://github.com/user-attachments/assets/13f7ea04-c79d-4f81-8496-10bb568b28b7

https://github.com/user-attachments/assets/b171195b-e2ad-4f71-a2eb-464808719be4




After: 

https://github.com/user-attachments/assets/ed720839-5f25-47c7-bc47-6623f7e8961e


https://github.com/user-attachments/assets/fe57e592-6568-41d2-9abf-a75382695c0e


**LInks:**
UCLA Site: 
https://deploy-preview-821--ucla-library-storybook.netlify.app/?path=/story/nav-primary--default
FTVA Site: 
https://deploy-preview-821--ucla-library-storybook.netlify.app/?path=/story/global-header-sticky--ftva-version

**Checklist:**

-   [x] I checked that it is working locally in the dev server
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3395]: https://uclalibrary.atlassian.net/browse/APPS-3395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ