### PR TITLE
fix: Flexible Media with Text fallback to buttonURL if item is empty

### DIFF
--- a/packages/vue-component-library/src/lib-components/Flexible/MediaWithText.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaWithText.vue
@@ -32,8 +32,8 @@ const parsedContent = computed(() => {
       // item: upload
       // item[0].src & buttonUrl can return as null - neither are required
       parsedButtonUrl:
-        obj.item[0]?.src && obj.typeMedia === 'other'
-          ? obj.item[0]?.src
+        obj.item?.[0]?.src && obj.typeMedia === 'other'
+          ? obj.item[0].src
           : obj.buttonUrl,
     }
   })

--- a/packages/vue-component-library/src/lib-components/Flexible/MediaWithText.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/MediaWithText.vue
@@ -32,7 +32,7 @@ const parsedContent = computed(() => {
       // item: upload
       // item[0].src & buttonUrl can return as null - neither are required
       parsedButtonUrl:
-        obj.item && obj.typeMedia === 'other'
+        obj.item[0]?.src && obj.typeMedia === 'other'
           ? obj.item[0]?.src
           : obj.buttonUrl,
     }

--- a/packages/vue-component-library/src/stories/mock/Flexible_MediaWithText.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_MediaWithText.js
@@ -268,6 +268,7 @@ export const mockSingle = {
       id: '13670',
       titleLink: 'A media Link',
       description: 'Citation Integration',
+      item: [], // production data sometimes has empty items array
       coverImage: [
         {
           id: '5115',


### PR DESCRIPTION
Connected to [LADI-5147](https://jira.library.ucla.edu/browse/LADI-5147)

**Component Updated:** MediaWithText.vue

**Stories:** ~/stories/Flexible_MediaWithText.js

**Notes:**

What happened?

When we made this change https://github.com/UCLALibrary/ucla-library-website-components/pull/927/changes#diff-8e34ba0a55d79bdacbe215ac9b235df519c54fa8edf5fd848d0c97fafef5d5cf …
we didn’t account for the MediaWithText wrapper which was mistakenly leading to empty buttons because its algorithm was trying to send the item.src field instead of the ButtonText field. 

I noticed there is a case with flexible blocks where empty items are passed, but we still want to use the 'ButtonUrl' field rather than the 'item[0].src' field. I changed the logic in Flexible MediaWithText to check for the src field on button before preferring that option, otherwise ButtonUrl. 

I also updated the story to add an empty object to better resemble actual production data & test this case. 

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[LADI-5147]: https://uclalibrary.atlassian.net/browse/LADI-5147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ