### PR TITLE
fix: LADI-5283 broken release and improve Nuxt module build and development workflow

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -33,12 +33,12 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24.16.0
           registry-url: "https://registry.npmjs.org/"
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          run_install: false
       - name: Install dependencies
         run: pnpm install
       - name: Install semantic-release extra plugins

--- a/packages/component-library-nuxt-module/README.md
+++ b/packages/component-library-nuxt-module/README.md
@@ -1,80 +1,203 @@
-<!--
-Get your module up and running quickly.
+# UCLA Library Component Library Nuxt Module
 
-Find and replace all on all files (CMD+SHIFT+F):
-- Name: My Module
-- Package name: my-module
-- Description: My new Nuxt module
--->
+This package exposes the UCLA Library Vue Component Library as a Nuxt module. It automatically registers all exported Vue components and injects the shared component library stylesheet into a Nuxt application.
 
-# Nuxt Module
+## Package Layout
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![License][license-src]][license-href]
-[![Nuxt][nuxt-src]][nuxt-href]
-
-My new Nuxt module for doing amazing things.
-
-- [✨ &nbsp;Release Notes](/CHANGELOG.md)
-  <!-- - [🏀 Online playground](https://stackblitz.com/github/your-org/my-module?file=playground%2Fapp.vue) -->
-  <!-- - [📖 &nbsp;Documentation](https://example.com) -->
-
-## Features
-
-<!-- Highlight some of the features your module provide here -->
-
-- ⛰ Auto import vue component library
-
-## Quick Setup
-
-Install the module to your Nuxt application with one command:
-
-```bash
-npx nuxi module add @apps-monorepo-poc/nuxt-module
+```
+packages/
+├── vue-component-library/          # Vue component library
+└── component-library-nuxt-module/
+    ├── src/                        # Nuxt module source
+    ├── playground/                 # Manual development application
+    └── test/fixtures/              # Automated test applications
 ```
 
-That's it! You can now use Nuxt Module in your Nuxt app ✨
+---
 
-## Contribution
+# Prerequisites
 
-<details>
-  <summary>Local development</summary>
-  
-  ```bash
-  
-  # Install dependencies
-  pnpm install
-  
-  # Generate type stubs
-  pnpm run dev:prepare
-  
-  # Develop with the playground
-  pnpm run dev
-  
-  # Build the playground
-  pnpm run dev:build
-  
-  # Run ESLint
-  pnpm run lint
-  
-  # Run Vitest
-  pnpm run test
-  pnpm run test:watch
-  
-  # Release new version (Github action handles this)
-  pnpm relaase && pnpm publish
-  ```
+Install dependencies from the monorepo root.
 
-</details>
+```bash
+pnpm install
+```
 
-<!-- Badges -->
+---
 
-[npm-version-src]: https://img.shields.io/npm/v/my-module/latest.svg?style=flat&colorA=020420&colorB=00DC82
-[npm-version-href]: https://npmjs.com/package/my-module
-[npm-downloads-src]: https://img.shields.io/npm/dm/my-module.svg?style=flat&colorA=020420&colorB=00DC82
-[npm-downloads-href]: https://npm.chart.dev/my-module
-[license-src]: https://img.shields.io/npm/l/my-module.svg?style=flat&colorA=020420&colorB=00DC82
-[license-href]: https://npmjs.com/package/my-module
-[nuxt-src]: https://img.shields.io/badge/Nuxt-020420?logo=nuxt.js
-[nuxt-href]: https://nuxt.com
+# Development Workflow
+
+This package depends on the Vue component library package.
+
+Whenever you make changes to the Vue component library, rebuild the workspace first.
+
+From the **monorepo root**:
+
+```bash
+pnpm run build
+```
+
+This builds:
+
+- `packages/vue-component-library`
+- `packages/component-library-nuxt-module`
+
+and refreshes the workspace links between both packages.
+
+---
+
+# Running the Playground
+
+The playground is a real Nuxt application used for manual development.
+
+Start it from the **monorepo root**:
+
+```bash
+pnpm run nuxt-module:prepare
+pnpm run nuxt-module:dev
+```
+
+Normally you only need to run `nuxt-module:prepare` after:
+
+- installing dependencies
+- changing Nuxt configuration
+- deleting `.nuxt`
+
+During normal development you can usually just run:
+
+```bash
+pnpm run nuxt-module:dev
+```
+
+---
+
+# Building the Playground
+
+To verify that the playground builds successfully as a production Nuxt application:
+
+```bash
+pnpm --filter @ucla-library/component-library-nuxt-module run dev:build
+```
+
+Use this before opening a PR or when investigating production-only issues.
+
+This is **not** part of the normal development workflow.
+
+---
+
+# Building the Module
+
+To build the publishable Nuxt module:
+
+```bash
+pnpm run nuxt-module:build
+```
+
+This runs the module's `prepack` script and produces the distributable package in:
+
+```
+packages/component-library-nuxt-module/dist/
+```
+
+Normally you only run this when verifying the package before publishing.
+
+---
+
+# Testing
+
+There are two ways to test the module.
+
+## Playground
+
+The playground is intended for manual testing.
+
+Use it to verify:
+
+- components auto-import correctly
+- CSS is loaded
+- components render correctly
+- module configuration behaves correctly
+- browser behaviour
+
+The playground loads the module from source:
+
+```ts
+modules: ["@radya/nuxt-dompurify", "../src/module"];
+```
+
+---
+
+## Test Fixtures
+
+The fixtures are used by `@nuxt/test-utils`.
+
+Unlike the playground, they create a minimal Nuxt application specifically for automated tests.
+
+Example:
+
+```ts
+import MyModule from "../../../src/module";
+
+export default defineNuxtConfig({
+  modules: [MyModule],
+});
+```
+
+Use fixtures for:
+
+- integration tests
+- automated testing
+- module installation tests
+
+---
+
+# Common Commands
+
+Run all commands from the **monorepo root**.
+
+| Task                 | Command                                                                    |
+| -------------------- | -------------------------------------------------------------------------- |
+| Install dependencies | `pnpm install`                                                             |
+| Build workspace      | `pnpm run build`                                                           |
+| Prepare playground   | `pnpm run nuxt-module:prepare`                                             |
+| Start playground     | `pnpm run nuxt-module:dev`                                                 |
+| Build module         | `pnpm run nuxt-module:build`                                               |
+| Run tests            | `pnpm --filter @ucla-library/component-library-nuxt-module run test`       |
+| Type check           | `pnpm --filter @ucla-library/component-library-nuxt-module run test:types` |
+
+---
+
+# Gotchas
+
+## Always build the workspace first
+
+If you modify the Vue component library, run:
+
+```bash
+pnpm run build
+```
+
+before testing the Nuxt module.
+
+The module depends on the built output of the Vue component library.
+
+---
+
+## Playground vs Test Fixtures
+
+These are different environments.
+
+| Playground            | Test Fixtures            |
+| --------------------- | ------------------------ |
+| Manual development    | Automated tests          |
+| Browser testing       | Integration testing      |
+| Full Nuxt application | Minimal Nuxt application |
+| Interactive           | Non-interactive          |
+
+---
+
+## Publishing
+
+Publishing is handled by GitHub Actions.
+
+During publishing, `pnpm publish` automatically runs the module's `prepack` script to build the distributable package before it is published.

--- a/packages/component-library-nuxt-module/package.json
+++ b/packages/component-library-nuxt-module/package.json
@@ -30,7 +30,7 @@
     "prepack": "nuxt build-module --build --prepare",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
-    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare && nuxi dev playground",
+    "dev:prepare": "nuxt prepare playground",
     "build": "pnpm run dev:prepare",
     "release": "semantic-release",
     "lint": "eslint .",

--- a/packages/component-library-nuxt-module/playground/app.vue
+++ b/packages/component-library-nuxt-module/playground/app.vue
@@ -23,7 +23,8 @@
   </div>
 
   <div>
-    <h2> BannerHeader
+    <h2>
+      BannerHeader
     </h2>
     <BannerHeader
       :start-date="MOCK.mockdata.startDate"

--- a/packages/component-library-nuxt-module/playground/app.vue
+++ b/packages/component-library-nuxt-module/playground/app.vue
@@ -21,9 +21,13 @@
     <hr>
     <br>
   </div>
+
   <div>
-    <h2> BannerFeatured component</h2>
-    <BannerFeatured
+    <h2> BannerHeader
+    </h2>
+    <BannerHeader
+      :start-date="MOCK.mockdata.startDate"
+      :end-date="MOCK.mockdata.endDate"
       :media="MOCK.mockdata.image"
       :to="MOCK.mockdata.toHelp"
       :title="MOCK.mockdata.title"

--- a/packages/component-library-nuxt-module/tsconfig.json
+++ b/packages/component-library-nuxt-module/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./.nuxt/tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "nodenext",
     "module": "NodeNext",

--- a/packages/vue-component-library/src/stories/mock/Flexible_SimpleCards.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_SimpleCards.js
@@ -82,16 +82,16 @@ export const mockFourCards = {
       externalLink: 'https://www.metmuseum.org/about-the-met/collection-areas/drawings-and-prints/materials-and-techniques/printmaking/screenprint#:~:text=Screenprinting%20is%20a%20process%20where,through%20forms%20the%20printed%20image.'
     },
     {
-      id: "4986286",
-      typeHandle: "internalServiceOrResource",
+      id: '4986286',
+      typeHandle: 'internalServiceOrResource',
       contentLink: [
         {
-          id: "4981833",
-          uri: "https:/www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2",
-          slug: "water-polo",
-          title: "Water Polo - ( Internal Content External Article )",
-          summary: "<p><strong><strong><strong>Internal Content</strong> - External Article </strong></strong> A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>",
-          externalResourceUrl: "https://www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2/"
+          id: '4981833',
+          uri: 'https:/www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2',
+          slug: 'water-polo',
+          title: 'Water Polo - ( Internal Content External Article )',
+          summary: '<p><strong><strong><strong>Internal Content</strong> - External Article </strong></strong> A highly competitive, fast-paced aquatic sport that builds elite endurance, speed, and teamwork.</p>',
+          externalResourceUrl: 'https://www.the562.org/2022/11/17/girls-water-polo-preview-long-beach-poly-jackrabbits-2/'
         }
       ]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "baseUrl": "."
+  },
+  "exclude": ["node_modules", "dist", "**/.nuxt"]
+}


### PR DESCRIPTION
#### Connected to [LADI-5283](https://jira.library.ucla.edu/browse/LADI-5283)

#### Deployed on https://deploy-preview-962--ucla-library-storybook.netlify.app/

# Summary

This PR updates the Nuxt module development and build workflow following the pnpm 11 migration.

While upgrading the workspace, the Nuxt module build began failing locally due to changes in the module build command and the way generated Nuxt files were resolved. This PR stabilizes the build process, updates the release workflow for the pinned pnpm version, documents the expected workflows, and clarifies the different development and testing environments used by the module.

---

# Changes

## Build Configuration

- Fixed the Nuxt module build configuration so it no longer relies on generated Nuxt files during package builds.
- Updated the module build workflow to use the current Nuxt module build command.
- Verified that the module can be packaged successfully using the `prepack` script.

## Release Workflow

Updated the GitHub Actions release workflow to align with the repository's pinned package manager version.

Changes include:

- Removed the explicit pnpm 9 installation from the publishing workflow.
- Updated the workflow to use the repository's pinned pnpm version (`11.5.1`) defined in `packageManager`.
- Resolved release failures caused by multiple pnpm versions being used during the same workflow, which resulted in pnpm version mismatch errors during publishing.

## Development Workflow

Documented the recommended local development workflow for working within the monorepo.

This includes:

- installing dependencies
- building the workspace
- preparing the Nuxt playground
- running the playground
- building the module for publishing

The documentation now clearly explains which commands should be run from the **monorepo root**.

## Playground

Documented the purpose of the playground application.

The playground is intended for:

- manual development
- browser testing
- validating component auto-registration
- verifying stylesheet injection
- testing module configuration

Updated the playground example component to use `BannerHeader` instead of `BannerFeatured`.

`BannerFeatured` currently relies on Vue's `useId()` composable, which is not available in the Vue version used by the Nuxt playground. Replacing it with `BannerHeader` allows the playground to be used for manual testing while the workspace remains on the current Nuxt 3 / Vue runtime.

This is a temporary compatibility workaround until the workspace is upgraded to a Vue version that supports `useId()`.

## Test Fixtures

Documented the difference between the playground and the test fixtures.

The fixtures are used for automated testing with `@nuxt/test-utils` and create isolated Nuxt applications specifically for integration testing.

## Documentation

Added a README for the Nuxt module package covering:

- package overview
- development workflow
- build workflow
- publishing workflow
- playground usage
- automated testing
- available scripts
- common commands
- common gotchas

---

# Verification

The following workflows were verified:

- ✅ Workspace builds successfully
- ✅ Vue component library builds successfully
- ✅ Nuxt module packages successfully
- ✅ Playground can be started for local development

---

# Developer Workflow

From the monorepo root:

```bash
pnpm install

pnpm run build

pnpm run nuxt-module:prepare

pnpm run nuxt-module:dev
```

For production verification:

```bash
pnpm run nuxt-module:build
```

---

# Notes

This PR focuses on improving the Nuxt module developer experience, stabilizing the build and release workflows after the pnpm 11 migration, and documenting the expected development workflows. No functional changes were made to the module API or to the component registration behavior.


### Next Steps:
Upgrade nuxt module to use Nuxt 4

[LADI-5283]: https://uclalibrary.atlassian.net/browse/LADI-5283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ