### PR TITLE
fix: override image style media gallery

### DIFF
--- a/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaGallery/NewLightbox.vue
@@ -57,6 +57,7 @@ const classes = computed(() => {
   return ['lightbox', theme?.value || '', inline ? 'inline' : '']
 })
 // if ftva, pass cover as object fit, otherwise contain
+// note: this is overwritten with css styles for ftva media gallery carousels
 const parsedObjectFit = computed(() => {
   return theme?.value === 'ftva' ? 'cover' : 'contain'
 })
@@ -108,6 +109,7 @@ function setCurrentSlide(currentSlide: number) {
         <MediaItem
           :key="`${item.captionTitle}-${index}`" :object-fit="parsedObjectFit" :item="item.item"
           :cover-image="item.coverImage" :embed-code="item.embedCode"
+          class="library-media-item"
         >
           <div v-if="item.credit" class="credit-text">
             <span v-text="item.credit" />

--- a/packages/vue-component-library/src/stories/mock/FTVAMedia.js
+++ b/packages/vue-component-library/src/stories/mock/FTVAMedia.js
@@ -35,11 +35,10 @@ export const Gallery = {
       item: [
         {
           id: '46054',
-          src: 'https://static.library.ucla.edu/craftassetstest/images/pine-needles_2022-10-18-005212_jcjf.jpg',
-          srcset:
-      'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/pine-needles_2022-10-18-005212_jcjf.jpg 2560w',
+          src: 'https://placehold.co/100x400',
+          srcset: 'https://placehold.co/100x400.jpg 375w, https://placehold.co/100x400.jpg 960w, https://placehold.co/100x400.jpg',
           height: 1918,
-          width: 2560,
+          width: 560,
           title: 'Pine needles',
           focalPoint: [0.5, 0.5],
           kind: 'image',

--- a/packages/vue-component-library/src/styles/ftva/_media-gallery.scss
+++ b/packages/vue-component-library/src/styles/ftva/_media-gallery.scss
@@ -32,4 +32,13 @@
     padding-top: var(--space-xl);
     list-style-type: none;
   }
+
+  // change image treatment to contain for ftva carousels inside media galleries only
+  :deep(.media-container) {
+    .library-media-item {
+      img.media-image {
+        object-fit: contain !important;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Connected to [APPS-](https://jira.library.ucla.edu/browse/APPS-3447)

**Component Edited:** FTVA MediaGallery.vue styles

**Notes:**

- [X] Added a css override for the cover / contain behavior in ftva
- [X] Added a long, tall image to test data

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR
