### PR TITLE
feat: LADI-5142 allow calendar height to grow to fit events

### DIFF
--- a/packages/vue-component-library/src/stories/mock/CalendarEvents.js
+++ b/packages/vue-component-library/src/stories/mock/CalendarEvents.js
@@ -239,6 +239,170 @@ export const mockCalendarEvents = {
       image: null
     },
 
+    {
+      imageCarousel: [
+        {
+          image: [
+            {
+              src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/stick_it_ver2.jpg',
+              width: 2560,
+              alt: null,
+              id: '3370311',
+              srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/stick_it_ver2.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/stick_it_ver2.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/stick_it_ver2.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/stick_it_ver2.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/stick_it_ver2.jpg 2560w',
+              focalPoint: [
+                0.5,
+                0.5
+              ],
+              height: 1924
+            }
+          ],
+          creditText: null
+        }
+      ],
+      typeHandle: 'ftvaEvent',
+      title: 'A Quiet Place: Day One',
+      uri: 'events/',
+      startDateWithTime: '2025-10-06T03:30:00',
+      startTime: '2025-10-06T03:30:00',
+      location: [],
+      id: '3370201',
+      ftvaTicketInformation: [],
+      ftvaEventScreeningDetails: [
+        {
+          tagLabels: [
+            {
+              title: 'Silent'
+            },
+            {
+              title: 'Digital'
+            }],
+        }],
+      ftvaScreeningFormatFilters: [
+        {
+          id: '3439018',
+          title: 'Digital'
+        }
+      ],
+      ftvaEventTypeFilters: [
+        {
+          title: 'Film',
+          id: '4001432'
+        },
+      ],
+      startDate: '2025-10-06T03:30:00',
+      to: '/events/',
+      image: null
+    },
+
+    {
+      imageCarousel: [
+        {
+          image: [
+            {
+              src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/stick_it_ver2.jpg',
+              width: 2560,
+              alt: null,
+              id: '3370311',
+              srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/stick_it_ver2.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/stick_it_ver2.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/stick_it_ver2.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/stick_it_ver2.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/stick_it_ver2.jpg 2560w',
+              focalPoint: [
+                0.5,
+                0.5
+              ],
+              height: 1924
+            }
+          ],
+          creditText: null
+        }
+      ],
+      typeHandle: 'ftvaEvent',
+      title: 'A Quiet Place: Day One',
+      uri: 'events/',
+      startDateWithTime: '2025-10-06T03:30:00',
+      startTime: '2025-10-06T03:30:00',
+      location: [],
+      id: '3370201',
+      ftvaTicketInformation: [],
+      ftvaEventScreeningDetails: [
+        {
+          tagLabels: [
+            {
+              title: 'Silent'
+            },
+            {
+              title: 'Digital'
+            }],
+        }],
+      ftvaScreeningFormatFilters: [
+        {
+          id: '3439018',
+          title: 'Digital'
+        }
+      ],
+      ftvaEventTypeFilters: [
+        {
+          title: 'Film',
+          id: '4001432'
+        },
+      ],
+      startDate: '2025-10-06T03:30:00',
+      to: '/events/',
+      image: null
+    },
+
+    {
+      imageCarousel: [
+        {
+          image: [
+            {
+              src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/stick_it_ver2.jpg',
+              width: 2560,
+              alt: null,
+              id: '3370311',
+              srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/stick_it_ver2.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/stick_it_ver2.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/stick_it_ver2.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/stick_it_ver2.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/stick_it_ver2.jpg 2560w',
+              focalPoint: [
+                0.5,
+                0.5
+              ],
+              height: 1924
+            }
+          ],
+          creditText: null
+        }
+      ],
+      typeHandle: 'ftvaEvent',
+      title: 'A Quiet Place: Day One',
+      uri: 'events/',
+      startDateWithTime: '2025-10-06T03:30:00',
+      startTime: '2025-10-06T03:30:00',
+      location: [],
+      id: '3370201',
+      ftvaTicketInformation: [],
+      ftvaEventScreeningDetails: [
+        {
+          tagLabels: [
+            {
+              title: 'Silent'
+            },
+            {
+              title: 'Digital'
+            }],
+        }],
+      ftvaScreeningFormatFilters: [
+        {
+          id: '3439018',
+          title: 'Digital'
+        }
+      ],
+      ftvaEventTypeFilters: [
+        {
+          title: 'Film',
+          id: '4001432'
+        },
+      ],
+      startDate: '2025-10-06T03:30:00',
+      to: '/events/',
+      image: null
+    },
     // Unique Day Events
     {
       imageCarousel: [

--- a/packages/vue-component-library/src/styles/default/_base-calendar.scss
+++ b/packages/vue-component-library/src/styles/default/_base-calendar.scss
@@ -1,6 +1,6 @@
 .base-calendar {
   position: relative;
-  height: 1100px;
+  min-height: 1100px;
 
   .calendar-wrapper {
     display: grid;


### PR DESCRIPTION
Connected to [LADI-5142](https://jira.library.ucla.edu/browse/LADI-5142)

**Notes:**

We added a specific height to the calendar container to prevent the arrows from moving around from month to month. However, when there are a lot of events, we need to allow the calendar to grow. 

The height has been changed to a min-height. The arrows will generally stay in the same spot UNLESS the calendar has a lot of events on a few days, in which case the arrows will move down to the middle of the new height. 

Note: Allowing the arrow to move down is a good usability choice so that people scrolling down to see the events at the end of the month don't have to scroll back up to see the arrows to move forward.

https://deploy-preview-936--ucla-library-storybook.netlify.app/?path=/story/base-calendar--same-day-events

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[LADI-5142]: https://uclalibrary.atlassian.net/browse/LADI-5142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ