### PR TITLE
feat: LADI-5240 Add External Article Entry Type to Flexible Page Blocks

### DIFF
--- a/packages/vue-component-library/src/lib-components/Flexible/BannerFeatured.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/BannerFeatured.vue
@@ -61,11 +61,7 @@ const parsedLocations = computed(() => {
         break
 
       case contentType.includes('externalArticle'):
-        category = block.content[0].contentLink[0].articleCategory
-          .map((obj) => {
-            return obj.title
-          })
-          .toString()
+        locations = block.content[0].contentLink[0].articleLocations
         break
 
       case contentType.includes('project'):

--- a/packages/vue-component-library/src/lib-components/Flexible/BannerFeatured.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/BannerFeatured.vue
@@ -254,15 +254,21 @@ const parsedDescription = computed(() => {
 })
 
 const parsedLink = computed(() => {
-  const content = block?.content?.[0]?.contentLink?.[0]
+  const content = block?.content?.[0]
 
-  if (!content)
-    return ''
+  // Internal Content → External Article
+  if (content?.contentLink?.[0]?.contentType === 'externalArticle')
+    return content.contentLink[0].to
 
-  if (content.contentType === 'externalArticle')
+  // Internal Content → Article and other internal entries
+  if (content?.contentLink?.[0]?.to)
+    return stripMeapFromURI(content.contentLink[0].to)
+
+  // Standalone External Article
+  if (content?.to)
     return content.to
 
-  return stripMeapFromURI(content.to)
+  return ''
 })
 </script>
 

--- a/packages/vue-component-library/src/lib-components/Flexible/BannerFeatured.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/BannerFeatured.vue
@@ -273,7 +273,7 @@ const parsedLink = computed(() => {
       v-if="block && block.content && block.content[0].contentLink"
       class="flexible-banner-featured"
       :media="parseImage"
-      :to="stripMeapFromURI(block.content[0].contentLink[0].to)"
+      :to="parsedLink"
       :title="block.content[0].contentLink[0].title"
       :breadcrumb="parsedTypeHandle"
       :byline="parseByLine"

--- a/packages/vue-component-library/src/lib-components/Flexible/BannerFeatured.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/BannerFeatured.vue
@@ -60,6 +60,14 @@ const parsedLocations = computed(() => {
         locations = block.content[0].contentLink[0].articleLocations
         break
 
+      case contentType.includes('externalArticle'):
+        category = block.content[0].contentLink[0].articleCategory
+          .map((obj) => {
+            return obj.title
+          })
+          .toString()
+        break
+
       case contentType.includes('project'):
         locations = block.content[0].contentLink[0].projectLocations
         break
@@ -91,6 +99,14 @@ const parsedCategory = computed(() => {
 
     switch (true) {
       case contentType.includes('article'):
+        category = block.content[0].contentLink[0].articleCategory
+          .map((obj) => {
+            return obj.title
+          })
+          .toString()
+        break
+
+      case contentType.includes('externalArticle'):
         category = block.content[0].contentLink[0].articleCategory
           .map((obj) => {
             return obj.title
@@ -202,6 +218,15 @@ const parseByLine = computed(() => {
           output.push(formatDate)
         }
         break
+      case entry_type.includes('externalArticle'):
+        if (articleByline1) {
+          articleByline1.forEach(obj => output.push(obj.title))
+          output.push(formatDate)
+        }
+        else {
+          output.push(formatDate)
+        }
+        break
       case entry_type.includes('project'):
         if (projectByline1)
           output.push(projectByline1[0].title)
@@ -231,6 +256,18 @@ const parsedDescription = computed(() => {
     return c.contentLink[0].summary ?? ''
   return c.summary ?? ''
 })
+
+const parsedLink = computed(() => {
+  const content = block?.content?.[0]?.contentLink?.[0]
+
+  if (!content)
+    return ''
+
+  if (content.contentType === 'externalArticle')
+    return content.to
+
+  return stripMeapFromURI(content.to)
+})
 </script>
 
 <template>
@@ -258,7 +295,7 @@ const parsedDescription = computed(() => {
       v-if="block && block.content && !block.content[0].contentLink"
       class="flexible-banner-featured"
       :media="parseImage"
-      :to="stripMeapFromURI(block.content[0].to)"
+      :to="parsedLink"
       :title="block.content[0].title"
       :breadcrumb="parsedTypeHandle"
       :byline="parseByLine"

--- a/packages/vue-component-library/src/lib-components/Flexible/CardWithImage.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/CardWithImage.vue
@@ -34,10 +34,7 @@ const classes = computed(() => {
 function parsedFtvaLink(obj: any) {
   if (obj.typeHandle === 'externalContent')
     return obj.to
-  else if (
-    obj.contentType === 'article'
-    || obj.contentType === 'generalContentPage'
-  )
+  else if (obj.contentType === 'article' || obj.contentType === 'generalContentPage')
     return `https://www.library.ucla.edu/${obj.uri}`
   else if (obj.contentType === 'ftvaGeneralContentPage')
     return obj.slug
@@ -64,12 +61,8 @@ function parsedFtvaImage(obj: any) {
   )
     return (obj.imageCarousel && obj.imageCarousel[0] && obj.imageCarousel[0].image[0]) || obj.ftvaImage[0] || undefined
 
-  else if (obj.contentType === 'article'
-    || obj.contentType === 'externalArticle'
-    || obj.contentType === 'generalContentPage'
-    || obj.contentType === 'collection'
-  )
-    return ((obj.heroImage?.length > 0) && obj.heroImage[0].image[0]) || undefined
+  else if (obj.contentType === 'article' || obj.contentType === 'generalContentPage' || obj.contentType === 'collection')
+    return ((obj.heroImage.length > 0) && obj.heroImage[0].image[0]) || undefined
 
   else if (obj.typeHandle === 'externalContent')
     return obj.image[0] || undefined
@@ -108,24 +101,23 @@ const parsedItems = computed(() => {
           to: parsedFtvaLink(obj),
           title: obj.eventTitle || obj.title || obj.titleGeneral,
           parsedImage: parsedFtvaImage(obj),
-          postDate: obj.contentType === 'ftvaArticle' ? 'obj.postDate' : null,
+          postDate: (obj.contentType === 'ftvaArticle') ? 'obj.postDate' : null,
           // byline2 Formats the date to April 3, 2025
           byline2: parsedFtvaArticleAndEventDate(obj),
         }
       }
-      // InternalContent - Article OR External Article
+
       else if (
         obj.typeHandle !== 'externalContent'
-        && ['article', 'externalArticle'].includes(obj.contentType)
+        && obj.contentType.includes('article')
       ) {
         return {
           ...obj,
-          to: obj.contentType === 'externalArticle'
-            ? obj.to
-            : stripMeapFromURI(obj.to),
+          to: stripMeapFromURI(obj.to),
           parsedImage: _get(
             obj,
             'heroImage[0].image[0]',
+            undefined
           ),
           parsedLocation: _get(
             obj,
@@ -192,7 +184,7 @@ const parsedItems = computed(() => {
       else if (
         obj.typeHandle !== 'externalContent'
         && (obj.contentType === 'exhibition'
-          || obj.contentType === 'workshopOrEventSeries')
+          || 'workshopOrEventSeries')
       ) {
         return {
           ...obj,

--- a/packages/vue-component-library/src/lib-components/Flexible/CardWithImage.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/CardWithImage.vue
@@ -64,8 +64,12 @@ function parsedFtvaImage(obj: any) {
   )
     return (obj.imageCarousel && obj.imageCarousel[0] && obj.imageCarousel[0].image[0]) || obj.ftvaImage[0] || undefined
 
-  else if (obj.contentType === 'article' || obj.contentType === 'generalContentPage' || obj.contentType === 'collection')
-    return ((obj.heroImage.length > 0) && obj.heroImage[0].image[0]) || undefined
+  else if (obj.contentType === 'article'
+    || obj.contentType === 'externalArticle'
+    || obj.contentType === 'generalContentPage'
+    || obj.contentType === 'collection'
+  )
+    return ((obj.heroImage?.length > 0) && obj.heroImage[0].image[0]) || undefined
 
   else if (obj.typeHandle === 'externalContent')
     return obj.image[0] || undefined
@@ -104,15 +108,15 @@ const parsedItems = computed(() => {
           to: parsedFtvaLink(obj),
           title: obj.eventTitle || obj.title || obj.titleGeneral,
           parsedImage: parsedFtvaImage(obj),
-          postDate: (obj.contentType === 'ftvaArticle') ? 'obj.postDate' : null,
+          postDate: obj.contentType === 'ftvaArticle' ? obj.postDate : null,
           // byline2 Formats the date to April 3, 2025
           byline2: parsedFtvaArticleAndEventDate(obj),
         }
       }
-      // InternalContent - External Article
+      // InternalContent - Article OR External Article
       else if (
         obj.typeHandle !== 'externalContent'
-        && obj.contentType.includes('article')
+        && ['article', 'externalArticle'].includes(obj.contentType)
       ) {
         return {
           ...obj,
@@ -122,7 +126,6 @@ const parsedItems = computed(() => {
           parsedImage: _get(
             obj,
             'heroImage[0].image[0]',
-            undefined
           ),
           parsedLocation: _get(
             obj,

--- a/packages/vue-component-library/src/lib-components/Flexible/CardWithImage.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/CardWithImage.vue
@@ -108,7 +108,7 @@ const parsedItems = computed(() => {
           to: parsedFtvaLink(obj),
           title: obj.eventTitle || obj.title || obj.titleGeneral,
           parsedImage: parsedFtvaImage(obj),
-          postDate: obj.contentType === 'ftvaArticle' ? obj.postDate : null,
+          postDate: obj.contentType === 'ftvaArticle' ? 'obj.postDate' : null,
           // byline2 Formats the date to April 3, 2025
           byline2: parsedFtvaArticleAndEventDate(obj),
         }

--- a/packages/vue-component-library/src/lib-components/Flexible/CardWithImage.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/CardWithImage.vue
@@ -34,7 +34,10 @@ const classes = computed(() => {
 function parsedFtvaLink(obj: any) {
   if (obj.typeHandle === 'externalContent')
     return obj.to
-  else if (obj.contentType === 'article' || obj.contentType === 'generalContentPage')
+  else if (
+    obj.contentType === 'article'
+    || obj.contentType === 'generalContentPage'
+  )
     return `https://www.library.ucla.edu/${obj.uri}`
   else if (obj.contentType === 'ftvaGeneralContentPage')
     return obj.slug
@@ -106,14 +109,16 @@ const parsedItems = computed(() => {
           byline2: parsedFtvaArticleAndEventDate(obj),
         }
       }
-
+      // InternalContent - External Article
       else if (
         obj.typeHandle !== 'externalContent'
         && obj.contentType.includes('article')
       ) {
         return {
           ...obj,
-          to: stripMeapFromURI(obj.to),
+          to: obj.contentType === 'externalArticle'
+            ? obj.to
+            : stripMeapFromURI(obj.to),
           parsedImage: _get(
             obj,
             'heroImage[0].image[0]',
@@ -184,7 +189,7 @@ const parsedItems = computed(() => {
       else if (
         obj.typeHandle !== 'externalContent'
         && (obj.contentType === 'exhibition'
-          || 'workshopOrEventSeries')
+          || obj.contentType === 'workshopOrEventSeries')
       ) {
         return {
           ...obj,

--- a/packages/vue-component-library/src/lib-components/Flexible/GridGalleryCards.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/GridGalleryCards.vue
@@ -17,30 +17,51 @@ const { block } = defineProps ({
 
 function flattenTimeLineStructure(galleryData: FlexibleGridGallery) {
   const flattenedValues = []
+
   for (const subitem of galleryData.gridGalleryCards) {
     const obj: GridGalleryItemType = {}
+
     obj.headlineText
-                  = subitem.contentLink && subitem.contentLink[0]
+      = subitem.contentLink && subitem.contentLink[0]
         ? subitem.contentLink[0].headlineText
         : subitem.headlineText
+
     obj.snippet
-                  = subitem.contentLink && subitem.contentLink[0]
+      = subitem.contentLink && subitem.contentLink[0]
         ? subitem.contentLink[0].snippet
         : subitem.snippet
+
     obj.featured = subitem.featured === 'true'
-    obj.to = stripMeapFromURI(
+    obj.to =
+      // Is it internalContent?
       subitem.contentLink && subitem.contentLink[0]
-        ? subitem.contentLink[0].to
-        : subitem.to
-    )
+        ? (
+            // Is it externalArticle?
+            subitem.contentLink[0].contentType === 'externalArticle'
+              // Yes → return raw external URL
+              ? subitem.contentLink[0].to
+              // No → strip + return internal URL
+              : stripMeapFromURI(subitem.contentLink[0].to)
+          )
+        : (
+            // Is it standalone externalContent?
+            subitem.contentType === 'externalArticle'
+              // Yes → return raw external URL
+              ? subitem.to
+              // Else → return empty string (or fallback behavior)
+              : subitem.to
+                ? stripMeapFromURI(subitem.to)
+                : ''
+          )
     obj.image
-                  = subitem.contentLink
-                  && subitem.contentLink[0]
-                  && subitem.contentLink[0].heroImage
+      = subitem.contentLink
+        && subitem.contentLink[0]
+        && subitem.contentLink[0].heroImage
         ? subitem.contentLink[0].heroImage[0].image[0]
         : subitem.image
           ? subitem.image[0]
           : {}
+
     flattenedValues.push(obj)
   }
 

--- a/packages/vue-component-library/src/lib-components/Flexible/GridGalleryCards.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/GridGalleryCards.vue
@@ -32,9 +32,9 @@ function flattenTimeLineStructure(galleryData: FlexibleGridGallery) {
         : subitem.snippet
 
     obj.featured = subitem.featured === 'true'
-    obj.to =
+    obj.to
       // Is it internalContent?
-      subitem.contentLink && subitem.contentLink[0]
+      = subitem.contentLink && subitem.contentLink[0]
         ? (
             // Is it externalArticle?
             subitem.contentLink[0].contentType === 'externalArticle'

--- a/packages/vue-component-library/src/lib-components/Flexible/GridGalleryCards.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/GridGalleryCards.vue
@@ -32,27 +32,18 @@ function flattenTimeLineStructure(galleryData: FlexibleGridGallery) {
         : subitem.snippet
 
     obj.featured = subitem.featured === 'true'
-    obj.to
-      // Is it internalContent?
-      = subitem.contentLink && subitem.contentLink[0]
-        ? (
-            // Is it externalArticle?
-            subitem.contentLink[0].contentType === 'externalArticle'
-              // Yes → return raw external URL
-              ? subitem.contentLink[0].to
-              // No → strip + return internal URL
-              : stripMeapFromURI(subitem.contentLink[0].to)
-          )
-        : (
-            // Is it standalone externalContent?
-            subitem.contentType === 'externalArticle'
-              // Yes → return raw external URL
-              ? subitem.to
-              // Else → return empty string (or fallback behavior)
-              : subitem.to
-                ? stripMeapFromURI(subitem.to)
-                : ''
-          )
+    // Is it internalContent?
+    obj.to = subitem.contentLink?.[0]
+      ? (
+          // Is it externalArticle?
+          subitem.contentLink[0].contentType === 'externalArticle'
+            // Yes → return raw external URL
+            ? subitem.contentLink[0].to
+            // Else → return /local/version
+            : stripMeapFromURI(subitem.contentLink[0].to)
+        )
+      // Is it standalone externalContent? Yes → return raw external URL
+      : subitem.to || ''
     obj.image
       = subitem.contentLink
         && subitem.contentLink[0]
@@ -94,7 +85,7 @@ const parseGalleryCards = computed(() => {
         v-html="block.sectionSummary"
       />
     </div>
-
+<h3>BLOCK:<pre>{{block}}</pre></h3>
     <GridGallery
       v-if="block.gridGalleryCards && block.gridGalleryCards.length > 0"
       class="section-summary"

--- a/packages/vue-component-library/src/lib-components/Flexible/GridGalleryCards.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/GridGalleryCards.vue
@@ -85,7 +85,7 @@ const parseGalleryCards = computed(() => {
         v-html="block.sectionSummary"
       />
     </div>
-<h3>BLOCK:<pre>{{block}}</pre></h3>
+
     <GridGallery
       v-if="block.gridGalleryCards && block.gridGalleryCards.length > 0"
       class="section-summary"

--- a/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
@@ -34,22 +34,21 @@ const parsedItems = computed(() => {
   return parsedList.value
     .filter(e => e !== null)
     .map((obj) => {
-
     // Internal Content External Article
-    if (obj.contentType?.toLowerCase().includes('externalarticle')
-    ) {
-      return {
-        ...obj,
-        to: obj.to, // DO NOT strip
-        parsedImage: _get(obj, 'heroImage[0].image[0]', undefined),
-        locations: _get(obj, 'articleLocations', undefined),
-        category: _get(obj, 'articleCategory[0].title', ''),
-        byline2:
+      if (obj.contentType?.toLowerCase().includes('externalarticle')
+      ) {
+        return {
+          ...obj,
+          to: obj.to, // DO NOT strip
+          parsedImage: _get(obj, 'heroImage[0].image[0]', undefined),
+          locations: _get(obj, 'articleLocations', undefined),
+          category: _get(obj, 'articleCategory[0].title', ''),
+          byline2:
           obj.articleByline2 != null
             ? formatDates(obj.articleByline2, obj.articleByline2)
             : '',
+        }
       }
-    }
 
       // Article
       else if (

--- a/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
@@ -27,16 +27,34 @@ const parsedList = computed(() => {
   return items
 })
 
+// TODO: Once we stop using the External Article we should delete this
 const parsedItems = computed(() => {
   // Maps values based on content type and external or internal content
   // filter out null objects
   return parsedList.value
     .filter(e => e !== null)
     .map((obj) => {
+
+    // Internal Content External Article
+    if (obj.contentType?.toLowerCase().includes('externalarticle')
+    ) {
+      return {
+        ...obj,
+        to: obj.to, // DO NOT strip
+        parsedImage: _get(obj, 'heroImage[0].image[0]', undefined),
+        locations: _get(obj, 'articleLocations', undefined),
+        category: _get(obj, 'articleCategory[0].title', ''),
+        byline2:
+          obj.articleByline2 != null
+            ? formatDates(obj.articleByline2, obj.articleByline2)
+            : '',
+      }
+    }
+
       // Article
-      if (
+      else if (
         obj.typeHandle !== 'externalContent'
-        && obj.contentType.includes('article')
+        && obj.contentType?.includes('article')
       ) {
         return {
           ...obj,
@@ -85,6 +103,8 @@ const parsedItems = computed(() => {
           byline1: _get(obj, 'projectByline1[0].title', ''),
         }
       }
+
+      // Event
       else if (
         obj.typeHandle !== 'externalContent'
         && obj.contentType === 'event'
@@ -108,10 +128,14 @@ const parsedItems = computed(() => {
           text: _get(obj, 'eventDescription', ''),
         }
       }
+
+      // Exhibition / Workshop Series
       else if (
         obj.typeHandle !== 'externalContent'
-        && (obj.contentType === 'exhibition'
-          || 'workshopOrEventSeries')
+        && (
+          obj.contentType === 'exhibition'
+          || obj.contentType === 'workshopOrEventSeries'
+        )
       ) {
         return {
           ...obj,
@@ -130,6 +154,8 @@ const parsedItems = computed(() => {
           endDate: _get(obj, 'endDate', ''),
         }
       }
+
+      // External Content (true external block, not internalContent)
       else if (obj.typeHandle === 'externalContent') {
         return {
           ...obj,
@@ -138,6 +164,7 @@ const parsedItems = computed(() => {
           /* locations:
             obj.locations != null ? [obj.locations] : undefined, */
           category: _get(obj, 'category', ''),
+          to: obj.to,
         }
       }
       else {

--- a/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
@@ -15,6 +15,7 @@ const { block } = defineProps({
 })
 
 const parsedList = computed(() => {
+  // flattens internalContent vs externalContent
   const items = []
   for (const item in block.highlight) {
     if (
@@ -27,7 +28,6 @@ const parsedList = computed(() => {
   return items
 })
 
-// TODO: Once we stop using the External Article we should delete this
 const parsedItems = computed(() => {
   // Maps values based on content type and external or internal content
   // filter out null objects

--- a/packages/vue-component-library/src/stories/FlexibleBlocks.stories.js
+++ b/packages/vue-component-library/src/stories/FlexibleBlocks.stories.js
@@ -5,7 +5,7 @@ import SectionWrapper from '@/lib-components/SectionWrapper'
 import DividerGeneral from '@/lib-components/DividerGeneral'
 
 import { mock as mockCardWithImage } from '@/stories/mock/Flexible_CardWithImage.js'
-import { mock as mockHighlight } from '@/stories/mock/Flexible_Highlight.js'
+import { mockInternalContentEventAndExhibition as mockHighlight } from '@/stories/mock/Flexible_Highlight.js'
 import {
   Gallery as mockMediaGallery,
   GalleryHalfWidth as mockMediaGalleryHalfWidth,

--- a/packages/vue-component-library/src/stories/Flexible_BannerFeatured.stories.js
+++ b/packages/vue-component-library/src/stories/Flexible_BannerFeatured.stories.js
@@ -35,7 +35,7 @@ const mockExternalArticle = {
       },
       byline1: 'Feburary 2022',
       byline2: 'Kiki Smith',
-      to: 'www.foxes.com',
+      to: 'https://www.animalspot.net/fox',
       category: 'foxes',
       contentType: 'project',
     },

--- a/packages/vue-component-library/src/stories/Flexible_BannerFeatured.stories.js
+++ b/packages/vue-component-library/src/stories/Flexible_BannerFeatured.stories.js
@@ -424,6 +424,64 @@ const mockInternalArticle = {
   typeHandle: 'bannerFeatured',
 }
 
+const mockInternalContentExternalArticle = {
+  id: '4984869',
+  typeHandle: 'bannerFeatured',
+  sectionTitle: 'Internal Content ExternalArticle',
+  content: [
+    {
+      id: '4987160',
+      contentLink: [
+        {
+          contentType: 'externalArticle',
+          title: 'Davenport California',
+          to: 'https:/www.tripadvisor.com/Tourism-g32282-Davenport_California-Vacations.html',
+          summary: '<p>New External Article field. Davenport is notable for its scenery, with numerous bluffs and cliff faces stretching along its perimeter, as well as foothills and forests toward its east.</p>',
+          articleCategory: [
+            {
+              title: 'Preservation & Restoration'
+            }
+          ],
+          articleByline1: [
+            {
+              id: '11827',
+              to: 'about/staff/brigid-abreu',
+              title: 'Brigid Abreu',
+            },
+          ],
+          articleByline2: '2026-06-26T14:27:00-07:00',
+          articleLocations: [
+            {
+              id: '18347',
+              title: 'Arts library',
+              to: 'visit/locations/arts-library',
+              uri: 'visit/locations/arts-library'
+            }
+          ],
+          heroImage: [
+            {
+              image: [
+                {
+                  id: '4981817',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/davenport-landing-beach.jpg',
+                  height: 1705,
+                  width: 2560,
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/davenport-landing-beach.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/davenport-landing-beach.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/davenport-landing-beach.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/davenport-landing-beach.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/davenport-landing-beach.jpg 2560w',
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
 const mockInternalArticleWithVideo = {
   id: '36699',
   typeHandle: 'bannerFeatured',
@@ -876,6 +934,22 @@ export function InternalArticle() {
     data() {
       return {
         block: mockInternalArticle,
+      }
+    },
+    components: { FlexibleBannerFeatured },
+    template: `
+        <flexible-banner-featured
+            :block="block"
+       />
+    `,
+  }
+}
+
+export function InternalContentExternalArticle() {
+  return {
+    data() {
+      return {
+        block: mockInternalContentExternalArticle,
       }
     },
     components: { FlexibleBannerFeatured },

--- a/packages/vue-component-library/src/stories/Flexible_BannerFeatured.stories.js
+++ b/packages/vue-component-library/src/stories/Flexible_BannerFeatured.stories.js
@@ -435,7 +435,7 @@ const mockInternalContentExternalArticle = {
         {
           contentType: 'externalArticle',
           title: 'Davenport California',
-          to: 'https:/www.tripadvisor.com/Tourism-g32282-Davenport_California-Vacations.html',
+          to: 'https://www.tripadvisor.com/Tourism-g32282-Davenport_California-Vacations.html',
           summary: '<p>New External Article field. Davenport is notable for its scenery, with numerous bluffs and cliff faces stretching along its perimeter, as well as foothills and forests toward its east.</p>',
           articleCategory: [
             {

--- a/packages/vue-component-library/src/stories/Flexible_GridGalleryCards.stories.js
+++ b/packages/vue-component-library/src/stories/Flexible_GridGalleryCards.stories.js
@@ -60,29 +60,29 @@ const mock = {
 }
 
 const mockInternalContentArticleExternalArticleAndExternalContent = {
-  id: "4986283",
-  typeHandle: "gridGalleryCards",
+  id: '4986283',
+  typeHandle: 'gridGalleryCards',
   sectionSummary: null,
-  sectionTitle: "Grid Gallery Cards -- Internal Content - Article,  Internal Content - ExternalArticle & External Article",
+  sectionTitle: 'Grid Gallery Cards -- Internal Content - Article,  Internal Content - ExternalArticle & External Article',
   gridGalleryCards: [
     {
-      id: "4990384",
+      id: '4990384',
       contentLink: [
         {
-          contentType: "article",
-          headlineText: "So Many Squirrels",
-          snippet: "<p><strong>Internal Content - Article</strong><br/>There are between 200 and 300 million squirrels in the world. There are 40 million in the United States. ;) In Alaska there are 466 squirrels for every 1 person. ;)</p>",
-          to: "about/news/testnews",
+          contentType: 'article',
+          headlineText: 'So Many Squirrels',
+          snippet: '<p><strong>Internal Content - Article</strong><br/>There are between 200 and 300 million squirrels in the world. There are 40 million in the United States. ;) In Alaska there are 466 squirrels for every 1 person. ;)</p>',
+          to: 'about/news/testnews',
           heroImage: [
             {
               image: [
                 {
-                  id: "2900571",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/fox-squirrel.jpeg",
+                  id: '2900571',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/fox-squirrel.jpeg',
                   height: 1699,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/fox-squirrel.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/fox-squirrel.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/fox-squirrel.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/fox-squirrel.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/fox-squirrel.jpeg 2560w",
-                  alt: "Fox squirrel",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/fox-squirrel.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/fox-squirrel.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/fox-squirrel.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/fox-squirrel.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/fox-squirrel.jpeg 2560w',
+                  alt: 'Fox squirrel',
                   focalPoint: [
                     0.5,
                     0.5
@@ -93,25 +93,25 @@ const mockInternalContentArticleExternalArticleAndExternalContent = {
           ]
         }
       ],
-      featured: "false"
+      featured: 'false'
     },
     {
-      id: "4986469",
+      id: '4986469',
       contentLink: [
         {
-          contentType: "externalArticle",
-          headlineText: "Water Polo",
-          snippet: "<p><strong>Internal Content - External Article</strong><br/> A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>",
-          to: "https:/www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2",
+          contentType: 'externalArticle',
+          headlineText: 'Water Polo',
+          snippet: '<p><strong>Internal Content - External Article</strong><br/> A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>',
+          to: 'https:/www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2',
           heroImage: [
             {
               image: [
                 {
-                  id: "4981835",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/water-polo-1.jpg",
+                  id: '4981835',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/water-polo-1.jpg',
                   height: 1358,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/water-polo-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/water-polo-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/water-polo-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/water-polo-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/water-polo-1.jpg 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/water-polo-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/water-polo-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/water-polo-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/water-polo-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/water-polo-1.jpg 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -123,20 +123,20 @@ const mockInternalContentArticleExternalArticleAndExternalContent = {
           ]
         }
       ],
-      featured: "false"
+      featured: 'false'
     },
     {
-      id: "4990143",
-      featured: "false",
-      headlineText: "Bears Lovers of Sierra Madre",
-      snippet: "<p><strong>External Article</strong><br/> Sierra Madre is a major hotspot for bear encounters. The bears frequently wander down from the Angeles National Forest in search of food and water.</p>",
+      id: '4990143',
+      featured: 'false',
+      headlineText: 'Bears Lovers of Sierra Madre',
+      snippet: '<p><strong>External Article</strong><br/> Sierra Madre is a major hotspot for bear encounters. The bears frequently wander down from the Angeles National Forest in search of food and water.</p>',
       image: [
         {
-          id: "4990141",
-          src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/bear.jpeg",
+          id: '4990141',
+          src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/bear.jpeg',
           height: 1707,
           width: 2560,
-          srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/bear.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/bear.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/bear.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/bear.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/bear.jpeg 2560w",
+          srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/bear.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/bear.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/bear.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/bear.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/bear.jpeg 2560w',
           alt: null,
           focalPoint: [
             0.5,
@@ -144,7 +144,7 @@ const mockInternalContentArticleExternalArticleAndExternalContent = {
           ]
         }
       ],
-      to: "https://www.bearloverssm.com/"
+      to: 'https://www.bearloverssm.com/'
     }
   ]
 }

--- a/packages/vue-component-library/src/stories/Flexible_GridGalleryCards.stories.js
+++ b/packages/vue-component-library/src/stories/Flexible_GridGalleryCards.stories.js
@@ -102,7 +102,7 @@ const mockInternalContentArticleExternalArticleAndExternalContent = {
           contentType: 'externalArticle',
           headlineText: 'Water Polo',
           snippet: '<p><strong>Internal Content - External Article</strong><br/> A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>',
-          to: 'https:/www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2',
+          to: 'https://www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2',
           heroImage: [
             {
               image: [

--- a/packages/vue-component-library/src/stories/Flexible_GridGalleryCards.stories.js
+++ b/packages/vue-component-library/src/stories/Flexible_GridGalleryCards.stories.js
@@ -15,9 +15,8 @@ const mock = {
       contentLink: [
         {
           contentType: 'article',
-          title: 'La Niña',
-          snippet:
-                        '<p>La Niña is an oceanic and atmospheric phenomenon that is the colder counterpart of El Niño, as part of the broader El Niño–Southern Oscillation climate pattern.</p>',
+          headlineText: 'La Niña',
+          snippet: '<p>La Niña is an oceanic and atmospheric phenomenon that is the colder counterpart of El Niño, as part of the broader El Niño–Southern Oscillation climate pattern.</p>',
           to: 'about/news/la-niña',
           heroImage: [
             {
@@ -41,7 +40,7 @@ const mock = {
     {
       id: '40363',
       featured: 'true',
-      titleGeneral: 'This is a featured content',
+      headlineText: 'This is a featured content',
       snippet: '<p>Virtual library demo</p>',
       image: [
         {
@@ -60,11 +59,117 @@ const mock = {
   typeHandle: 'gridGalleryCards',
 }
 
+const mockInternalContentArticleExternalArticleAndExternalContent = {
+  id: "4986283",
+  typeHandle: "gridGalleryCards",
+  sectionSummary: null,
+  sectionTitle: "Grid Gallery Cards -- Internal Content - Article,  Internal Content - ExternalArticle & External Article",
+  gridGalleryCards: [
+    {
+      id: "4990384",
+      contentLink: [
+        {
+          contentType: "article",
+          headlineText: "So Many Squirrels",
+          snippet: "<p><strong>Internal Content - Article</strong><br/>There are between 200 and 300 million squirrels in the world. There are 40 million in the United States. ;) In Alaska there are 466 squirrels for every 1 person. ;)</p>",
+          to: "about/news/testnews",
+          heroImage: [
+            {
+              image: [
+                {
+                  id: "2900571",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/fox-squirrel.jpeg",
+                  height: 1699,
+                  width: 2560,
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/fox-squirrel.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/fox-squirrel.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/fox-squirrel.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/fox-squirrel.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/fox-squirrel.jpeg 2560w",
+                  alt: "Fox squirrel",
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      featured: "false"
+    },
+    {
+      id: "4986469",
+      contentLink: [
+        {
+          contentType: "externalArticle",
+          headlineText: "Water Polo",
+          snippet: "<p><strong>Internal Content - External Article</strong><br/> A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>",
+          to: "https:/www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2",
+          heroImage: [
+            {
+              image: [
+                {
+                  id: "4981835",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/water-polo-1.jpg",
+                  height: 1358,
+                  width: 2560,
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/water-polo-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/water-polo-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/water-polo-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/water-polo-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/water-polo-1.jpg 2560w",
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      featured: "false"
+    },
+    {
+      id: "4990143",
+      featured: "false",
+      headlineText: "Bears Lovers of Sierra Madre",
+      snippet: "<p><strong>External Article</strong><br/> Sierra Madre is a major hotspot for bear encounters. The bears frequently wander down from the Angeles National Forest in search of food and water.</p>",
+      image: [
+        {
+          id: "4990141",
+          src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/bear.jpeg",
+          height: 1707,
+          width: 2560,
+          srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/bear.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/bear.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/bear.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/bear.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/bear.jpeg 2560w",
+          alt: null,
+          focalPoint: [
+            0.5,
+            0.5
+          ]
+        }
+      ],
+      to: "https://www.bearloverssm.com/"
+    }
+  ]
+}
+
 export function Default() {
   return {
     data() {
       return {
         block: mock,
+      }
+    },
+    components: { FlexibleGridGalleryCards },
+    template: `
+        <flexible-grid-gallery-cards
+            :block="block"
+        />
+    `,
+  }
+}
+
+export function InternalContentArticleExternalArticleAndExternalContent() {
+  return {
+    data() {
+      return {
+        block: mockInternalContentArticleExternalArticleAndExternalContent,
       }
     },
     components: { FlexibleGridGalleryCards },

--- a/packages/vue-component-library/src/stories/Flexible_Highlight.stories.js
+++ b/packages/vue-component-library/src/stories/Flexible_Highlight.stories.js
@@ -1,4 +1,4 @@
-import { mockInternalContentEventAndExhibition, mockInternalContentWorshopSeriesAndEventSeries, mockInternalContentArticleAndExternalArticle, mockInternalContentEndowmentAndCollectionAndGeneralContentPage, mockInternalContentMeapArticleAndProject, mockExternalContent } from './mock/Flexible_Highlight'
+import { mockExternalContent, mockInternalContentArticleAndExternalArticle, mockInternalContentEndowmentAndCollectionAndGeneralContentPage, mockInternalContentEventAndExhibition, mockInternalContentMeapArticleAndProject, mockInternalContentWorshopSeriesAndEventSeries } from './mock/Flexible_Highlight'
 import FlexibleHighlight from '@/lib-components/Flexible/Highlight'
 
 export default {

--- a/packages/vue-component-library/src/stories/Flexible_Highlight.stories.js
+++ b/packages/vue-component-library/src/stories/Flexible_Highlight.stories.js
@@ -1,4 +1,4 @@
-import { eventExhibitonArticle, mock } from './mock/Flexible_Highlight'
+import { mockInternalContentEventAndExhibition, mockInternalContentWorshopSeriesAndEventSeries, mockInternalContentArticleAndExternalArticle, mockInternalContentEndowmentAndCollectionAndGeneralContentPage, mockInternalContentMeapArticleAndProject, mockExternalContent } from './mock/Flexible_Highlight'
 import FlexibleHighlight from '@/lib-components/Flexible/Highlight'
 
 export default {
@@ -10,7 +10,87 @@ export function Default() {
   return {
     data() {
       return {
-        block: mock,
+        block: mockInternalContentEventAndExhibition,
+      }
+    },
+    components: { FlexibleHighlight },
+    template: `
+        <flexible-highlight
+            :block="block"
+       />
+    `,
+  }
+}
+
+export function InternalContentWorshopSeriesAndEventSeries() {
+  return {
+    data() {
+      return {
+        block: mockInternalContentWorshopSeriesAndEventSeries,
+      }
+    },
+    components: { FlexibleHighlight },
+    template: `
+        <flexible-highlight
+            :block="block"
+       />
+    `,
+  }
+}
+
+export function InternalContentArticleAndExternalArticle() {
+  return {
+    data() {
+      return {
+        block: mockInternalContentArticleAndExternalArticle,
+      }
+    },
+    components: { FlexibleHighlight },
+    template: `
+        <flexible-highlight
+            :block="block"
+       />
+    `,
+  }
+}
+
+export function InternalContentEndowmentAndCollectionAndGeneralContentPage() {
+  return {
+    data() {
+      return {
+        block: mockInternalContentEndowmentAndCollectionAndGeneralContentPage,
+      }
+    },
+    components: { FlexibleHighlight },
+    template: `
+        <flexible-highlight
+            :block="block"
+       />
+    `,
+  }
+}
+
+export function InternalContentMeapArticleAndProject() {
+  return {
+    data() {
+      return {
+        block: mockInternalContentMeapArticleAndProject,
+      }
+    },
+    components: { FlexibleHighlight },
+    template: `
+        <flexible-highlight
+            :block="block"
+       />
+    `,
+  }
+}
+
+export function ExternalContent() {
+  return {
+    data() {
+      return {
+        block: mockExternalContent,
       }
     },
     components: { FlexibleHighlight },
@@ -24,20 +104,4 @@ export function Default() {
 
 Default.parameters = {
   chromatic: { disableSnapshot: false },
-}
-
-export function EventExhibitonArticle() {
-  return {
-    data() {
-      return {
-        block: eventExhibitonArticle,
-      }
-    },
-    components: { FlexibleHighlight },
-    template: `
-        <flexible-highlight
-            :block="block"
-       />
-    `,
-  }
 }

--- a/packages/vue-component-library/src/stories/mock/Flexible_CardWithImage.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_CardWithImage.js
@@ -332,7 +332,7 @@ export const mockInternalArticle = {
         }
       ]
     },
-      {
+    {
       id: '4989629',
       typeHandle: 'internalContent',
       contentLink: [

--- a/packages/vue-component-library/src/stories/mock/Flexible_CardWithImage.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_CardWithImage.js
@@ -355,10 +355,10 @@ export const mockInternalArticle = {
               image: [
                 {
                   id: '4989566',
-                  src: 'https: //static.library.ucla.edu/craftassetstest/images/_fullscreen/twiggy.jpg',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/twiggy.jpg',
                   height: 1440,
                   width: 2560,
-                  srcset: 'https: //static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/twiggy.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/twiggy.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/twiggy.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/twiggy.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/twiggy.jpg 2560w',
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/twiggy.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/twiggy.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/twiggy.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/twiggy.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/twiggy.jpg 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,

--- a/packages/vue-component-library/src/stories/mock/Flexible_CardWithImage.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_CardWithImage.js
@@ -124,7 +124,7 @@ export const mockInternalEvent = {
           ]
         }
       ]
-    },
+    }
   ]
 }
 
@@ -280,11 +280,11 @@ export const mockInternalSeries = {
   ]
 }
 
-// Article
+// Internal Article & InternalContent - External Article
 export const mockInternalArticle = {
   id: '2900942',
   typeHandle: 'cardWithImage',
-  sectionTitle: 'FPB CARD WITH IMAGE - Dangerous Diseases from Squirrels',
+  sectionTitle: 'FPB CARD WITH IMAGE - InternalContent Article & ExternalArticle',
   sectionSummary: '<p><em><a href=\"https://www.critterguard.org/blogs/articles/dangerous-diseases-from-squirrels-in-the-home\" target=\"_blank\" rel=\"noreferrer noopener\">Be careful of these</a></em> <strong>diseases</strong> that can be transmitted from squirrels to humans: Leptospirosis, Lyme Disease, Salmonellosis, Tularemia, Rabies.</p>',
   cardWithImage: [
     {
@@ -331,7 +331,46 @@ export const mockInternalArticle = {
           ]
         }
       ]
-    }
+    },
+      {
+      id: '4989629',
+      typeHandle: 'internalContent',
+      contentLink: [
+        {
+          id: '4989564',
+          contentType: 'externalArticle',
+          to: 'https://twiggyshow.com',
+          title: 'Twiggy the Skiing Squirrel',
+          text: '<p><strong>New External Article field.</strong> Twiggy the squirrel has appeared in numerous books, magazines, newspapers, and television shows all over the world.</p>',
+          articleCategory: [
+            {
+              title: 'Animals'
+            }
+          ],
+          articleByline2: '2026-07-08T16: 51: 00-07: 00',
+          associatedLocations: [],
+          heroImage: [
+            {
+              id: '4989567',
+              image: [
+                {
+                  id: '4989566',
+                  src: 'https: //static.library.ucla.edu/craftassetstest/images/_fullscreen/twiggy.jpg',
+                  height: 1440,
+                  width: 2560,
+                  srcset: 'https: //static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/twiggy.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/twiggy.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/twiggy.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/twiggy.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/twiggy.jpg 2560w',
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
   ]
 }
 

--- a/packages/vue-component-library/src/stories/mock/Flexible_Highlight.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_Highlight.js
@@ -1,242 +1,40 @@
-export const mock = {
-  id: '27359',
-  typeHandle: 'highlight',
-  sectionTitle: 'Section Title: BlockHighlight',
-  sectionSummary: '<p>Section Summary: BlockHighlight</p>',
+export const mockInternalContentEventAndExhibition = {
+  id: "4980101",
+  typeHandle: "highlight",
+  sectionTitle: "Highlight with Internal Content - Event  & Exhibition",
+  sectionSummary: null,
   highlight: [
     {
-      id: '27360',
-      typeHandle: 'internalContent',
+      id: "4980102",
+      typeHandle: "internalContent",
       contentLink: [
         {
-          id: '20628',
-          contentType: 'article',
-          to: 'about/news/la-niña',
-          title: 'La Niña',
-          text: '<p><strong>La Niña</strong> is an <em>oceanic and atmospheric phenomenon</em> that is the colder counterpart of El Niño, as part of the broader El Niño–Southern Oscillation climate pattern.</p>',
-          articleCategory: [
+          id: "4720385",
+          contentType: "event",
+          to: "visit/events-exhibitions/the-cultural-politics-of-eddie-murphy-coming-to-america-04-04-26",
+          title: "The Cultural Politics of Eddie Murphy: Coming to America 04-20-26",
+          text: null,
+          eventDescription: "<p>Eddie Murphy stands at the center of the Black Pack as Prince Akeem, heir to the throne of Zamunda, who leaves royal luxury for Queens, New York, in search of love on his own terms.</p>",
+          articleByline2: "2026-02-20T13:45:00-08:00",
+          startDateWithTime: "2026-04-20T19:30",
+          endDateWithTime: "2026-04-20T21:30",
+          eventType: [
             {
-              title: 'Internal Content Article',
-            },
-          ],
-          articleByline1: [
-            {
-              id: '11827',
-              to: 'about/staff/brigid-abreu',
-              title: 'Brigid Abreu',
-            },
-            {
-              id: '11910',
-              to: 'about/staff/sylvia-page',
-              title: 'Sylvia Page',
-            },
-          ],
-          articleByline2: '2022-06-21T12:39:00-07:00',
-          associatedLocations: [
-            {
-              id: '11709',
-              title: 'William Andrews Clark Memorial Library',
-              to: 'visit/locations/william-andrews-clark-memorial-library',
-            },
-            {
-              id: '11497',
-              title: 'Richard C. Rudolph East Asian Library',
-              to: 'visit/locations/east-asian-library',
-            },
-          ],
-          heroImage: [
-            {
-              id: '20639',
-              image: [
-                {
-                  id: '20637',
-                  src: 'https://static.library.ucla.edu/craftassetstest/LaNina-Jet-Wintertime-Pattern.jpg',
-                  height: 1997,
-                  width: 2560,
-                  srcset: 'https://static.library.ucla.edu/craftassetstest/_375xAUTO_crop_center-center_none/LaNina-Jet-Wintertime-Pattern.jpg 375w, https://static.library.ucla.edu/craftassetstest/_960xAUTO_crop_center-center_none/LaNina-Jet-Wintertime-Pattern.jpg 960w, https://static.library.ucla.edu/craftassetstest/_1280xAUTO_crop_center-center_none/LaNina-Jet-Wintertime-Pattern.jpg 1280w, https://static.library.ucla.edu/craftassetstest/_1920xAUTO_crop_center-center_none/LaNina-Jet-Wintertime-Pattern.jpg 1920w, https://static.library.ucla.edu/craftassetstest/_2560xAUTO_crop_center-center_none/LaNina-Jet-Wintertime-Pattern.jpg 2560w',
-                  alt: 'La Nina Jet Wintertime Pattern',
-                  focalPoint: [0.5, 0.5],
-                  altText: 'La Niña',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      id: '27361',
-      typeHandle: 'internalContent',
-      contentLink: [
-        {
-          id: '16484',
-          contentType: 'article',
-          to: 'about/news/this-is-the-newest-article',
-          title: 'Shortbread is delicious',
-          text: '<p><strong>Shortbread</strong> or shortie is a traditional <a href="https://www.scotchandscones.com/shortbread-history/">Scottish biscuit</a> usually made from <em>one part white sugar</em>, two parts butter, and three to four parts plain wheat flour.</p>',
-          articleCategory: [
-            {
-              title: 'Internal Content Article',
-            },
-          ],
-          articleByline1: [
-            {
-              id: '3522',
-              to: 'about/staff/dianne',
-              title: 'Dianne Weinthal',
-            },
-          ],
-          articleByline2: '2022-05-19T13:59:00-07:00',
-          associatedLocations: [
-            {
-              id: '4695',
-              title: 'Louise M. Darling Biomedical Library',
-              to: 'visit/locations/biomed',
-            },
-          ],
-          heroImage: [
-            {
-              id: '16537',
-              image: [
-                {
-                  id: '2442',
-                  src: 'https://static.library.ucla.edu/craftassetstest/shortbread-cookies.jpg',
-                  height: 1421,
-                  width: 2560,
-                  srcset: 'https://static.library.ucla.edu/craftassetstest/_375xAUTO_crop_center-center_none/shortbread-cookies.jpg 375w, https://static.library.ucla.edu/craftassetstest/_960xAUTO_crop_center-center_none/shortbread-cookies.jpg 960w, https://static.library.ucla.edu/craftassetstest/_1280xAUTO_crop_center-center_none/shortbread-cookies.jpg 1280w, https://static.library.ucla.edu/craftassetstest/_1920xAUTO_crop_center-center_none/shortbread-cookies.jpg 1920w, https://static.library.ucla.edu/craftassetstest/_2560xAUTO_crop_center-center_none/shortbread-cookies.jpg 2560w',
-                  alt: 'Shortbread cookies',
-                  focalPoint: [0.5, 0.5],
-                  altText: null,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      id: '39508',
-      typeHandle: 'externalContent',
-      title: 'Pandemic Spurs Virtual Screening Room, Bringing Moving Images to a Global Audience',
-      image: [
-        {
-          id: '36751',
-          src: 'https://static.library.ucla.edu/craftassetstest/images/virtual-screening-room-toll-sea.jpeg',
-          height: 1869,
-          width: 2560,
-          srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/virtual-screening-room-toll-sea.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/virtual-screening-room-toll-sea.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/virtual-screening-room-toll-sea.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/virtual-screening-room-toll-sea.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/virtual-screening-room-toll-sea.jpeg 2560w',
-          alt: 'Virtual screening room toll sea',
-          focalPoint: [0.5, 0.5],
-        },
-      ],
-      byline1: null,
-      byline2: null,
-      category: null,
-      text: 'When its <a href"https://www.nationaltheatre.org.uk/">theatrical home</a> closed its doors in <strong>March 2020</strong> due to <em>COVID-19</em> the UCLA Film & Television Archive shifted public programming to an ambitious new online screening',
-      to: 'https://www.cinema.ucla.edu/blogs/archive-blog/2022/01/31/pandemic-spurs-virtual-screening-room',
-    },
-    {
-      id: '4987907',
-      typeHandle: 'externalContent',
-      title: 'Lady Liberty - External Content',
-      image: [
-        {
-          id: '4987902',
-          src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/statue_of_liberty_3_poster.jpg',
-          height: 3681,
-          width: 2560,
-          srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 2560w',
-          alt: null,
-          focalPoint: [
-            0.5,
-            0.5
-          ]
-        }
-      ],
-      byline1: 'February 23, 2028',
-      byline2: '7:00 P.M.',
-      category: 'External Content',
-      text: '<p>Give me your tired, your poor Your huddled masses yearning to breathe free The wretched refuse of your teeming shore. Send these, the homeless, tempest-tost to me I lift my lamp beside the golden door</p>',
-      to: 'https://www.nps.gov/stli/index.htm'
-    },
-    {
-      id: '28621',
-      typeHandle: 'internalContent',
-      contentLink: [
-        {
-          id: '25318',
-          contentType: 'meapProject',
-          to: 'projects/argentinean-human-rights-digital-library-of-periodical-and-non-periodical-publications',
-          title: 'Argentinean Human Rights Digital Library of Periodical and Non-periodical Publications',
-          text: '<p><a href="https://www.cinema.ucla.edu/billy-wilder-theater">Memoria Abierta</a> is an <strong>alliance</strong> of nine Argentinean <em>human rights</em> organizations. Most of them were created during the last dictatorship (1976-1983) to denounce the violations committed during that period and to support relatives and victims. The Argentinean human rights movement, with its innovative strategies to fight oblivion and achieve justice, is known worldwide and referenced by other countries where human rights crimes have been or are being committed.</p>',
-          projectCategory: 'Internal Content MEAP Projects',
-          projectByline1: [
-            {
-              id: '25325',
-              title: 'Memoria Abierta',
-            },
-          ],
-          articleByline2: '2022-07-26T10:49:00-07:00',
-          projectLocations: [
-            {
-              id: '25324',
-              title: 'South America',
-            },
-          ],
-          heroImage: [
-            {
-              id: '25334',
-              image: [
-                {
-                  id: '24878',
-                  src: 'https://static.library.ucla.edu/craftassetstest/toni-g-rbregi1jeo-unsplash.jpg',
-                  height: 4552,
-                  width: 2560,
-                  srcset: 'https://static.library.ucla.edu/craftassetstest/_375xAUTO_crop_center-center_none/toni-g-rbregi1jeo-unsplash.jpg 375w, https://static.library.ucla.edu/craftassetstest/_960xAUTO_crop_center-center_none/toni-g-rbregi1jeo-unsplash.jpg 960w, https://static.library.ucla.edu/craftassetstest/_1280xAUTO_crop_center-center_none/toni-g-rbregi1jeo-unsplash.jpg 1280w, https://static.library.ucla.edu/craftassetstest/_1920xAUTO_crop_center-center_none/toni-g-rbregi1jeo-unsplash.jpg 1920w, https://static.library.ucla.edu/craftassetstest/_2560xAUTO_crop_center-center_none/toni-g-rbregi1jeo-unsplash.jpg 2560w',
-                  alt: 'Toni g rbregi1jeo unsplash',
-                  focalPoint: [0.5, 0.5],
-                  altText: null,
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      id: '4986534',
-      typeHandle: 'internalContent',
-      contentLink: [
-        {
-          id: '4980208',
-          contentType: 'externalArticle',
-          to: 'https://www.hawaiimagazine.com/worlds-best-tandem-surfers-compete-at-waikiki-beach',
-          title: 'Gymnastics & Surfing',
-          text: '<p>New External Article field. Gymnasts possess core strength, balance, and aerial awareness, while surfers movements combine flexibility with cardiovascular endurance.</p>',
-          articleCategory: [
-            {
-              title: 'Internal Content External Article'
+              id: "50396",
+              title: "Screening"
             }
           ],
-          articleByline2: '2026-06-23T15:48:00-07:00',
-          associatedLocations: [
-            {
-              id: '523',
-              title: 'Powell Library',
-              to: 'visit/locations/powell-library',
-              uri: 'visit/locations/powell-library'
-            }
-          ],
+          associatedLocations: [],
           heroImage: [
             {
-              id: '4980211',
+              id: "4989273",
               image: [
                 {
-                  id: '4980210',
-                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Gymnastics-Surfing.jpeg',
-                  height: 1278,
+                  id: "4989272",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/coming2america.jpg",
+                  height: 2560,
                   width: 2560,
-                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 2560w',
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/coming2america.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/coming2america.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/coming2america.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/coming2america.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/coming2america.jpg 2560w",
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -249,160 +47,490 @@ export const mock = {
         }
       ]
     },
-  ],
+    {
+      id: "4980103",
+      typeHandle: "internalContent",
+      contentLink: [
+        {
+          id: "4981311",
+          contentType: "exhibition",
+          to: "visit/events-exhibitions/ucla-library-special-collections",
+          title: "UCLA Library Special Collections",
+          text: "<p>Open to all, UCLA Library Special Collections (LSC) preserves, shares and promotes the Librarys unique primary sources.</p>",
+          articleByline2: "2026-06-25T16:22:00-07:00",
+          ongoing: false,
+          startDate: null,
+          endDate: null,
+          heroImage: [
+            {
+              id: "4981312",
+              image: [
+                {
+                  id: "4981310",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/UCLA_LibraryLocations_LSC-1.jpg",
+                  height: 1124,
+                  width: 2560,
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 2560w",
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }
 
-export const eventExhibitonArticle = {
-  id: '696267',
-  typeHandle: 'highlight',
-  sectionTitle: 'Flexible Highlight with events and exhibitions',
-  sectionSummary:
-      '<p>Flexible Highlight with events and exhibitions so that we can test</p>',
+export const mockInternalContentWorshopSeriesAndEventSeries = {
+  id: "4988975",
+  typeHandle: "highlight",
+  sectionTitle: "Highlight with Internal Content - Worshop Series & Event Series",
+  sectionSummary: null,
   highlight: [
     {
-      id: '696268',
-      typeHandle: 'internalContent',
+      id: "4988976",
+      typeHandle: "internalContent",
       contentLink: [
         {
-          id: '197177',
-          contentType: 'event',
-          to: 'visit/events-exhibitions/test-the-white-balloon',
-          title: 'TEST - The White Balloon',
-          text: null,
-          eventDescription:
-                      '<p><strong>All <em>Family Flicks</em> screenings are free admission. Seating is first come, first served. The Billy Wilder Theater opens 15 minutes before each <em>Family Flicks</em> program.</strong></p>\n\n<p>Director Jafar Panahi’s debut feature, <em>The White Balloon</em>, won the Camera d’Or at the Cannes Film Festival and announced the arrival of a major new voice on the international film scene. A simply presented but powerful moving fable of perseverance, it follows a young girl as she overcomes the obstacles of the big city on her way to buy a goldfish for Nowruz, the Iranian New Year. Among The Guardian newspaper’s top 50 family films of all time, <em>The White Balloon</em> is also on the British Film Institute’s list of 50 films you should see by the age of 14.</p>\n\n<p>35mm, color, in Persian with English subtitles, 85 min. Director: Jafar Panahi. Screenwriter: Abbas Kiarostami. With: Aida Mohammadkhani, Mohsen Kafili, Fereshteh Sadre Orafaiy.</p>\n\n<p>Part of: <a href="https://www.cinema.ucla.edu/events/family-flicks" target="_blank" rel="noreferrer noopener">Family Flicks</a><br /><a href="https://www.cinema.ucla.edu/events/2023/01/22/the-white-balloon" target="_blank" rel="noreferrer noopener">Learn more</a> </p>',
-          articleByline2: '2022-12-19T07:48:00-08:00',
-          startDateWithTime: '2022-12-19T11:00',
-          endDateWithTime: '2022-12-19T12:30',
-          eventType: [],
+          id: "197039",
+          contentType: "workshopOrEventSeries",
+          to: "help/services-resources/family-flicks",
+          title: "Test - Workshop - Family Flicks",
+          text: "<p>All <strong>Family Flicks</strong> screenings are <em>free admission</em>. An incorrigible squirrel helps his friends raid a nut store, a location that also happens to be a front for a human gangs bank robbery.</p>",
+          articleByline2: "2022-12-19T07:44:00-08:00",
+          ongoing: true,
+          startDate: "1967-10-09T00:00",
+          endDate: "2002-04-19T00:00",
           associatedLocations: [
             {
-              id: '11612',
-              title: 'UCLA Film & Television Archive',
-              to: 'visit/locations/film-television-archive',
-            },
+              id: "11612",
+              title: "UCLA Film & Television Archive",
+              to: "visit/locations/film-television-archive",
+              uri: "visit/locations/film-television-archive"
+            }
           ],
           heroImage: [
             {
-              id: '197178',
+              id: "2930538",
               image: [
                 {
-                  id: '86612',
-                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/1670615203.jpg',
-                  height: 1846,
+                  id: "2930537",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Screenshot-2024-03-22-at-3.07.33-PM.png",
+                  height: 1391,
                   width: 2560,
-                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/1670615203.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/1670615203.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/1670615203.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/1670615203.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/1670615203.jpg 2560w',
-                  alt: 'placeholder',
-                  focalPoint: [0.5, 0.5],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      id: '696269',
-      typeHandle: 'internalContent',
-      contentLink: [
-        {
-          id: '8901',
-          contentType: 'exhibition',
-          to: 'visit/events-exhibitions/fante-asafo-flags',
-          title: 'Fante Asafo Flags',
-          text: '<p>Prior to the colonial era, asafo companies were charged with the safety and protection of the region. Surviving a century of violence and upheaval, they remain one of the core local institutions.</p>',
-          articleByline2: '2022-03-09T15:17:00-08:00',
-          startDate: '2023-01-04T00:00',
-          endDate: '2023-03-05T00:00',
-          heroImage: [
-            {
-              id: '9068',
-              image: [
-                {
-                  id: '63048',
-                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/flag_2022-11-23-012414_fjms.jpg',
-                  height: 1703,
-                  width: 2560,
-                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/flag_2022-11-23-012414_fjms.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/flag_2022-11-23-012414_fjms.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/flag_2022-11-23-012414_fjms.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/flag_2022-11-23-012414_fjms.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/flag_2022-11-23-012414_fjms.jpg 2560w',
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 2560w",
                   alt: null,
-                  focalPoint: [0.5, 0.5],
-                },
-              ],
-            },
-          ],
-        },
-      ],
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
-      id: '696270',
-      typeHandle: 'internalContent',
+      id: "4988977",
+      typeHandle: "internalContent",
       contentLink: [
         {
-          id: '36092',
-          contentType: 'article',
-          to: 'about/news/casper-the-ghost',
-          title: 'Casper the Ghost',
-          text: '<p>He is a pleasant, personable and translucent <a href="https://en.wikipedia.org/wiki/Ghost" title="Ghost" target="_blank" rel="noreferrer noopener">ghost</a>, but often criticized by his three wicked uncles, <a href="https://en.wikipedia.org/wiki/The_Ghostly_Trio" class="mw-redirect" title="The Ghostly Trio" target="_blank" rel="noreferrer noopener">the Ghostly Trio</a>.<br /></p>',
-          articleCategory: [],
-          articleByline2: '2022-09-13T15:06:00-07:00',
+          id: "50864",
+          contentType: "workshopOrEventSeries",
+          to: "visit/events-exhibitions/test-event-series",
+          title: "Test - Event Series - Side Pie",
+          text: "<p>Started in a Side Yard in a Pandemic. Our goals are simple: to bring the best pizza to the neighborhood and give back to the community. We love Altadena, we love pizza.</p>",
+          articleByline2: "2022-10-31T16:11:00-07:00",
+          ongoing: false,
+          startDate: "2022-11-17T00:00",
+          endDate: "2022-11-30T00:00",
+          associatedLocations: [
+            {
+              id: "801",
+              title: "Charles E. Young Research Library",
+              to: "visit/locations/research-library",
+              uri: "visit/locations/research-library"
+            }
+          ],
+          heroImage: [
+            {
+              id: "60178",
+              image: [
+                {
+                  id: "59935",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/SidePie20220278_470x.webp",
+                  height: 1026,
+                  width: 2560,
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/SidePie20220278_470x.webp 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/SidePie20220278_470x.webp 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/SidePie20220278_470x.webp 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/SidePie20220278_470x.webp 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/SidePie20220278_470x.webp 2560w",
+                  alt: "color photograph of beige tshirt with side pie text",
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+export const mockInternalContentArticleAndExternalArticle = {
+  id: "4988978",
+  typeHandle: "highlight",
+  sectionTitle: "Highlight with Internal Content - Article & External Article",
+  sectionSummary: null,
+  highlight: [
+    {
+      id: "4988979",
+      typeHandle: "internalContent",
+      contentLink: [
+        {
+          id: "2930588",
+          contentType: "article",
+          to: "about/news/test-article-squirrel-guinea-pig-garden-in-japan",
+          title: "Test - Article - Squirrel & Guinea Pig Garden in Japan",
+          text: "<p><strong>Behold wild squirrel </strong>and guinea pig feeding frenzies at the Squirrel Garden petting zoo in Machida, Japan. These hunger-crazed rodents feverishly feasted on top-notch chow with buckwild enthusiasm.</p>",
+          articleCategory: [
+            {
+              title: "Featured"
+            }
+          ],
+          articleByline2: "2024-03-22T15:21:00-07:00",
+          associatedLocations: [
+            {
+              id: "11560",
+              title: "Eugene and Maxine Rosenfeld Management Library",
+              to: "visit/locations/management-library-eugene-maxine-rosenfeld",
+              uri: "visit/locations/management-library-eugene-maxine-rosenfeld"
+            }
+          ],
+          heroImage: [
+            {
+              id: "2930589",
+              image: [
+                {
+                  id: "2930586",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg",
+                  height: 1953,
+                  width: 2560,
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 2560w",
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: "4988980",
+      typeHandle: "internalContent",
+      contentLink: [
+        {
+          id: "4981833",
+          contentType: "externalArticle",
+          to: "https://www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2",
+          title: "Water Polo",
+          text: "<p>New External Article field. A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>",
+          articleCategory: [
+            {
+              title: "Sports"
+            }
+          ],
+          articleByline2: "2026-06-26T14:32:00-07:00",
           associatedLocations: [],
           heroImage: [
             {
-              id: '49470',
+              id: "4981836",
               image: [
                 {
-                  id: '49469',
-                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Casper.png',
-                  height: 2225,
+                  id: "4981835",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/water-polo-1.jpg",
+                  height: 1358,
                   width: 2560,
-                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Casper.png 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Casper.png 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Casper.png 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Casper.png 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Casper.png 2560w',
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/water-polo-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/water-polo-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/water-polo-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/water-polo-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/water-polo-1.jpg 2560w",
                   alt: null,
-                  focalPoint: [0.5, 0.5],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    },
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+export const mockInternalContentEndowmentAndCollectionAndGeneralContentPage = {
+  id: "4988566",
+  typeHandle: "highlight",
+  sectionTitle: "Highlight with Internal Content - Endowment, Collection, General Content Page",
+  sectionSummary: null,
+  highlight: [
     {
-      id: '707393',
-      typeHandle: 'internalContent',
+      id: "4988567",
+      typeHandle: "internalContent",
       contentLink: [
         {
-          id: '50864',
-          contentType: 'workshopOrEventSeries',
-          to: 'visit/events-exhibitions/test-event-series',
-          title: 'Test Event Series: Side Pie',
-          text: '<p>Started in a Side Yard in a Pandemic. Our goals are simple: to bring the best pizza to the neighborhood and give back to the community. We love Altadena, we love pizza. <br /></p>',
-          articleByline2: '2022-10-31T16:11:00-07:00',
-          startDate: '2022-11-17T00:00',
-          endDate: '2022-11-30T00:00',
+          id: "75052",
+          contentType: "endowment",
+          to: "give/endowments/the-jen-diane-living-memorial-endowment",
+          title: "Endowment The Jen & Diane Living Memorial",
+          text: "<p><strong>Jen and Diane want</strong> everyone to have as many stuffed animals as they need to make them happy. This fund will allow recipients to purchase as many stuff animals as they want in one fiscal year.</p>",
+          articleByline2: "2022-12-06T16:05:00-08:00",
           associatedLocations: [
             {
-              id: '801',
-              title: 'Charles E. Young Research Library',
-              to: 'visit/locations/young-research-library',
+              id: "801",
+              title: "Charles E. Young Research Library",
+              to: "visit/locations/research-library",
+              uri: "visit/locations/research-library"
             },
+            {
+              id: "11602",
+              title: "UCLA Library Special Collections",
+              to: "visit/locations/library-special-collections",
+              uri: "visit/locations/library-special-collections"
+            }
           ],
           heroImage: [
             {
-              id: '60178',
+              id: "75081",
               image: [
                 {
-                  id: '59935',
-                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/SidePie20220278_470x.webp',
-                  height: 1026,
+                  id: "75076",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Animals-1-pick.jpg",
+                  height: 2560,
                   width: 2560,
-                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/SidePie20220278_470x.webp 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/SidePie20220278_470x.webp 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/SidePie20220278_470x.webp 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/SidePie20220278_470x.webp 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/SidePie20220278_470x.webp 2560w',
-                  alt: 'color photograph of beige tshirt with side pie text',
-                  focalPoint: [0.5, 0.5],
-                },
-              ],
-            },
-          ],
-        },
-      ],
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Animals-1-pick.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Animals-1-pick.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Animals-1-pick.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Animals-1-pick.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Animals-1-pick.jpg 2560w",
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
-  ],
+    {
+      id: "4988568",
+      typeHandle: "internalContent",
+      contentLink: [
+        {
+          id: "796386",
+          contentType: "collection",
+          to: "collections/explore/spools",
+          title: "Spools are so interesting",
+          text: "<p>A cylindrical device on which film, magnetic tape, thread, or other flexible materials can be wound; a reel.</p>",
+          articleByline2: "2023-02-03T01:08:00-08:00",
+          heroImage: [
+            {
+              id: "796389",
+              image: [
+                {
+                  id: "796388",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Screen-Shot-2023-02-03-at-1.10.27-AM.png",
+                  height: 1396,
+                  width: 2560,
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 2560w",
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: "4988569",
+      typeHandle: "internalContent",
+      contentLink: [
+        {
+          id: "6333",
+          contentType: "generalContentPage",
+          to: "get-help",
+          title: "Get Help",
+          text: null,
+          articleByline2: "2022-03-01T09:56:00-08:00",
+          heroImage: []
+        }
+      ]
+    }
+  ]
+}
+
+export const mockInternalContentMeapArticleAndProject = {
+  id: "4988192",
+  typeHandle: "highlight",
+  sectionTitle: "Highlight with MEAP Internal Content - Article & Project",
+  sectionSummary: null,
+  highlight: [
+    {
+      id: "4988193",
+      typeHandle: "internalContent",
+      contentLink: [
+        {
+          id: "4848315",
+          contentType: "meapArticle",
+          to: "about/news/meap-collections-surpass-100-000-objects",
+          title: "MEAP Collections Surpass 100,000 Objects",
+          text: "<p>The MEAP Digital Collection now includes over 100,000 unique objects from 44 collections, including materials from 27 countries around the world.</p>",
+          articleCategory: [
+            {
+              title: "MEAP Internal Content MEAP Article"
+            }
+          ],
+          articleByline2: "2026-04-14T19:15:00-07:00",
+          heroImage: [
+            {
+              id: "4848316",
+              image: [
+                {
+                  id: "4848238",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Bell_image.jpg",
+                  height: 2048,
+                  width: 2560,
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Bell_image.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Bell_image.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Bell_image.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Bell_image.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Bell_image.jpg 2560w",
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: "4988194",
+      typeHandle: "internalContent",
+      contentLink: [
+        {
+          id: "4848159",
+          contentType: "meapProject",
+          to: "projects/visual-histories-of-northeast-india",
+          title: "Visual Histories of Northeast India - MEAP Project",
+          text: "<p>Digitization of photographs from the archive of Ahmed Hossain, following a successful survey the collection. Photographs depict the socio-cultural life of Northeast Indias tribal communities (1960s - 2000s).</p>",
+          projectCategory: null,
+          projectByline1: [
+            {
+              id: "4848109",
+              title: "Indigenous Communities"
+            },
+            {
+              id: "4848158",
+              title: "Photography"
+            }
+          ],
+          articleByline2: "2026-04-14T18:37:00-07:00",
+          projectLocations: [
+            {
+              id: "4848157",
+              title: "South Asia"
+            }
+          ],
+          heroImage: [
+            {
+              id: "4848160",
+              image: [
+                {
+                  id: "4848156",
+                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/0015_1_edit_2026-04-15-013308_miyg.jpg",
+                  height: 1862,
+                  width: 2560,
+                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 2560w",
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+export const mockExternalContent = {
+    id: "4988981",
+  typeHandle: "highlight",
+  sectionTitle: "Highlight with External Content",
+  sectionSummary: null,
+  highlight: [
+    {
+      id: "4988982",
+      typeHandle: "externalContent",
+      title: "Lady Liberty - External Content",
+      image: [
+        {
+          id: "4988815",
+          src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg",
+          height: 3681,
+          width: 2560,
+          srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 2560w",
+          alt: null,
+          focalPoint: [
+            0.5,
+            0.5
+          ]
+        }
+      ],
+      byline1: "February 23, 2028",
+      byline2: "7:00 P.M.",
+      category: "External Content",
+      text: "<p>Give me your tired, your poor Your huddled masses yearning to breathe free The wretched refuse of your teeming shore. Send these, the homeless, tempest-tost to me I lift my lamp beside the golden door</p>",
+      to: "https://www.nps.gov/stli/index.htm"
+    },
+    {
+      id: "4988983",
+      typeHandle: "externalContent",
+      title: "Swizzle Sticks",
+      image: [
+        {
+          id: "4988918",
+          src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/twizzle.jpg",
+          height: 1920,
+          width: 2560,
+          srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/twizzle.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/twizzle.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/twizzle.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/twizzle.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/twizzle.jpg 2560w",
+          alt: null,
+          focalPoint: [
+            0.5,
+            0.5
+          ]
+        }
+      ],
+      byline1: null,
+      byline2: null,
+      category: "External Content",
+      text: "<p>A <strong>swizzle stick</strong> is a small utensil used to stir drinks.</p>",
+      to: "https://marisafinetti.com/blog/stirring-with-vintage-swizzle-sticks/"
+    }
+  ]
 }

--- a/packages/vue-component-library/src/stories/mock/Flexible_Highlight.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_Highlight.js
@@ -16,7 +16,7 @@ export const mock = {
           text: '<p><strong>La Niña</strong> is an <em>oceanic and atmospheric phenomenon</em> that is the colder counterpart of El Niño, as part of the broader El Niño–Southern Oscillation climate pattern.</p>',
           articleCategory: [
             {
-              title: 'Featured Internal Content',
+              title: 'Internal Content Article',
             },
           ],
           articleByline1: [
@@ -76,7 +76,7 @@ export const mock = {
           text: '<p><strong>Shortbread</strong> or shortie is a traditional <a href="https://www.scotchandscones.com/shortbread-history/">Scottish biscuit</a> usually made from <em>one part white sugar</em>, two parts butter, and three to four parts plain wheat flour.</p>',
           articleCategory: [
             {
-              title: 'Featured External Content',
+              title: 'Internal Content Article',
             },
           ],
           articleByline1: [
@@ -136,26 +136,28 @@ export const mock = {
       to: 'https://www.cinema.ucla.edu/blogs/archive-blog/2022/01/31/pandemic-spurs-virtual-screening-room',
     },
     {
-      id: '27384',
+      id: '4987907',
       typeHandle: 'externalContent',
-      title: 'Mmmmm Shortbread',
+      title: 'Lady Liberty - External Content',
       image: [
         {
-          id: '26803',
-          src: 'https://static.library.ucla.edu/craftassetstest/shortbread-cookies.jpg',
-          height: 1421,
+          id: '4987902',
+          src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/statue_of_liberty_3_poster.jpg',
+          height: 3681,
           width: 2560,
-          srcset: 'https://static.library.ucla.edu/craftassetstest/_375xAUTO_crop_center-center_none/shortbread-cookies.jpg 375w, https://static.library.ucla.edu/craftassetstest/_960xAUTO_crop_center-center_none/shortbread-cookies.jpg 960w, https://static.library.ucla.edu/craftassetstest/_1280xAUTO_crop_center-center_none/shortbread-cookies.jpg 1280w, https://static.library.ucla.edu/craftassetstest/_1920xAUTO_crop_center-center_none/shortbread-cookies.jpg 1920w, https://static.library.ucla.edu/craftassetstest/_2560xAUTO_crop_center-center_none/shortbread-cookies.jpg 2560w',
-          alt: 'Kids',
-          focalPoint: [0.5, 0.5],
-          altText: null,
-        },
+          srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/statue_of_liberty_3_poster.jpg 2560w',
+          alt: null,
+          focalPoint: [
+            0.5,
+            0.5
+          ]
+        }
       ],
-      byline1: 'Ashton Prigge',
-      byline2: null,
+      byline1: 'February 23, 2028',
+      byline2: '7:00 P.M.',
       category: 'External Content',
-      location: null,
-      text: null,
+      text: '<p>Give me your tired, your poor Your huddled masses yearning to breathe free The wretched refuse of your teeming shore. Send these, the homeless, tempest-tost to me I lift my lamp beside the golden door</p>',
+      to: 'https://www.nps.gov/stli/index.htm'
     },
     {
       id: '28621',
@@ -164,10 +166,10 @@ export const mock = {
         {
           id: '25318',
           contentType: 'meapProject',
-          to: 'meap/projects/argentinean-human-rights-digital-library-of-periodical-and-non-periodical-publications',
+          to: 'projects/argentinean-human-rights-digital-library-of-periodical-and-non-periodical-publications',
           title: 'Argentinean Human Rights Digital Library of Periodical and Non-periodical Publications',
           text: '<p><a href="https://www.cinema.ucla.edu/billy-wilder-theater">Memoria Abierta</a> is an <strong>alliance</strong> of nine Argentinean <em>human rights</em> organizations. Most of them were created during the last dictatorship (1976-1983) to denounce the violations committed during that period and to support relatives and victims. The Argentinean human rights movement, with its innovative strategies to fight oblivion and achieve justice, is known worldwide and referenced by other countries where human rights crimes have been or are being committed.</p>',
-          projectCategory: 'Publications',
+          projectCategory: 'Internal Content MEAP Projects',
           projectByline1: [
             {
               id: '25325',
@@ -200,6 +202,52 @@ export const mock = {
           ],
         },
       ],
+    },
+    {
+      id: '4986534',
+      typeHandle: 'internalContent',
+      contentLink: [
+        {
+          id: '4980208',
+          contentType: 'externalArticle',
+          to: 'https://www.hawaiimagazine.com/worlds-best-tandem-surfers-compete-at-waikiki-beach',
+          title: 'Gymnastics & Surfing',
+          text: '<p>New External Article field. Gymnasts possess core strength, balance, and aerial awareness, while surfers movements combine flexibility with cardiovascular endurance.</p>',
+          articleCategory: [
+            {
+              title: 'Internal Content External Article'
+            }
+          ],
+          articleByline2: '2026-06-23T15:48:00-07:00',
+          associatedLocations: [
+            {
+              id: '523',
+              title: 'Powell Library',
+              to: 'visit/locations/powell-library',
+              uri: 'visit/locations/powell-library'
+            }
+          ],
+          heroImage: [
+            {
+              id: '4980211',
+              image: [
+                {
+                  id: '4980210',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Gymnastics-Surfing.jpeg',
+                  height: 1278,
+                  width: 2560,
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Gymnastics-Surfing.jpeg 2560w',
+                  alt: null,
+                  focalPoint: [
+                    0.5,
+                    0.5
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
   ],
 }

--- a/packages/vue-component-library/src/stories/mock/Flexible_Highlight.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_Highlight.js
@@ -1,40 +1,40 @@
 export const mockInternalContentEventAndExhibition = {
-  id: "4980101",
-  typeHandle: "highlight",
-  sectionTitle: "Highlight with Internal Content - Event  & Exhibition",
+  id: '4980101',
+  typeHandle: 'highlight',
+  sectionTitle: 'Highlight with Internal Content - Event  & Exhibition',
   sectionSummary: null,
   highlight: [
     {
-      id: "4980102",
-      typeHandle: "internalContent",
+      id: '4980102',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "4720385",
-          contentType: "event",
-          to: "visit/events-exhibitions/the-cultural-politics-of-eddie-murphy-coming-to-america-04-04-26",
-          title: "The Cultural Politics of Eddie Murphy: Coming to America 04-20-26",
+          id: '4720385',
+          contentType: 'event',
+          to: 'visit/events-exhibitions/the-cultural-politics-of-eddie-murphy-coming-to-america-04-04-26',
+          title: 'The Cultural Politics of Eddie Murphy: Coming to America 04-20-26',
           text: null,
-          eventDescription: "<p>Eddie Murphy stands at the center of the Black Pack as Prince Akeem, heir to the throne of Zamunda, who leaves royal luxury for Queens, New York, in search of love on his own terms.</p>",
-          articleByline2: "2026-02-20T13:45:00-08:00",
-          startDateWithTime: "2026-04-20T19:30",
-          endDateWithTime: "2026-04-20T21:30",
+          eventDescription: '<p>Eddie Murphy stands at the center of the Black Pack as Prince Akeem, heir to the throne of Zamunda, who leaves royal luxury for Queens, New York, in search of love on his own terms.</p>',
+          articleByline2: '2026-02-20T13:45:00-08:00',
+          startDateWithTime: '2026-04-20T19:30',
+          endDateWithTime: '2026-04-20T21:30',
           eventType: [
             {
-              id: "50396",
-              title: "Screening"
+              id: '50396',
+              title: 'Screening'
             }
           ],
           associatedLocations: [],
           heroImage: [
             {
-              id: "4989273",
+              id: '4989273',
               image: [
                 {
-                  id: "4989272",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/coming2america.jpg",
+                  id: '4989272',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/coming2america.jpg',
                   height: 2560,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/coming2america.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/coming2america.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/coming2america.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/coming2america.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/coming2america.jpg 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/coming2america.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/coming2america.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/coming2america.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/coming2america.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/coming2america.jpg 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -48,29 +48,29 @@ export const mockInternalContentEventAndExhibition = {
       ]
     },
     {
-      id: "4980103",
-      typeHandle: "internalContent",
+      id: '4980103',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "4981311",
-          contentType: "exhibition",
-          to: "visit/events-exhibitions/ucla-library-special-collections",
-          title: "UCLA Library Special Collections",
-          text: "<p>Open to all, UCLA Library Special Collections (LSC) preserves, shares and promotes the Librarys unique primary sources.</p>",
-          articleByline2: "2026-06-25T16:22:00-07:00",
+          id: '4981311',
+          contentType: 'exhibition',
+          to: 'visit/events-exhibitions/ucla-library-special-collections',
+          title: 'UCLA Library Special Collections',
+          text: '<p>Open to all, UCLA Library Special Collections (LSC) preserves, shares and promotes the Librarys unique primary sources.</p>',
+          articleByline2: '2026-06-25T16:22:00-07:00',
           ongoing: false,
           startDate: null,
           endDate: null,
           heroImage: [
             {
-              id: "4981312",
+              id: '4981312',
               image: [
                 {
-                  id: "4981310",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/UCLA_LibraryLocations_LSC-1.jpg",
+                  id: '4981310',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/UCLA_LibraryLocations_LSC-1.jpg',
                   height: 1124,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/UCLA_LibraryLocations_LSC-1.jpg 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -87,43 +87,43 @@ export const mockInternalContentEventAndExhibition = {
 }
 
 export const mockInternalContentWorshopSeriesAndEventSeries = {
-  id: "4988975",
-  typeHandle: "highlight",
-  sectionTitle: "Highlight with Internal Content - Worshop Series & Event Series",
+  id: '4988975',
+  typeHandle: 'highlight',
+  sectionTitle: 'Highlight with Internal Content - Worshop Series & Event Series',
   sectionSummary: null,
   highlight: [
     {
-      id: "4988976",
-      typeHandle: "internalContent",
+      id: '4988976',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "197039",
-          contentType: "workshopOrEventSeries",
-          to: "help/services-resources/family-flicks",
-          title: "Test - Workshop - Family Flicks",
-          text: "<p>All <strong>Family Flicks</strong> screenings are <em>free admission</em>. An incorrigible squirrel helps his friends raid a nut store, a location that also happens to be a front for a human gangs bank robbery.</p>",
-          articleByline2: "2022-12-19T07:44:00-08:00",
+          id: '197039',
+          contentType: 'workshopOrEventSeries',
+          to: 'help/services-resources/family-flicks',
+          title: 'Test - Workshop - Family Flicks',
+          text: '<p>All <strong>Family Flicks</strong> screenings are <em>free admission</em>. An incorrigible squirrel helps his friends raid a nut store, a location that also happens to be a front for a human gangs bank robbery.</p>',
+          articleByline2: '2022-12-19T07:44:00-08:00',
           ongoing: true,
-          startDate: "1967-10-09T00:00",
-          endDate: "2002-04-19T00:00",
+          startDate: '1967-10-09T00:00',
+          endDate: '2002-04-19T00:00',
           associatedLocations: [
             {
-              id: "11612",
-              title: "UCLA Film & Television Archive",
-              to: "visit/locations/film-television-archive",
-              uri: "visit/locations/film-television-archive"
+              id: '11612',
+              title: 'UCLA Film & Television Archive',
+              to: 'visit/locations/film-television-archive',
+              uri: 'visit/locations/film-television-archive'
             }
           ],
           heroImage: [
             {
-              id: "2930538",
+              id: '2930538',
               image: [
                 {
-                  id: "2930537",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Screenshot-2024-03-22-at-3.07.33-PM.png",
+                  id: '2930537',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Screenshot-2024-03-22-at-3.07.33-PM.png',
                   height: 1391,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Screenshot-2024-03-22-at-3.07.33-PM.png 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -137,38 +137,38 @@ export const mockInternalContentWorshopSeriesAndEventSeries = {
       ]
     },
     {
-      id: "4988977",
-      typeHandle: "internalContent",
+      id: '4988977',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "50864",
-          contentType: "workshopOrEventSeries",
-          to: "visit/events-exhibitions/test-event-series",
-          title: "Test - Event Series - Side Pie",
-          text: "<p>Started in a Side Yard in a Pandemic. Our goals are simple: to bring the best pizza to the neighborhood and give back to the community. We love Altadena, we love pizza.</p>",
-          articleByline2: "2022-10-31T16:11:00-07:00",
+          id: '50864',
+          contentType: 'workshopOrEventSeries',
+          to: 'visit/events-exhibitions/test-event-series',
+          title: 'Test - Event Series - Side Pie',
+          text: '<p>Started in a Side Yard in a Pandemic. Our goals are simple: to bring the best pizza to the neighborhood and give back to the community. We love Altadena, we love pizza.</p>',
+          articleByline2: '2022-10-31T16:11:00-07:00',
           ongoing: false,
-          startDate: "2022-11-17T00:00",
-          endDate: "2022-11-30T00:00",
+          startDate: '2022-11-17T00:00',
+          endDate: '2022-11-30T00:00',
           associatedLocations: [
             {
-              id: "801",
-              title: "Charles E. Young Research Library",
-              to: "visit/locations/research-library",
-              uri: "visit/locations/research-library"
+              id: '801',
+              title: 'Charles E. Young Research Library',
+              to: 'visit/locations/research-library',
+              uri: 'visit/locations/research-library'
             }
           ],
           heroImage: [
             {
-              id: "60178",
+              id: '60178',
               image: [
                 {
-                  id: "59935",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/SidePie20220278_470x.webp",
+                  id: '59935',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/SidePie20220278_470x.webp',
                   height: 1026,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/SidePie20220278_470x.webp 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/SidePie20220278_470x.webp 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/SidePie20220278_470x.webp 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/SidePie20220278_470x.webp 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/SidePie20220278_470x.webp 2560w",
-                  alt: "color photograph of beige tshirt with side pie text",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/SidePie20220278_470x.webp 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/SidePie20220278_470x.webp 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/SidePie20220278_470x.webp 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/SidePie20220278_470x.webp 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/SidePie20220278_470x.webp 2560w',
+                  alt: 'color photograph of beige tshirt with side pie text',
                   focalPoint: [
                     0.5,
                     0.5
@@ -184,45 +184,45 @@ export const mockInternalContentWorshopSeriesAndEventSeries = {
 }
 
 export const mockInternalContentArticleAndExternalArticle = {
-  id: "4988978",
-  typeHandle: "highlight",
-  sectionTitle: "Highlight with Internal Content - Article & External Article",
+  id: '4988978',
+  typeHandle: 'highlight',
+  sectionTitle: 'Highlight with Internal Content - Article & External Article',
   sectionSummary: null,
   highlight: [
     {
-      id: "4988979",
-      typeHandle: "internalContent",
+      id: '4988979',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "2930588",
-          contentType: "article",
-          to: "about/news/test-article-squirrel-guinea-pig-garden-in-japan",
-          title: "Test - Article - Squirrel & Guinea Pig Garden in Japan",
-          text: "<p><strong>Behold wild squirrel </strong>and guinea pig feeding frenzies at the Squirrel Garden petting zoo in Machida, Japan. These hunger-crazed rodents feverishly feasted on top-notch chow with buckwild enthusiasm.</p>",
+          id: '2930588',
+          contentType: 'article',
+          to: 'about/news/test-article-squirrel-guinea-pig-garden-in-japan',
+          title: 'Test - Article - Squirrel & Guinea Pig Garden in Japan',
+          text: '<p><strong>Behold wild squirrel </strong>and guinea pig feeding frenzies at the Squirrel Garden petting zoo in Machida, Japan. These hunger-crazed rodents feverishly feasted on top-notch chow with buckwild enthusiasm.</p>',
           articleCategory: [
             {
-              title: "Featured"
+              title: 'Featured'
             }
           ],
-          articleByline2: "2024-03-22T15:21:00-07:00",
+          articleByline2: '2024-03-22T15:21:00-07:00',
           associatedLocations: [
             {
-              id: "11560",
-              title: "Eugene and Maxine Rosenfeld Management Library",
-              to: "visit/locations/management-library-eugene-maxine-rosenfeld",
-              uri: "visit/locations/management-library-eugene-maxine-rosenfeld"
+              id: '11560',
+              title: 'Eugene and Maxine Rosenfeld Management Library',
+              to: 'visit/locations/management-library-eugene-maxine-rosenfeld',
+              uri: 'visit/locations/management-library-eugene-maxine-rosenfeld'
             }
           ],
           heroImage: [
             {
-              id: "2930589",
+              id: '2930589',
               image: [
                 {
-                  id: "2930586",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg",
+                  id: '2930586',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg',
                   height: 1953,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/guinea-pi-squirrel_2024-03-22-221716_nvfk.jpeg 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -236,32 +236,32 @@ export const mockInternalContentArticleAndExternalArticle = {
       ]
     },
     {
-      id: "4988980",
-      typeHandle: "internalContent",
+      id: '4988980',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "4981833",
-          contentType: "externalArticle",
-          to: "https://www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2",
-          title: "Water Polo",
-          text: "<p>New External Article field. A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>",
+          id: '4981833',
+          contentType: 'externalArticle',
+          to: 'https://www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2',
+          title: 'Water Polo',
+          text: '<p>New External Article field. A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>',
           articleCategory: [
             {
-              title: "Sports"
+              title: 'Sports'
             }
           ],
-          articleByline2: "2026-06-26T14:32:00-07:00",
+          articleByline2: '2026-06-26T14:32:00-07:00',
           associatedLocations: [],
           heroImage: [
             {
-              id: "4981836",
+              id: '4981836',
               image: [
                 {
-                  id: "4981835",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/water-polo-1.jpg",
+                  id: '4981835',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/water-polo-1.jpg',
                   height: 1358,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/water-polo-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/water-polo-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/water-polo-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/water-polo-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/water-polo-1.jpg 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/water-polo-1.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/water-polo-1.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/water-polo-1.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/water-polo-1.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/water-polo-1.jpg 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -278,46 +278,46 @@ export const mockInternalContentArticleAndExternalArticle = {
 }
 
 export const mockInternalContentEndowmentAndCollectionAndGeneralContentPage = {
-  id: "4988566",
-  typeHandle: "highlight",
-  sectionTitle: "Highlight with Internal Content - Endowment, Collection, General Content Page",
+  id: '4988566',
+  typeHandle: 'highlight',
+  sectionTitle: 'Highlight with Internal Content - Endowment, Collection, General Content Page',
   sectionSummary: null,
   highlight: [
     {
-      id: "4988567",
-      typeHandle: "internalContent",
+      id: '4988567',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "75052",
-          contentType: "endowment",
-          to: "give/endowments/the-jen-diane-living-memorial-endowment",
-          title: "Endowment The Jen & Diane Living Memorial",
-          text: "<p><strong>Jen and Diane want</strong> everyone to have as many stuffed animals as they need to make them happy. This fund will allow recipients to purchase as many stuff animals as they want in one fiscal year.</p>",
-          articleByline2: "2022-12-06T16:05:00-08:00",
+          id: '75052',
+          contentType: 'endowment',
+          to: 'give/endowments/the-jen-diane-living-memorial-endowment',
+          title: 'Endowment The Jen & Diane Living Memorial',
+          text: '<p><strong>Jen and Diane want</strong> everyone to have as many stuffed animals as they need to make them happy. This fund will allow recipients to purchase as many stuff animals as they want in one fiscal year.</p>',
+          articleByline2: '2022-12-06T16:05:00-08:00',
           associatedLocations: [
             {
-              id: "801",
-              title: "Charles E. Young Research Library",
-              to: "visit/locations/research-library",
-              uri: "visit/locations/research-library"
+              id: '801',
+              title: 'Charles E. Young Research Library',
+              to: 'visit/locations/research-library',
+              uri: 'visit/locations/research-library'
             },
             {
-              id: "11602",
-              title: "UCLA Library Special Collections",
-              to: "visit/locations/library-special-collections",
-              uri: "visit/locations/library-special-collections"
+              id: '11602',
+              title: 'UCLA Library Special Collections',
+              to: 'visit/locations/library-special-collections',
+              uri: 'visit/locations/library-special-collections'
             }
           ],
           heroImage: [
             {
-              id: "75081",
+              id: '75081',
               image: [
                 {
-                  id: "75076",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Animals-1-pick.jpg",
+                  id: '75076',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Animals-1-pick.jpg',
                   height: 2560,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Animals-1-pick.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Animals-1-pick.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Animals-1-pick.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Animals-1-pick.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Animals-1-pick.jpg 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Animals-1-pick.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Animals-1-pick.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Animals-1-pick.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Animals-1-pick.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Animals-1-pick.jpg 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -331,26 +331,26 @@ export const mockInternalContentEndowmentAndCollectionAndGeneralContentPage = {
       ]
     },
     {
-      id: "4988568",
-      typeHandle: "internalContent",
+      id: '4988568',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "796386",
-          contentType: "collection",
-          to: "collections/explore/spools",
-          title: "Spools are so interesting",
-          text: "<p>A cylindrical device on which film, magnetic tape, thread, or other flexible materials can be wound; a reel.</p>",
-          articleByline2: "2023-02-03T01:08:00-08:00",
+          id: '796386',
+          contentType: 'collection',
+          to: 'collections/explore/spools',
+          title: 'Spools are so interesting',
+          text: '<p>A cylindrical device on which film, magnetic tape, thread, or other flexible materials can be wound; a reel.</p>',
+          articleByline2: '2023-02-03T01:08:00-08:00',
           heroImage: [
             {
-              id: "796389",
+              id: '796389',
               image: [
                 {
-                  id: "796388",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Screen-Shot-2023-02-03-at-1.10.27-AM.png",
+                  id: '796388',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Screen-Shot-2023-02-03-at-1.10.27-AM.png',
                   height: 1396,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Screen-Shot-2023-02-03-at-1.10.27-AM.png 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -364,16 +364,16 @@ export const mockInternalContentEndowmentAndCollectionAndGeneralContentPage = {
       ]
     },
     {
-      id: "4988569",
-      typeHandle: "internalContent",
+      id: '4988569',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "6333",
-          contentType: "generalContentPage",
-          to: "get-help",
-          title: "Get Help",
+          id: '6333',
+          contentType: 'generalContentPage',
+          to: 'get-help',
+          title: 'Get Help',
           text: null,
-          articleByline2: "2022-03-01T09:56:00-08:00",
+          articleByline2: '2022-03-01T09:56:00-08:00',
           heroImage: []
         }
       ]
@@ -382,37 +382,37 @@ export const mockInternalContentEndowmentAndCollectionAndGeneralContentPage = {
 }
 
 export const mockInternalContentMeapArticleAndProject = {
-  id: "4988192",
-  typeHandle: "highlight",
-  sectionTitle: "Highlight with MEAP Internal Content - Article & Project",
+  id: '4988192',
+  typeHandle: 'highlight',
+  sectionTitle: 'Highlight with MEAP Internal Content - Article & Project',
   sectionSummary: null,
   highlight: [
     {
-      id: "4988193",
-      typeHandle: "internalContent",
+      id: '4988193',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "4848315",
-          contentType: "meapArticle",
-          to: "about/news/meap-collections-surpass-100-000-objects",
-          title: "MEAP Collections Surpass 100,000 Objects",
-          text: "<p>The MEAP Digital Collection now includes over 100,000 unique objects from 44 collections, including materials from 27 countries around the world.</p>",
+          id: '4848315',
+          contentType: 'meapArticle',
+          to: 'about/news/meap-collections-surpass-100-000-objects',
+          title: 'MEAP Collections Surpass 100,000 Objects',
+          text: '<p>The MEAP Digital Collection now includes over 100,000 unique objects from 44 collections, including materials from 27 countries around the world.</p>',
           articleCategory: [
             {
-              title: "MEAP Internal Content MEAP Article"
+              title: 'MEAP Internal Content MEAP Article'
             }
           ],
-          articleByline2: "2026-04-14T19:15:00-07:00",
+          articleByline2: '2026-04-14T19:15:00-07:00',
           heroImage: [
             {
-              id: "4848316",
+              id: '4848316',
               image: [
                 {
-                  id: "4848238",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Bell_image.jpg",
+                  id: '4848238',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/Bell_image.jpg',
                   height: 2048,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Bell_image.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Bell_image.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Bell_image.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Bell_image.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Bell_image.jpg 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/Bell_image.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/Bell_image.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/Bell_image.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/Bell_image.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/Bell_image.jpg 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -426,43 +426,43 @@ export const mockInternalContentMeapArticleAndProject = {
       ]
     },
     {
-      id: "4988194",
-      typeHandle: "internalContent",
+      id: '4988194',
+      typeHandle: 'internalContent',
       contentLink: [
         {
-          id: "4848159",
-          contentType: "meapProject",
-          to: "projects/visual-histories-of-northeast-india",
-          title: "Visual Histories of Northeast India - MEAP Project",
-          text: "<p>Digitization of photographs from the archive of Ahmed Hossain, following a successful survey the collection. Photographs depict the socio-cultural life of Northeast Indias tribal communities (1960s - 2000s).</p>",
+          id: '4848159',
+          contentType: 'meapProject',
+          to: 'projects/visual-histories-of-northeast-india',
+          title: 'Visual Histories of Northeast India - MEAP Project',
+          text: '<p>Digitization of photographs from the archive of Ahmed Hossain, following a successful survey the collection. Photographs depict the socio-cultural life of Northeast Indias tribal communities (1960s - 2000s).</p>',
           projectCategory: null,
           projectByline1: [
             {
-              id: "4848109",
-              title: "Indigenous Communities"
+              id: '4848109',
+              title: 'Indigenous Communities'
             },
             {
-              id: "4848158",
-              title: "Photography"
+              id: '4848158',
+              title: 'Photography'
             }
           ],
-          articleByline2: "2026-04-14T18:37:00-07:00",
+          articleByline2: '2026-04-14T18:37:00-07:00',
           projectLocations: [
             {
-              id: "4848157",
-              title: "South Asia"
+              id: '4848157',
+              title: 'South Asia'
             }
           ],
           heroImage: [
             {
-              id: "4848160",
+              id: '4848160',
               image: [
                 {
-                  id: "4848156",
-                  src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/0015_1_edit_2026-04-15-013308_miyg.jpg",
+                  id: '4848156',
+                  src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/0015_1_edit_2026-04-15-013308_miyg.jpg',
                   height: 1862,
                   width: 2560,
-                  srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 2560w",
+                  srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/0015_1_edit_2026-04-15-013308_miyg.jpg 2560w',
                   alt: null,
                   focalPoint: [
                     0.5,
@@ -479,22 +479,22 @@ export const mockInternalContentMeapArticleAndProject = {
 }
 
 export const mockExternalContent = {
-    id: "4988981",
-  typeHandle: "highlight",
-  sectionTitle: "Highlight with External Content",
+  id: '4988981',
+  typeHandle: 'highlight',
+  sectionTitle: 'Highlight with External Content',
   sectionSummary: null,
   highlight: [
     {
-      id: "4988982",
-      typeHandle: "externalContent",
-      title: "Lady Liberty - External Content",
+      id: '4988982',
+      typeHandle: 'externalContent',
+      title: 'Lady Liberty - External Content',
       image: [
         {
-          id: "4988815",
-          src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg",
+          id: '4988815',
+          src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg',
           height: 3681,
           width: 2560,
-          srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 2560w",
+          srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/statue_of_liberty_3_poster_2026-07-08-065430_fgvd.jpg 2560w',
           alt: null,
           focalPoint: [
             0.5,
@@ -502,23 +502,23 @@ export const mockExternalContent = {
           ]
         }
       ],
-      byline1: "February 23, 2028",
-      byline2: "7:00 P.M.",
-      category: "External Content",
-      text: "<p>Give me your tired, your poor Your huddled masses yearning to breathe free The wretched refuse of your teeming shore. Send these, the homeless, tempest-tost to me I lift my lamp beside the golden door</p>",
-      to: "https://www.nps.gov/stli/index.htm"
+      byline1: 'February 23, 2028',
+      byline2: '7:00 P.M.',
+      category: 'External Content',
+      text: '<p>Give me your tired, your poor Your huddled masses yearning to breathe free The wretched refuse of your teeming shore. Send these, the homeless, tempest-tost to me I lift my lamp beside the golden door</p>',
+      to: 'https://www.nps.gov/stli/index.htm'
     },
     {
-      id: "4988983",
-      typeHandle: "externalContent",
-      title: "Swizzle Sticks",
+      id: '4988983',
+      typeHandle: 'externalContent',
+      title: 'Swizzle Sticks',
       image: [
         {
-          id: "4988918",
-          src: "https://static.library.ucla.edu/craftassetstest/images/_fullscreen/twizzle.jpg",
+          id: '4988918',
+          src: 'https://static.library.ucla.edu/craftassetstest/images/_fullscreen/twizzle.jpg',
           height: 1920,
           width: 2560,
-          srcset: "https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/twizzle.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/twizzle.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/twizzle.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/twizzle.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/twizzle.jpg 2560w",
+          srcset: 'https://static.library.ucla.edu/craftassetstest/images/_375xAUTO_crop_center-center_none/twizzle.jpg 375w, https://static.library.ucla.edu/craftassetstest/images/_960xAUTO_crop_center-center_none/twizzle.jpg 960w, https://static.library.ucla.edu/craftassetstest/images/_1280xAUTO_crop_center-center_none/twizzle.jpg 1280w, https://static.library.ucla.edu/craftassetstest/images/_1920xAUTO_crop_center-center_none/twizzle.jpg 1920w, https://static.library.ucla.edu/craftassetstest/images/_2560xAUTO_crop_center-center_none/twizzle.jpg 2560w',
           alt: null,
           focalPoint: [
             0.5,
@@ -528,9 +528,9 @@ export const mockExternalContent = {
       ],
       byline1: null,
       byline2: null,
-      category: "External Content",
-      text: "<p>A <strong>swizzle stick</strong> is a small utensil used to stir drinks.</p>",
-      to: "https://marisafinetti.com/blog/stirring-with-vintage-swizzle-sticks/"
+      category: 'External Content',
+      text: '<p>A <strong>swizzle stick</strong> is a small utensil used to stir drinks.</p>',
+      to: 'https://marisafinetti.com/blog/stirring-with-vintage-swizzle-sticks/'
     }
   ]
 }

--- a/packages/vue-component-library/src/stories/mock/Flexible_SimpleCards.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_SimpleCards.js
@@ -82,6 +82,20 @@ export const mockFourCards = {
       externalLink: 'https://www.metmuseum.org/about-the-met/collection-areas/drawings-and-prints/materials-and-techniques/printmaking/screenprint#:~:text=Screenprinting%20is%20a%20process%20where,through%20forms%20the%20printed%20image.'
     },
     {
+      id: "4986286",
+      typeHandle: "internalServiceOrResource",
+      contentLink: [
+        {
+          id: "4981833",
+          uri: "https:/www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2",
+          slug: "water-polo",
+          title: "Water Polo - ( Internal Content External Article )",
+          summary: "<p><strong><strong><strong>Internal Content</strong> - External Article </strong></strong> A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>",
+          externalResourceUrl: "https://www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2/"
+        }
+      ]
+    },
+    {
       id: '2870799',
       typeHandle: 'externalServiceOrResource',
       title: 'Flexography (External Content)',
@@ -101,19 +115,19 @@ export const mockFourCards = {
         }
       ]
     },
-    {
-      id: '2881043',
-      typeHandle: 'internalServiceOrResource',
-      contentLink: [
-        {
-          id: '9254',
-          uri: 'visit/events-exhibitions/three-dimensional-printing',
-          slug: 'three-dimensional-printing',
-          title: 'TEST - Three Dimensional Printing',
-          summary: '<p><b>3D printing</b><span> or </span><b>additive manufacturing</b><span> is the </span><a href=\"https://en.wikipedia.org/wiki/Manufacturing\" title=\"Manufacturing\">construction</a><span> of a </span><a href=\"https://en.wikipedia.org/wiki/Three-dimensional_object\" class=\"mw-redirect\" title=\"Three-dimensional object\">three-dimensional object</a><span> from a </span><a href=\"https://en.wikipedia.org/wiki/Computer-aided_design\" title=\"Computer-aided design\">CAD</a><span> model or a digital </span><a href=\"https://en.wikipedia.org/wiki/3D_modeling\" title=\"3D modeling\">3D model</a><span>.</span></p>'
-        }
-      ]
-    },
+    // {
+    //   id: '2881043',
+    //   typeHandle: 'internalServiceOrResource',
+    //   contentLink: [
+    //     {
+    //       id: '9254',
+    //       uri: 'visit/events-exhibitions/three-dimensional-printing',
+    //       slug: 'three-dimensional-printing',
+    //       title: 'TEST - Three Dimensional Printing',
+    //       summary: '<p><b>3D printing</b><span> or </span><b>additive manufacturing</b><span> is the </span><a href=\"https://en.wikipedia.org/wiki/Manufacturing\" title=\"Manufacturing\">construction</a><span> of a </span><a href=\"https://en.wikipedia.org/wiki/Three-dimensional_object\" class=\"mw-redirect\" title=\"Three-dimensional object\">three-dimensional object</a><span> from a </span><a href=\"https://en.wikipedia.org/wiki/Computer-aided_design\" title=\"Computer-aided design\">CAD</a><span> model or a digital </span><a href=\"https://en.wikipedia.org/wiki/3D_modeling\" title=\"3D modeling\">3D model</a><span>.</span></p>'
+    //     }
+    //   ]
+    // },
     // TODO Event - eventDetail == title & eventDescription == summary
     // {
     //   id: "2870995",


### PR DESCRIPTION
#### Connected to [LADI-5240](https://jira.library.ucla.edu/browse/LADI-5240)

#### Storybook Links
1. [FPB BannerFeatured](https://deploy-preview-958--ucla-library-storybook.netlify.app/?path=/story/flexible-banner-featured--internal-content-external-article)
2. [FPB Highlight](https://deploy-preview-958--ucla-library-storybook.netlify.app/?path=/story/flexible-highlight--internal-content-article-and-external-article)
3. [FPB CardWithImage](https://deploy-preview-958--ucla-library-storybook.netlify.app/?path=/story/flexible-card-with-image--internal-article)
4. [FPB GridGalleryCards](https://deploy-preview-958--ucla-library-storybook.netlify.app/?path=/story/flexible-grid-gallery-cards--internal-content-article-external-article-and-external-content)
5. [FPB SimpleCards](https://deploy-preview-958--ucla-library-storybook.netlify.app/?path=/story/flexible-simple-cards--four-cards)


<img width="1179" height="636" alt="Screenshot 2026-07-13 at 5 11 05 PM" src="https://github.com/user-attachments/assets/8b9acf47-9f65-4a0c-8fcb-b5f049040b43" />
<img width="1194" height="642" alt="Screenshot 2026-07-13 at 5 09 44 PM" src="https://github.com/user-attachments/assets/895fdeed-209e-4903-8ece-482cc3f21d7f" />

---

### Notes

Updates FPB components to use the Internal Content - External Article with the correct Eternal Link

1. `lib-components/Flexible/BannerFeatured.vue`
    1. Add `externalArticle` to the component
    2. Add the external link for the InternalContent External Article by 
    adding a computed property `parsedLink`  
    `parsedLink` figures out what URL to use depending on what kind of content it receive
        + Is it internalContent?
            + └── Yes:
            + Is it externalArticle?
                + └── Yes → return raw external URL
                + └── No  → strip + return internal URL
        + Is it standalone external content?
              + └── Yes → return raw external URL
        + Else → return empty string
2. `stories/Flexible_BannerFeatured.stories.js`
    1. Add a test for Internal Content - ExternalArticle
3. `lib-components/Flexible/Highlight.vue`
    1. Add `externalArticle` to the component
    2. Add the external link for the InternalContent External Article
4. `stories/Flexible_Highlight.stories.js`
    1. Add a test for every type of data the component can receive
5. `stories/mock/Flexible_Highlight.js`
    1. Add data for new tests
7.  `stories/Flexible_CardWithImage.stories.js`
    1. Add a test for Internal Content - ExternalArticle
8. `stories/mock/Flexible_CardWithImage.js`
    1. Add data for new tests
9. `lib-components/Flexible_GridGalleryCards.vue`
    1. Add `externalArticle` to the component
    2. Add the external link for the InternalContent External Article in the `flattenTimeLineStructure` function
10. `stories/Flexible_GridGalleryCards.stories.js`
    1. Add a test for Internal Content - ExternalArticle
11. `lib-components/Flexible/SimpleCards.vue`
    1. Add `externalArticle` to the component
    2. Add the external link for the InternalContent External Article in
12. `stories/Flexible_SimpleCards.stories.js`
    1. Add a test for Internal Content - ExternalArticle

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - [x] Review PR in desktop view, tablet view, mobile view
- [x] A11Y
    - [x] Zoom the site to 200%
    - [x] Check for keyboard traps
- [x] Design & Code
    - [x] Add updates to Storybook and check them
    - [x] Check that it looks like the design(s)
    - [ ] Check that it is working in the local website nuxt dev server
    - [x] Review the Chromatic _(if the PR is large and requires it)_

### UX Review
- [x] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the Storybook preview
  - [ ] Review the code


[LADI-5240]: https://uclalibrary.atlassian.net/browse/LADI-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ