### PR TITLE
fix: LADI-5195 move position:relative back to top level

### DIFF
--- a/packages/vue-component-library/src/lib-components/ScrollWrapper.vue
+++ b/packages/vue-component-library/src/lib-components/ScrollWrapper.vue
@@ -73,6 +73,8 @@ onMounted(() => {
   // set the widths of cards that appear within scrollwrapper
   --card-max-width: 328px;
   --card-min-width: 322px;
+  // move arrows on top of content
+  position: relative;
   // START styles to emulate section-teaser-card for BlockCardWithImage inside Scrollwrapper
  :deep(.v-slide-group__content) {
      &:has(.block-highlight) {
@@ -98,8 +100,6 @@ onMounted(() => {
     // max-width: 327px !important;
     min-height: 350px;
     // END styles to emulate section-teaser-card for BlockCardWithImage inside Scrollwrapper
-    // move arrows on top of content
-    position: relative;
     // ensure links are clickable
     .card-meta {
       a.title {


### PR DESCRIPTION
Connected to [APPS-](https://jira.library.ucla.edu/browse/LADI-5195)

**Component Created:** {filename}.vue

**Stories:** ~/stories/{filename}.stories.js

**Spec:** ~/stories/{filename}.spec.js

**Notes:**

During the initial refactor of the component library to the new SASS structure the position: relative rule was accidentily moved on Scrollwrapper.vue from the top level to a nested block

https://github.com/UCLALibrary/ucla-library-website-components/pull/930/changes#diff-5af0ec25b7da22251e00b2bcd2bb440ab2d4bdd78f2b64fbcf3ee8b819cd661c 

I am moving it back

How it was before:
[@storybook/cli - Storybook](https://deploy-preview-941--ucla-library-storybook.netlify.app/?path=/story/scrollwrapper--six-items)  (correct)

On my component SASS update:
[@storybook/cli - Storybook](https://deploy-preview-930--ucla-library-storybook.netlify.app/?path=/story/scrollwrapper--six-items)  (incorrect)

This PR moving it back:

**Checklist:**

-   [ ] I checked that it is working locally in the dev server
-   [ ] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   [ ] I added a screenshot of it working
-   [ ] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [ ] I used a conventional commit message
-   [ ] I assigned myself to this PR
