### PR TITLE
fix: LADI-5183 Component blockStaffArticleList: Remove the margin bottom from byline in the meta

### DIFF
--- a/packages/vue-component-library/src/styles/default/_block-staff-article-item.scss
+++ b/packages/vue-component-library/src/styles/default/_block-staff-article-item.scss
@@ -53,7 +53,7 @@
 
   .byline {
     @include step-0;
-    margin: var(--space-s) 0;
+    margin: var(--space-s) 0 0;
     color: var(--color-secondary-grey-04);
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Connected to [LADI-5183](https://jira.library.ucla.edu/browse/LADI-5183)

https://deploy-preview-941--ucla-library-storybook.netlify.app/

The blockStaffArticleList component no longer has a fixed height so the shifting is expected, but i did notice the byline in the meta has a margin bottom that can be removed to reduce the layout shift.

Examples in these pages:
Before
https://deploy-preview-918--uclalibrary-test.netlify.app/about/staff/brigid-abreu/
https://deploy-preview-918--uclalibrary-test.netlify.app/about/news/



[LADI-5183]: https://uclalibrary.atlassian.net/browse/LADI-5183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ