### PR TITLE
fix: APPS-3428 update URL to UC library search in nav bar

### DIFF
--- a/packages/vue-component-library/src/lib-components/NavSearch.vue
+++ b/packages/vue-component-library/src/lib-components/NavSearch.vue
@@ -28,7 +28,7 @@ const route = useRoute()
 const defaultBottomText = 'Looking for a specific collection item? Search the UCLA Film & Television Archive Catalog at '
 const defaultBottomLink = {
   label: 'UC LIBRARY SEARCH >',
-  to: 'https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&tab=Articles_books_more_slot&search_scope=ArticlesBooksMore&lang=en&query=any,contains,',
+  to: 'https://search.library.ucla.edu/discovery/search?vid=01UCS_LAL:UCLA&mode=advanced',
 }
 const classes = computed(() => {
   return ['nav-search', theme?.value || '']


### PR DESCRIPTION
Connected to [APPS-3428](https://jira.library.ucla.edu/browse/APPS-3428)

**Component Created:** nacSearvh.vue

**Stories:** ~/stories/navSearch.stories.js

**Spec:** ~/stories/navSearch.spec.js

**Notes:**

Link changed to desired one based on ticket specification 

**Videos:**
Before:
https://github.com/user-attachments/assets/4d16e20b-86ee-44a5-b462-ec6d5a020eed

After:


https://github.com/user-attachments/assets/e82365ee-4b0c-4026-97b2-35a226b97b0c

**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [ ] I used a conventional commit message
-   [ ] I assigned myself to this PR
