### PR TITLE
feat: LADI-5187 v-bind image attributes

### DIFF
--- a/packages/vue-component-library/src/lib-components/ImageSlider.vue
+++ b/packages/vue-component-library/src/lib-components/ImageSlider.vue
@@ -43,8 +43,8 @@ function handleSliderInput(event: Event) {
 <template>
   <div ref="sliderContainer" class="image-slider" :style="{ aspectRatio: parsedSliderAspectRatio }">
     <div class="image-container" :style="{ aspectRatio: parsedSliderAspectRatio }">
-      <img class="after-image slider-image" :src="afterImage.src" :alt="parsedAfterImageAltText">
-      <img ref="beforeImageElement" class="before-image slider-image" :src="beforeImage.src" :alt="parsedBeforeImageAltText">
+      <img class="after-image slider-image" :src="afterImage.src" :alt="parsedAfterImageAltText" v-bind="afterImage">
+      <img ref="beforeImageElement" class="before-image slider-image" :src="beforeImage.src" :alt="parsedBeforeImageAltText" v-bind="beforeImage">
       <div class="image-labels">
         <span class="before-label slider-label">
           <slot name="beforeLabel">Before</slot>

--- a/packages/vue-component-library/src/stories/ImageSlider.stories.js
+++ b/packages/vue-component-library/src/stories/ImageSlider.stories.js
@@ -12,6 +12,7 @@ const mockBeforeImage = [
     src: 'https://static.library.ucla.edu/craftassetstest/FTVA/_fullscreen/hot_air_balloon.jpg',
     height: 1748,
     width: 2560,
+    sizes: '100vw',
     srcset: 'https://static.library.ucla.edu/craftassetstest/FTVA/_375xAUTO_crop_center-center_none/hot_air_balloon.jpg 375w, https://static.library.ucla.edu/craftassetstest/FTVA/_960xAUTO_crop_center-center_none/hot_air_balloon.jpg 960w, https://static.library.ucla.edu/craftassetstest/FTVA/_1280xAUTO_crop_center-center_none/hot_air_balloon.jpg 1280w, https://static.library.ucla.edu/craftassetstest/FTVA/_1920xAUTO_crop_center-center_none/hot_air_balloon.jpg 1920w, https://static.library.ucla.edu/craftassetstest/FTVA/_2560xAUTO_crop_center-center_none/hot_air_balloon.jpg 2560w',
     alt: 'Hot air balloon',
     focalPoint: [


### PR DESCRIPTION
Connected to [LADI-5187](https://jira.library.ucla.edu/browse/LADI-5187)
<img width="542" height="276" alt="Screenshot 2026-05-27 at 3 26 45 PM" src="https://github.com/user-attachments/assets/6a5da22c-61c0-488e-804e-b4b2a8fc6f9c" />

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [X] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   ~~[ ] I assigned this PR to someone on the dev team to review~~
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[LADI-5187]: https://uclalibrary.atlassian.net/browse/LADI-5187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ