### PR TITLE
fix: LADI-5261 add styles to prevent space on library site and meap

### DIFF
--- a/packages/vue-component-library/src/styles/default/_rich-text.scss
+++ b/packages/vue-component-library/src/styles/default/_rich-text.scss
@@ -77,7 +77,7 @@
 
   :deep(figure) {
     width: 100%;
-    margin: var(--space-s);
+    margin: var(--space-s); // this is the default behavior but we will make an exception for videos below
     display: flex;
     flex-direction: column;
 
@@ -270,5 +270,13 @@
       --spacing-text-left: 24px;
       --container-width: 100%;
     }
+  }
+}
+
+// We only want this style for the library & meap sites, not as a base for all default themes
+.rich-text:not(.ftva, .dlc) {
+  :deep(figure):has(iframe) {
+    // only for iframes (used for video youtube embeds)
+    margin: 0;
   }
 }


### PR DESCRIPTION
#### Connected to [LADI-5261](https://jira.library.ucla.edu/browse/LADI-5261)

#### Deployed on [https://deploy-preview-961--ucla-library-storybook.netlify.app/?path=/story/flexible-rich-text--default](https://deploy-preview-961--ucla-library-storybook.netlify.app/?path=/story/flexible-rich-text--default)

---

### Notes

Images shouldn't be impacted. ALL IFRAMES will be impacted by this, because youtube videos use `<iframe>` tags not `<video>` tags and we cannot target based on the title as its dynamic in production

Before:
https://ucla-library-storybook.netlify.app/?path=/story/flexible-rich-text--default

After: 
https://deploy-preview-961--ucla-library-storybook.netlify.app/?path=/story/flexible-rich-text--default


---

## Checklist

### Author
- [X] Browsers
    - [X] Review PR in Chrome, Firefox, Safari, Edge
    - [X] Review PR in desktop view, tablet view, mobile view
- [X] A11Y
    - [X] Zoom the site to 200%
    - [X] Check for keyboard traps
- [X] Design & Code
    - [X] Add updates to Storybook and check them
    - [X] Check that it looks like the design(s)
    - [X] Check that it is working in the local website nuxt dev server
    - ~~[ ] Review the Chromatic _(if the PR is large and requires it)_~~

### UX Review
- [X] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the Storybook preview
  - [ ] Review the code


[LADI-5261]: https://uclalibrary.atlassian.net/browse/LADI-5261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ