### PR TITLE
fix: APPS-3462 Correct FTVA Footer components variable syntax

### DIFF
--- a/packages/vue-component-library/src/styles/ftva/_footer-links.scss
+++ b/packages/vue-component-library/src/styles/ftva/_footer-links.scss
@@ -1,5 +1,5 @@
 .ftva.footer-links {
-    --unit-content-width: --ftva-container-max-width;
+    --unit-content-width: var(--ftva-container-max-width);
     background-color: #191919;
     color: white;
 

--- a/packages/vue-component-library/src/styles/ftva/_footer-primary.scss
+++ b/packages/vue-component-library/src/styles/ftva/_footer-primary.scss
@@ -1,5 +1,5 @@
 .ftva.footer-primary {
-    --unit-content-width: --ftva-container-max-width;
+    --unit-content-width: var(--ftva-container-max-width);
     background-color: $navy-blue;
     border-bottom: 0px;
 

--- a/packages/vue-component-library/src/styles/ftva/_footer-sock.scss
+++ b/packages/vue-component-library/src/styles/ftva/_footer-sock.scss
@@ -1,11 +1,12 @@
 .ftva.footer-sock {
-    --unit-content-width: --ftva-container-max-width;
+    --unit-content-width: var(--ftva-container-max-width);
     background-color: #191919;
 
     .container {
         .link {
             color: $white;
-            text-decoration-color: $grey-blue;
+            -webkit-text-decoration-color: $grey-blue;
+                    text-decoration-color: $grey-blue;
 
             &:hover {
                 color: $grey-blue;


### PR DESCRIPTION
Connected to [APPS-3462](https://jira.library.ucla.edu/browse/APPS-3462)

**Component Updated:**
- _footer-links.scss
- _footer-primary.scss
- _footer-socks.scss

**Notes:**
- Updated scss variable syntax for max-width of FTVA footer components

**Preview Links:**
- https://deploy-preview-823--ucla-library-storybook.netlify.app/?path=/story/footer-links--ftva-style-links
- https://deploy-preview-823--ucla-library-storybook.netlify.app/?path=/story/footer-primary--ftva-footer
- https://deploy-preview-823--ucla-library-storybook.netlify.app/?path=/story/footer-sock--ftva-footer

### Local - Before

<img width="800" height="460" alt="footer-before" src="https://github.com/user-attachments/assets/d9009dab-86c4-4121-a945-37072ea1e774" />

### Local - After

<img width="800" height="460" alt="footer-after" src="https://github.com/user-attachments/assets/19828621-497a-4c50-905e-a0022c0264d9" />

### Checklist:

-   ~~[ ] I checked that it is working locally in the dev server~~
-   [ ] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the FTVA-nuxt dev server
-   [x] I added a screenshot of it working
-   [x] UX has reviewed and approved this
-   [x] I requested a review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[APPS-3462]: https://uclalibrary.atlassian.net/browse/APPS-3462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ