### PR TITLE
fix: LADI-3732 add alt, srcset, and sizes data to poster img

### DIFF
--- a/packages/vue-component-library/src/lib-components/VideoEmbed.vue
+++ b/packages/vue-component-library/src/lib-components/VideoEmbed.vue
@@ -45,6 +45,9 @@ const parsedTrailer = computed(() => {
       <img
         v-if="posterImage?.src"
         :src="posterImage.src"
+        :alt="posterImage.alt || ''"
+        :srcset="posterImage.srcset || ''"
+        :sizes="posterImage.sizes || ''"
         class="cover"
       >
       <SvgIconPlayFilled class="play-button" />


### PR DESCRIPTION
Connected to [LADI-3732](https://jira.library.ucla.edu/browse/APPS-)

**Component Updated:** VideoEmbed.vue

**Notes:**

The VideoEmbed component uses a simple `img` tag that doesn't have srcset or sizes data, so its not responsive. 

I added the data if it exists

Before
Poster Image always uses largest size
https://ucla-library-storybook.netlify.app/?path=/story/section-screening-details--default
<img width="501" height="691" alt="Screenshot 2026-05-07 at 3 09 10 PM" src="https://github.com/user-attachments/assets/a0ac67a6-d44c-44f5-be10-22f356032b83" />

After
Poster Image can be smaller on smaller screens (if you load at a large size first it will persist once loaded)
https://deploy-preview-940--ucla-library-storybook.netlify.app/?path=/story/section-screening-details--default

<img width="501" height="691" alt="Screenshot 2026-05-07 at 3 09 04 PM" src="https://github.com/user-attachments/assets/de5acc5d-9f7b-45a4-a454-89a04880eb2b" />


**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [X] I added a screenshot of it working
-   [X] UX has reviewed and approved this
-   [X] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[LADI-3732]: https://uclalibrary.atlassian.net/browse/LADI-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ