### PR TITLE
fix: LADI-5126 useID to prevent duplicate ids

### DIFF
--- a/packages/vue-component-library/src/lib-components/BlockEvent.vue
+++ b/packages/vue-component-library/src/lib-components/BlockEvent.vue
@@ -1,5 +1,6 @@
 <script>
 import format from 'date-fns/format'
+import { useId } from 'vue'
 import SmartLink from '@/lib-components/SmartLink'
 
 // Utility functions
@@ -40,6 +41,14 @@ export default {
       default: '',
     },
   },
+  setup() {
+    const titleId = useId()
+    const buttonId = useId()
+    return {
+      titleId,
+      buttonId,
+    }
+  },
   computed: {
     classes() {
       return ['block-event', `button color-${this.sectionName}`]
@@ -69,13 +78,12 @@ export default {
 
     <div class="text row">
       <span class="category">{{ category }}</span>
-      <h2 class="title" v-text="title" />
+      <h2 class="title" :id="titleId" v-text="title" />
       <div class="date-time">
         <time v-if="startDate" class="dates" v-text="parsedDate" />
         <time v-if="parsedTime" class="time" v-text="parsedTime" />
       </div>
-      <SmartLink :class="classes" :to="to" v-text="prompt" />
-      <!-- TO DO: Use button-link component instead -->
+      <SmartLink :id="buttonId" :class="classes" :to="to" :aria-labelledby="`${buttonId} ${titleId}`" v-text="prompt" />
     </div>
 
     <div class="sizer" />


### PR DESCRIPTION
Connected to [LADI-5126](https://jira.library.ucla.edu/browse/LADI-5126)

**Component Edited:** BlockEvent.vue

**Notes:**

Similar to https://github.com/UCLALibrary/ucla-library-website-components/pull/933, we need the button to read the title text which requires an id and aria-labelledby field, but an id requires that the element be unique on the entire page, and often these components aren't.

Therefore we are using vue's composable useID()

Tested the voiceover for the button here: https://deploy-preview-934--ucla-library-storybook.netlify.app/?path=/story/block-event--short-text#storybook-preview-wrapper

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[LADI-5126]: https://uclalibrary.atlassian.net/browse/LADI-5126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ