### PR TITLE
fix: APPS-5127 useId instead of id to prevent duplicate ids

### DIFF
--- a/packages/vue-component-library/src/lib-components/BannerFeatured.vue
+++ b/packages/vue-component-library/src/lib-components/BannerFeatured.vue
@@ -362,7 +362,7 @@ const classes = computed(() => {
 
       <ButtonLink
         v-if="to && prompt"
-        :id="useId()"
+        :id="buttonId"
         :label="prompt"
         :to="to"
         :aria-labelledby="`${buttonId} ${titleId}`"

--- a/packages/vue-component-library/src/lib-components/BannerFeatured.vue
+++ b/packages/vue-component-library/src/lib-components/BannerFeatured.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, useId } from 'vue'
 import type { PropType } from 'vue'
 import format from 'date-fns/format'
 
@@ -104,6 +104,9 @@ const props = defineProps({
 })
 
 const theme = useTheme()
+
+const titleId = useId()
+const buttonId = useId()
 
 // Video & Image
 const isVideo = computed(() => {
@@ -278,7 +281,7 @@ const classes = computed(() => {
 
       <div v-if="titleLink.length > 0">
         <SmartLink
-          id="banner-featured"
+          :id="titleId"
           :to="titleLink"
           class="title title-linked"
         >
@@ -288,7 +291,7 @@ const classes = computed(() => {
 
       <div v-else>
         <h3
-          id="banner-featured"
+          :id="titleId"
           class="title"
           v-html="title"
         />
@@ -359,10 +362,10 @@ const classes = computed(() => {
 
       <ButtonLink
         v-if="to && prompt"
-        id="banner-featured-button"
+        :id="useId()"
         :label="prompt"
         :to="to"
-        aria-labelledby="banner-featured-button banner-featured"
+        :aria-labelledby="`${buttonId} ${titleId}`"
         class="button"
       />
 

--- a/packages/vue-component-library/src/lib-components/ButtonLink.vue
+++ b/packages/vue-component-library/src/lib-components/ButtonLink.vue
@@ -117,7 +117,7 @@ const parsedIconName = computed(() => {
     :aria-label="label"
   >
     <!-- Default layer (hidden from screen readers) -->
-    <span class="label">{{ label }}</span>
+    <span class="label" aria-hidden="true">{{ label }}</span>
 
     <!-- Allows for adding additional elements inside the button -->
     <slot aria-hidden="true" />
@@ -132,7 +132,7 @@ const parsedIconName = computed(() => {
 
     <!-- Hover layer (also hidden from screen readers) -->
     <div class="hover" aria-hidden="true">
-      <span class="label" aria-hidden="true">{{ label }}</span>
+      <span class="label">{{ label }}</span>
       <component
         :is="parsedIconName"
         v-if="parsedIconName !== ''"

--- a/packages/vue-component-library/src/lib-components/ButtonLink.vue
+++ b/packages/vue-component-library/src/lib-components/ButtonLink.vue
@@ -117,7 +117,7 @@ const parsedIconName = computed(() => {
     :aria-label="label"
   >
     <!-- Default layer (hidden from screen readers) -->
-    <span class="label" aria-hidden="true">{{ label }}</span>
+    <span class="label">{{ label }}</span>
 
     <!-- Allows for adding additional elements inside the button -->
     <slot aria-hidden="true" />
@@ -132,7 +132,7 @@ const parsedIconName = computed(() => {
 
     <!-- Hover layer (also hidden from screen readers) -->
     <div class="hover" aria-hidden="true">
-      <span class="label">{{ label }}</span>
+      <span class="label" aria-hidden="true">{{ label }}</span>
       <component
         :is="parsedIconName"
         v-if="parsedIconName !== ''"


### PR DESCRIPTION
Connected to [APPS-5127](https://jira.library.ucla.edu/browse/APPS-5127)

**Notes:**

Vue has a composable to fix this issue of dynamic ids, I've implemented it here
https://vueschool.io/articles/vuejs-tutorials/generating-random-ids-in-vue-js/

https://deploy-preview-933--ucla-library-storybook.netlify.app/?path=/story/banner-featured--default

Now if you inspect the html, you will see unique vue-generated IDs that preserve the voiceover behavior of the button (it will still read the button text + the title text)


**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR
