### PR TITLE
feat: LADI-5226 ensure all children of ul are li

### DIFF
--- a/packages/vue-component-library/src/lib-components/NavPrimary.vue
+++ b/packages/vue-component-library/src/lib-components/NavPrimary.vue
@@ -404,22 +404,23 @@ onMounted(() => {
         </SmartLink>
       </li>
       <!-- Add search icon to nav menu list on desktop for FTVA -->
-      <ButtonLink
-        v-if="!isMobile && theme === 'ftva'"
-        class="search-button"
-        icon-name="none"
-        aria-label="Search"
-        @click="searchClick"
-      >
-        <IconSearch class="icon-search" />
-      </ButtonLink>
+      <li v-if="!isMobile && theme === 'ftva'">
+        <ButtonLink
+          class="search-button"
+          icon-name="none"
+          aria-label="Search"
+          @click="searchClick"
+        >
+          <IconSearch class="icon-search" />
+        </ButtonLink>
+      </li>
       <!-- slot for additional buttons that stick to the bottom of the mobile menu (like donate on ftva mobile) -->
-      <div
+      <li
         v-if="isMobile && mobileMenuIsOpened"
         class="mobile-menu-slot"
       >
         <slot name="additional-mobile-menu-items" />
-      </div>
+      </li>
     </ul>
 
     <div

--- a/packages/vue-component-library/src/styles/ftva/_nav-menu-item.scss
+++ b/packages/vue-component-library/src/styles/ftva/_nav-menu-item.scss
@@ -26,9 +26,9 @@
                 opacity: 1;
             }
         }
-        &:focus {
-            outline: none;
-        }
+        // &:focus {
+        //     outline: none;
+        // }
     }   
 
     // Hover


### PR DESCRIPTION
Connected to [LADI-5226](https://jira.library.ucla.edu/browse/LADI-5226)

**Notes:**

- [X] Wrapped the button in an li element since the button needed to stay
- [X] Changed a div wrapper to an li wrapper instead
- [X] Noticed a focus specific style (outline: none) preventing the tab target from being visible, so I removed it
- [X] Noticed that tab order on the menu isn't easy to navigate during tests, however as its an existing issue on `main`, I think it's better to fix as part of a separate branch. So I made a ticket: https://uclalibrary.atlassian.net/browse/LADI-5235

Now: story has violations
https://ucla-library-storybook.netlify.app/?path=/story/global-header-sticky--ftva-version

Fixed: no violations
https://deploy-preview-948--ucla-library-storybook.netlify.app/?path=/story/global-header-sticky--ftva-version

**Checklist:**

-   [X] I checked that it is working locally in the dev server
-   [X] I checked that it is working locally in the storybook
-   [ ] I checked that it is working locally in the 
library-website-nuxt dev server
-   ~~[ ] I added a screenshot of it working~~
-   [X] UX has reviewed and approved this
-   [ ] I assigned this PR to someone on the dev team to review
-   [X] I used a conventional commit message
-   [X] I assigned myself to this PR


[LADI-5226]: https://uclalibrary.atlassian.net/browse/LADI-5226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ