### PR TITLE
fix: LADI-5205 Remove hardcoded iframe title in VideoEmbed component

### DIFF
--- a/packages/vue-component-library/src/lib-components/BlockEvent.vue
+++ b/packages/vue-component-library/src/lib-components/BlockEvent.vue
@@ -78,7 +78,7 @@ export default {
 
     <div class="text row">
       <span class="category">{{ category }}</span>
-      <h2 class="title" :id="titleId" v-text="title" />
+      <h2 :id="titleId" class="title" v-text="title" />
       <div class="date-time">
         <time v-if="startDate" class="dates" v-text="parsedDate" />
         <time v-if="parsedTime" class="time" v-text="parsedTime" />

--- a/packages/vue-component-library/src/lib-components/VideoEmbed.vue
+++ b/packages/vue-component-library/src/lib-components/VideoEmbed.vue
@@ -1,66 +1,67 @@
 <!-- The VideoEmbed component creates an iframe with a youtube video embed
  it has an optional custom posterImage and icon -->
 <script lang="ts" setup>
-import type { PropType } from "vue"
-import SvgIconPlayFilled from "ucla-library-design-tokens/assets/svgs/icon-ftva-playvideo.svg"
-import { computed, defineProps } from "vue"
-import type { MediaItemType } from "@/types/types"
+import type { PropType } from 'vue'
+import SvgIconPlayFilled from 'ucla-library-design-tokens/assets/svgs/icon-ftva-playvideo.svg'
+import { computed, defineProps } from 'vue'
+import type { MediaItemType } from '@/types/types'
 
 const { trailer, posterImage } = defineProps({
-    trailer: {
-        type: String,
-        required: true,
-    },
-    posterImage: {
-        type: Object as PropType<MediaItemType>,
-        required: false,
-    },
+  trailer: {
+    type: String,
+    required: true,
+  },
+  posterImage: {
+    type: Object as PropType<MediaItemType>,
+    required: false,
+  },
 })
 
 // this component doesn't have themes currently
 const classes = computed(() => {
-    const src = posterImage?.src
-    return ["video-embed", src ? "has-poster" : "no-poster"]
+  const src = posterImage?.src
+  return ['video-embed', src ? 'has-poster' : 'no-poster']
 })
 // Updated trailer parsing to use a regex for safer and more reliable extraction of the `src` value.
 // This handles cases where `trailer` may be undefined, null, or missing the expected `src="..."` pattern.
 const parsedTrailer = computed(() => {
-    if (!trailer || typeof trailer !== "string") return ""
+  if (!trailer || typeof trailer !== 'string')
+    return ''
 
-    const match = trailer.match(/src="([^"]+)"/)
-    return match ? match[1] : ""
+  const match = trailer.match(/src="([^"]+)"/)
+  return match ? match[1] : ''
 })
 </script>
 
 <template>
-    <div v-if="trailer" :class="classes">
-        <div
-            class="cover-container"
-            onclick="this.nextElementSibling.style.display='block'; this.style.display='none'"
-        >
-            <img
-                v-if="posterImage?.src"
-                :src="posterImage.src"
-                :alt="posterImage.alt || ''"
-                :srcset="posterImage.srcset || ''"
-                :sizes="posterImage.sizes || ''"
-                class="cover"
-            />
-            <SvgIconPlayFilled class="play-button" />
-        </div>
-
-        <div v-if="parsedTrailer" class="video-container">
-            <iframe
-                :src="parsedTrailer"
-                class="responsive-iframe"
-                frameborder="0"
-                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                referrerpolicy="strict-origin-when-cross-origin"
-                allowfullscreen
-                loading="lazy"
-            />
-        </div>
+  <div v-if="trailer" :class="classes">
+    <div
+      class="cover-container"
+      onclick="this.nextElementSibling.style.display='block'; this.style.display='none'"
+    >
+      <img
+        v-if="posterImage?.src"
+        :src="posterImage.src"
+        :alt="posterImage.alt || ''"
+        :srcset="posterImage.srcset || ''"
+        :sizes="posterImage.sizes || ''"
+        class="cover"
+      >
+      <SvgIconPlayFilled class="play-button" />
     </div>
+
+    <div v-if="parsedTrailer" class="video-container">
+      <iframe
+        :src="parsedTrailer"
+        class="responsive-iframe"
+        frameborder="0"
+        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        referrerpolicy="strict-origin-when-cross-origin"
+        allowfullscreen
+        loading="lazy"
+      />
+    </div>
+  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/packages/vue-component-library/src/lib-components/VideoEmbed.vue
+++ b/packages/vue-component-library/src/lib-components/VideoEmbed.vue
@@ -1,128 +1,120 @@
 <!-- The VideoEmbed component creates an iframe with a youtube video embed
  it has an optional custom posterImage and icon -->
-<script lang='ts' setup>
-import type { PropType } from 'vue'
-import SvgIconPlayFilled from 'ucla-library-design-tokens/assets/svgs/icon-ftva-playvideo.svg'
-import { computed, defineProps } from 'vue'
-import type { MediaItemType } from '@/types/types'
+<script lang="ts" setup>
+import type { PropType } from "vue"
+import SvgIconPlayFilled from "ucla-library-design-tokens/assets/svgs/icon-ftva-playvideo.svg"
+import { computed, defineProps } from "vue"
+import type { MediaItemType } from "@/types/types"
 
 const { trailer, posterImage } = defineProps({
-  trailer: {
-    type: String,
-    required: true
-  },
-  posterImage: {
-    type: Object as PropType<MediaItemType>,
-    required: false
-  }
+    trailer: {
+        type: String,
+        required: true,
+    },
+    posterImage: {
+        type: Object as PropType<MediaItemType>,
+        required: false,
+    },
 })
 
 // this component doesn't have themes currently
 const classes = computed(() => {
-  const src = posterImage?.src
-  return ['video-embed', src ? 'has-poster' : 'no-poster']
+    const src = posterImage?.src
+    return ["video-embed", src ? "has-poster" : "no-poster"]
 })
 // Updated trailer parsing to use a regex for safer and more reliable extraction of the `src` value.
 // This handles cases where `trailer` may be undefined, null, or missing the expected `src="..."` pattern.
 const parsedTrailer = computed(() => {
-  if (!trailer || typeof trailer !== 'string')
-    return ''
+    if (!trailer || typeof trailer !== "string") return ""
 
-  const match = trailer.match(/src="([^"]+)"/)
-  return match ? match[1] : ''
+    const match = trailer.match(/src="([^"]+)"/)
+    return match ? match[1] : ""
 })
 </script>
 
 <template>
-  <div
-    v-if="trailer"
-    :class="classes"
-  >
-    <div
-      class="cover-container"
-      onclick="this.nextElementSibling.style.display='block'; this.style.display='none'"
-    >
-      <img
-        v-if="posterImage?.src"
-        :src="posterImage.src"
-        :alt="posterImage.alt || ''"
-        :srcset="posterImage.srcset || ''"
-        :sizes="posterImage.sizes || ''"
-        class="cover"
-      >
-      <SvgIconPlayFilled class="play-button" />
-    </div>
+    <div v-if="trailer" :class="classes">
+        <div
+            class="cover-container"
+            onclick="this.nextElementSibling.style.display='block'; this.style.display='none'"
+        >
+            <img
+                v-if="posterImage?.src"
+                :src="posterImage.src"
+                :alt="posterImage.alt || ''"
+                :srcset="posterImage.srcset || ''"
+                :sizes="posterImage.sizes || ''"
+                class="cover"
+            />
+            <SvgIconPlayFilled class="play-button" />
+        </div>
 
-    <div
-      v-if="parsedTrailer"
-      class="video-container"
-    >
-      <iframe
-        :src="parsedTrailer"
-        title="YouTube video player"
-        class="responsive-iframe"
-        frameborder="0"
-        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        referrerpolicy="strict-origin-when-cross-origin"
-        allowfullscreen
-        loading="lazy"
-      />
+        <div v-if="parsedTrailer" class="video-container">
+            <iframe
+                :src="parsedTrailer"
+                class="responsive-iframe"
+                frameborder="0"
+                allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                referrerpolicy="strict-origin-when-cross-origin"
+                allowfullscreen
+                loading="lazy"
+            />
+        </div>
     </div>
-  </div>
 </template>
 
-<style lang='scss' scoped>
+<style lang="scss" scoped>
 .video-embed {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 16/9;
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16/9;
 
-  &.has-poster {
-    .video-container {
-      display: none;
+    &.has-poster {
+        .video-container {
+            display: none;
+        }
     }
-  }
 
-  &.no-poster {
+    &.no-poster {
+        .cover-container {
+            display: none;
+        }
+    }
+
     .cover-container {
-      display: none;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        display: grid;
+        grid-template: 1fr / 1fr;
+        place-items: center;
+
+        > * {
+            grid-column: 1 / 1;
+            grid-row: 1 / 1;
+        }
+
+        .cover {
+            cursor: pointer;
+            width: 100%;
+            height: 100%;
+            aspect-ratio: 16 / 9;
+            object-fit: cover;
+        }
+
+        .play-button {
+            width: 55px;
+            height: 55px;
+            z-index: 5;
+            transition: all 250ms ease-in-out;
+        }
     }
-  }
 
-  .cover-container {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    display: grid;
-    grid-template: 1fr / 1fr;
-    place-items: center;
-
-    >* {
-      grid-column: 1 / 1;
-      grid-row: 1 / 1;
+    .video-container,
+    .responsive-iframe {
+        position: absolute;
+        width: 100%;
+        height: 100%;
     }
-
-    .cover {
-      cursor: pointer;
-      width: 100%;
-      height: 100%;
-      aspect-ratio: 16 / 9;
-      object-fit: cover;
-    }
-
-    .play-button {
-      width: 55px;
-      height: 55px;
-      z-index: 5;
-      transition: all 250ms ease-in-out;
-    }
-  }
-
-  .video-container,
-  .responsive-iframe {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-  }
 }
 </style>


### PR DESCRIPTION
Connected to [LADI-5205](https://jira.library.ucla.edu/browse/LADI-5205)

**Component Updated:** VideoEmbed.vue

**Notes:**
- Chrome was defaulting to the iframe title value "_YouTube video player_" hardcoded into VideoEmbed component instead of to the actual iframe video title; if-when multiple videos are on a page, screenreaders will be unable to distinguish them (for example, Section-Screening-Details component uses VideoEmbed to display more than one video)
- Removed the title attribute and the hardcoded value in the template markup
- Tested locally against FTVA Nuxt site on Chrome, Firefox, Safari and Edge to make sure that iframes would/could still display the content title if the attribute is missing in the markup
  - To verify that local component build synced to local Nuxt, added fake class `test-LADI-5205` to VideoEmbed component
  - Test content/page: `events/afrofuturism-the-last-angel-of-history-space-is-the-place-10-04-24/`
  - See screenshots below
- With the hardcoded title value removed, iframes from the VideoEmbed component displayed titles correctly
- Also double-checked that iframes embedded into RichText displayed correct titles across browsers


### Screenshots

**Chrome VideoEmbed Component**
<kbd><img width="500" height="203" alt="chrome_video-embed-component" src="https://github.com/user-attachments/assets/2effa7c7-d840-4756-87b0-a15f8b330767" /></kbd>

**Chrome Rich Text Video**
<kbd><img width="500" height="113" alt="chrome_rich-text-video" src="https://github.com/user-attachments/assets/664c8d6e-0b57-4891-a8e5-26c4a0aefe71" /></kbd>

**Firefox VideoEmbed Component**
<kbd><img width="500" height="162" alt="firefox_video-embed-component" src="https://github.com/user-attachments/assets/017af944-2ace-4651-81a0-b606e462343c" /></kbd>

**Firefox Rich Text Video**
<kbd><img width="500" height="134" alt="firefox_rich-text-video" src="https://github.com/user-attachments/assets/0ebf303c-555d-4f35-a1d2-f075d2eeb655" /></kbd>

**Safari VideoEmbed Component**
<kbd><img width="500" height="159" alt="safari_video-embed-component" src="https://github.com/user-attachments/assets/afa51ef4-d9b3-4dfc-adaf-0d74c1b4d8bb" /></kbd>

**Safari Rich Text Video**
<kbd><img width="500" height="95" alt="safari_rich-text-video" src="https://github.com/user-attachments/assets/36db4041-9a02-410d-af3d-46ba8b2a3745" /></kbd>

**Edge VideoEmbed Component**
<kbd><img width="500" height="191" alt="edge_video-embed-component" src="https://github.com/user-attachments/assets/797230ee-5154-4902-a731-4e8c2cfa24d2" /></kbd>

**Edge Rich Text Video**
<kbd><img width="500" height="126" alt="edge_rich-text-video" src="https://github.com/user-attachments/assets/59cd2d58-12dd-412b-b8e9-0c83cccd0506" /></kbd>

**Checklist:**

-   ~~[ ] I checked that it is working locally in the dev server~~
-   [x] I checked that it is working locally in the storybook
-   [x] I checked that it is working locally in the ftva-website-nuxt dev server
-   [x] I added a screenshot of it working
-   ~~[ ] UX has reviewed and approved this~~
-   [x] I requested a PR review from the Dev team
-   [x] I used a conventional commit message
-   [x] I assigned myself to this PR


[LADI-5205]: https://uclalibrary.atlassian.net/browse/LADI-5205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ