### PR TITLE
fix: LADI-5265 Darken FTVA homepage carousel gradient

### DIFF
--- a/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
+++ b/packages/vue-component-library/src/styles/ftva/_new-lightbox.scss
@@ -161,7 +161,11 @@
 
     max-height: 400px;
     height: 100%;
-    background: linear-gradient(0deg, rgba(0, 0, 0, .75) 0%, rgba(0, 0, 0, 0) 100%);
+    background: linear-gradient(to top,
+          rgba(0, 0, 0, 1) 0%,
+          rgba(0, 0, 0, 0.6) 60%,
+          rgba(0, 0, 0, 0) 100%
+        );
 
     .caption-content {
       position: absolute;


### PR DESCRIPTION
#### Connected to [LADI-5265](https://jira.library.ucla.edu/browse/LADI-5265)

### Notes

- Increased the gradient on carousel per UX specs in ticket

Before: https://deploy-preview-956--ucla-library-storybook.netlify.app/?path=/story/media-gallery-new-lightbox--ftva-homepage-carousel

<img width="500" height="186" alt="carousel-before" src="https://github.com/user-attachments/assets/0aa76ea0-7729-42b2-b87b-3ba043422ab1" />

<br><br>

After: https://deploy-preview-957--ucla-library-storybook.netlify.app/?path=/story/media-gallery-new-lightbox--ftva-homepage-carousel


<img width="500" height="186" alt="carousel-after" src="https://github.com/user-attachments/assets/b02c723b-8361-455e-851a-90862e1895c5" />


---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - ~~[ ] Review PR in desktop view, tablet view, mobile view~~
- ~~[ ] A11Y~~
    - ~~[ ] Zoom the site to 200%~~
    - ~~[ ] Check for keyboard traps~~
- [x] Design & Code
    - ~~[ ] Add updates to Storybook and check them~~
    - [x] Check that it looks like the design(s)
    - ~~[ ] Check that it is working in the local website nuxt dev server~~
    - ~~[ ] Review the Chromatic _(if the PR is large and requires it)_~~

### UX Review
- [x] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the Storybook preview
  - [ ] Review the code


[LADI-5265]: https://uclalibrary.atlassian.net/browse/LADI-5265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ