### PR TITLE
fix: LADI-5143 Add a placeholder to item

### DIFF
--- a/packages/vue-component-library/src/lib-components/BlockMediaWithText.vue
+++ b/packages/vue-component-library/src/lib-components/BlockMediaWithText.vue
@@ -181,6 +181,7 @@ const showButton = computed(() => {
         </SmartLink>
       </template>
     </div>
+
     <MediaItem
       v-if="item || coverImage"
       :item="item"
@@ -213,6 +214,7 @@ const showButton = computed(() => {
         class="icon-headphones"
       />
     </MediaItem>
+
     <div
       v-if="!(item || coverImage)"
       class="no-media"

--- a/packages/vue-component-library/src/lib-components/BlockMediaWithText.vue
+++ b/packages/vue-component-library/src/lib-components/BlockMediaWithText.vue
@@ -126,7 +126,7 @@ const showButton = computed(() => {
       />
       <div class="meta-mobile">
         <MediaItem
-          v-if="item.length > 0 || coverImage.length > 0"
+          v-if="item || coverImage"
           :item="item"
           :cover-image="coverImage"
           :cover-only="true"
@@ -134,7 +134,7 @@ const showButton = computed(() => {
           @click="showLightbox = true"
         />
         <div
-          v-if="!(item.length > 0 || coverImage.length > 0)"
+          v-if="!(item || coverImage)"
           class="no-media-mobile"
         />
         <div class="clippy">
@@ -181,9 +181,8 @@ const showButton = computed(() => {
         </SmartLink>
       </template>
     </div>
-
     <MediaItem
-      v-if="item.length > 0 || coverImage.length > 0"
+      v-if="item || coverImage"
       :item="item"
       :cover-image="coverImage"
       :cover-only="true"
@@ -214,9 +213,8 @@ const showButton = computed(() => {
         class="icon-headphones"
       />
     </MediaItem>
-
     <div
-      v-if="!(item.length > 0 || coverImage.length > 0)"
+      v-if="!(item || coverImage)"
       class="no-media"
     />
     <!--eslint-disable-->

--- a/packages/vue-component-library/src/lib-components/BlockMediaWithText.vue
+++ b/packages/vue-component-library/src/lib-components/BlockMediaWithText.vue
@@ -126,7 +126,7 @@ const showButton = computed(() => {
       />
       <div class="meta-mobile">
         <MediaItem
-          v-if="item || coverImage"
+          v-if="item.length > 0 || coverImage.length > 0"
           :item="item"
           :cover-image="coverImage"
           :cover-only="true"
@@ -134,7 +134,7 @@ const showButton = computed(() => {
           @click="showLightbox = true"
         />
         <div
-          v-if="!(item || coverImage)"
+          v-if="!(item.length > 0 || coverImage.length > 0)"
           class="no-media-mobile"
         />
         <div class="clippy">
@@ -183,7 +183,7 @@ const showButton = computed(() => {
     </div>
 
     <MediaItem
-      v-if="item || coverImage"
+      v-if="item.length > 0 || coverImage.length > 0"
       :item="item"
       :cover-image="coverImage"
       :cover-only="true"
@@ -216,7 +216,7 @@ const showButton = computed(() => {
     </MediaItem>
 
     <div
-      v-if="!(item || coverImage)"
+      v-if="!(item.length > 0 || coverImage.length > 0)"
       class="no-media"
     />
     <!--eslint-disable-->

--- a/packages/vue-component-library/src/lib-components/Media/Item.vue
+++ b/packages/vue-component-library/src/lib-components/Media/Item.vue
@@ -105,7 +105,7 @@ const hasImage = computed(() => {
   position: relative;
   margin: 0;
   z-index: 0;
-  // opacity: 0; // TODO add this back when we resolve why onload is not firing on craft images in netlify, works locally
+  // opacity: 0;  // TODO add this back when we resolve why onload is not firing on craft images in netlify, works locally
   transition: opacity 400ms ease-in-out;
 
   .media {

--- a/packages/vue-component-library/src/lib-components/Media/Item.vue
+++ b/packages/vue-component-library/src/lib-components/Media/Item.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import type { PropType } from 'vue'
 import VideoJs from './VideoJs.vue'
 import type { MediaItemType } from '@/types/types'
+import ResponsiveImage from '@/lib-components/ResponsiveImage.vue'
 
 const props = defineProps({
   // the image / video / audio / embed
@@ -71,12 +72,17 @@ const sizerStyles = computed(() => {
     `paddingBottom: ${parsedAspectRatio.value}%`,
   ]
 })
+
+const hasImage = computed(() => {
+  return isImage.value && (props.item && props.item.length > 0)
+})
 </script>
 
 <template>
   <div class="media-item">
     <div v-if="isEmbed" class="media media-embed" v-html="embedCode" />
-    <img v-else-if="isImage" class="media media-image" :style="mediaStyles" v-bind="item[0]">
+    <img v-else-if="hasImage" class="media media-image" :style="mediaStyles" v-bind="item[0]">
+    <ResponsiveImage v-else-if="!hasImage" :media="{} as MediaItemType" object-fit="cover" class="media media-image" />
     <img v-else-if="props.coverOnly" class="media media-image" :style="mediaStyles" v-bind="props.coverImage[0]">
     <VideoJs
       v-else-if="isVideo || isAudio" class="media media-video" :style="mediaStyles" :sources="props.item"

--- a/packages/vue-component-library/src/lib-components/Media/Item.vue
+++ b/packages/vue-component-library/src/lib-components/Media/Item.vue
@@ -76,19 +76,23 @@ const sizerStyles = computed(() => {
 const hasImage = computed(() => {
   return isImage.value && (props.item && props.item.length > 0)
 })
+// sometimes coverOnly is true but no cover image is passed, so we need to check for it separately
+const hasCoverImage = computed(() => {
+  return props.coverOnly && (props.coverImage && props.coverImage.length > 0)
+})
 </script>
 
 <template>
   <div class="media-item">
     <div v-if="isEmbed" class="media media-embed" v-html="embedCode" />
     <img v-else-if="hasImage" class="media media-image" :style="mediaStyles" v-bind="item[0]">
-    <ResponsiveImage v-else-if="!hasImage" :media="{} as MediaItemType" object-fit="cover" class="media media-image" />
-    <img v-else-if="props.coverOnly" class="media media-image" :style="mediaStyles" v-bind="props.coverImage[0]">
+    <img v-else-if="hasCoverImage" class="media media-image coveronly" :style="mediaStyles" v-bind="props.coverImage[0]">
     <VideoJs
       v-else-if="isVideo || isAudio" class="media media-video" :style="mediaStyles" :sources="props.item"
       :poster="coverImageSrc" :controls="props.controls" :autoplay="props.autoplay" :loop="props.loop"
       :muted="props.muted" :playsinline="props.playsinline" :audio-poster-mode="isAudio"
     />
+    <ResponsiveImage v-else-if="!hasImage" :media="{} as MediaItemType" object-fit="cover" class="media media-image responsive-image" />
     <p
       v-else class="media" style="background-color: white; padding: 10px" v-text="isAudio
         ? 'Audio uploads not supported yet'

--- a/packages/vue-component-library/src/stories/BlockMediaWithText.stories.js
+++ b/packages/vue-component-library/src/stories/BlockMediaWithText.stories.js
@@ -147,6 +147,8 @@ export function Embed() {
   }
 }
 
+// Sometimes the type-media is an image but an image is not provided, so we need to display a placeholder image.
+
 export function NoImage() {
   return {
     data() {


### PR DESCRIPTION
Connected to [LADI-5143](https://jira.library.ucla.edu/browse/LADI-5143)

**Notes:**

The story for Block Media with Text with No Image has been broken for awhile, I couldn't find a working story for this case, even going back several months in deployments:
https://ucla-library-storybook.netlify.app/?path=/story/block-media-with-text--no-image

While MediaWithText requires an image for the image type when used with FlexibleMediaWithText, we are using MediaWithText on its own in some areas (like the FTVA homepage) so we need to fix this. 

<img width="821" height="469" alt="Archive Blogs" src="https://github.com/user-attachments/assets/d37f829c-f0cb-4e86-bd7d-dea43b899db1" />

Fixed story: https://deploy-preview-937--ucla-library-storybook.netlify.app/?path=/story/block-media-with-text--no-image

<img width="815" height="359" alt="Screenshot 2026-04-22 at 3 45 06 PM" src="https://github.com/user-attachments/assets/d6825e80-0e4c-4ea3-890b-61693e037532" />

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[LADI-5143]: https://uclalibrary.atlassian.net/browse/LADI-5143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ