### PR TITLE
fix: APPS-3453 add tel to contact info block

### DIFF
--- a/packages/vue-component-library/src/lib-components/Flexible/Info.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/Info.vue
@@ -58,9 +58,9 @@ const classes = computed(() => {
         <ul class="contact-info">
           <li>
             <IconWithLink
-              :text="parsedItems.phone || ''"
-              icon-name="svg-icon-ftva-phone"
-              :to="parsedItems.phone"
+            :text="`tel: ${parsedItems.phone || ''}`"
+            icon-name="svg-icon-ftva-phone"
+            :to="`tel:${parsedItems.phone || ''}`"
             />
           </li>
           <li>


### PR DESCRIPTION
Connected to [APPS-3453](https://jira.library.ucla.edu/browse/APPS-3453)

**Component Created:** info.vue

**Stories:** ~/stories/flexible_info.stories.js

**Spec:** ~/stories/flexible_info.spec.js

**Notes:**
Add `tel: ` to contact block

**Photos:**
Before: 
<img width="579" height="294" alt="Screenshot 2025-09-23 at 5 40 19 PM" src="https://github.com/user-attachments/assets/2055a0af-c352-42c5-9957-2f3a8bf920cf" />

After:
<img width="1144" height="329" alt="Screenshot 2025-09-23 at 5 43 21 PM" src="https://github.com/user-attachments/assets/9f043377-24e3-4684-b237-3a1da2a060fe" />

**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [ ] I used a conventional commit message
-   [ ] I assigned myself to this PR
