### PR TITLE
fix: LADI-5196b Update SectionLocationList mock API call

### DIFF
--- a/packages/vue-component-library/src/stories/SectionLocationList.stories.js
+++ b/packages/vue-component-library/src/stories/SectionLocationList.stories.js
@@ -1,3 +1,5 @@
+import { onUnmounted } from 'vue'
+
 // Import mock api data
 import * as API from '@/stories/mock-api.json'
 
@@ -109,16 +111,18 @@ export function Default() {
       const originalFetch = globalThis.fetch
 
       // Use mock/fixed hours for UCLA Library locations only
-      if (mock.some(({ isUclaLibrary }) => isUclaLibrary)) {
-        globalThis.fetch = async () => {
-          globalThis.fetch = originalFetch // Restore original fetch
+      const useMock = mock.some(({ isUclaLibrary }) => isUclaLibrary)
 
-          return {
+      if (useMock) {
+          globalThis.fetch = async () => ({
             ok: true,
             json: async () => mockHoursResponse,
-          }
+          })
         }
-      }
+
+        onUnmounted(() => {
+          globalThis.fetch = originalFetch
+        })
     },
     data() {
       return { items: mock }

--- a/packages/vue-component-library/src/stories/SectionLocationList.stories.js
+++ b/packages/vue-component-library/src/stories/SectionLocationList.stories.js
@@ -114,15 +114,15 @@ export function Default() {
       const useMock = mock.some(({ isUclaLibrary }) => isUclaLibrary)
 
       if (useMock) {
-          globalThis.fetch = async () => ({
-            ok: true,
-            json: async () => mockHoursResponse,
-          })
-        }
-
-        onUnmounted(() => {
-          globalThis.fetch = originalFetch
+        globalThis.fetch = async () => ({
+          ok: true,
+          json: async () => mockHoursResponse,
         })
+      }
+
+      onUnmounted(() => {
+        globalThis.fetch = originalFetch
+      })
     },
     data() {
       return { items: mock }


### PR DESCRIPTION
#### Connected to [LADI-5196](https://jira.library.ucla.edu/browse/LADI-5196)

#### Related to [PR-959](https://github.com/UCLALibrary/ucla-library-website-components/pull/959)

#### Deploy Preview

- Before: https://deploy-preview-959--ucla-library-storybook.netlify.app/?path=/story/section-location-list--default

- After: https://deploy-preview-960--ucla-library-storybook.netlify.app/?path=/story/section-location-list--default

### Notes

- Updated logic for mock fetch call 
- Previous implementation only mocked the first fetch call (Biomed) and restored fetch for subsequent libraries
  - In the **before** deploy link, compare Biomed Library and Art Library hours
- For the default story, all calls (for each library) should be mocked
  - In the **after** deploy link, both libraries have the same mocked hours

---

## Checklist

### Author
- [x] Design & Code
    - [x] Add updates to Storybook and check them
   
### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the Storybook preview
  - [ ] Review the code


[LADI-5196]: https://uclalibrary.atlassian.net/browse/LADI-5196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PR-959]: https://uclalibrary.atlassian.net/browse/PR-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ