### PR TITLE
fix: LADI-5138 fix overflowing placeholder

### DIFF
--- a/packages/vue-component-library/src/stories/SectionStaffArticleList.stories.js
+++ b/packages/vue-component-library/src/stories/SectionStaffArticleList.stories.js
@@ -593,7 +593,6 @@ export function FtvaBlogList() {
         }
           .stories-ftva-articles .ftva.block-staff-article-item .image, .stories-ftva-articles .ftva.block-staff-article-item .molecule-no-image {
             min-width: 100%;
-            height: auto;
             margin: 0;
           }
           .stories-ftva-articles .ftva.block-staff-article-item .meta {


### PR DESCRIPTION
Connected to [LADI-5138](https://jira.library.ucla.edu/browse/LADI-5138)

**Notes:**
current, broken at mobile sizes: https://ucla-library-storybook.netlify.app/?path=/story/section-staff-article-list--ftva-blog-list

fixed:
https://deploy-preview-935--ucla-library-storybook.netlify.app/?path=/story/section-staff-article-list--ftva-blog-list

<img width="542" height="434" alt="Screenshot 2026-04-14 at 3 23 52 PM" src="https://github.com/user-attachments/assets/60c059b2-4bcb-4229-bd66-8a9956c91ee7" />

This was being caused by styles injected at the story level, so I removed the style that caused trouble. This fixes the story, but won't fix the issue on the live site. 

So, there is a matching PR to fix the issue on the FTVA site:
https://github.com/UCLALibrary/ftva-website-nuxt/pull/339

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[LADI-5138]: https://uclalibrary.atlassian.net/browse/LADI-5138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ