### PR TITLE
fix: LADI-5307 make sure list array exists and has items before rendering the ul

### DIFF
--- a/packages/vue-component-library/src/lib-components/FooterPrimary.vue
+++ b/packages/vue-component-library/src/lib-components/FooterPrimary.vue
@@ -179,7 +179,7 @@ function formatTarget(target: string) {
         </ul>
 
         <ul
-          v-if="parsedPressItems"
+          v-if="parsedPressItems && parsedPressItems.length > 0"
           class="press-links"
         >
           <li


### PR DESCRIPTION
#### Connected to [LADI-5307](https://jira.library.ucla.edu/browse/LADI-5307)

#### Deployed on https://deploy-preview-965--ucla-library-storybook.netlify.app/

---

### Notes

There are no visual changes but we are now checking that the list in the footer has items before rendering it. This prevents empty list errors on accessibility audits.

before
https://deploy-preview-964--ucla-library-storybook.netlify.app/?path=/story/footer-primary--default

after
https://deploy-preview-965--ucla-library-storybook.netlify.app/?path=/story/footer-primary--default

---

## Checklist

### Author
- [X] Browsers
    - [X] Review PR in Chrome, Firefox, Safari, Edge
    - [X] Review PR in desktop view, tablet view, mobile view
- [X] A11Y
    - [X] Zoom the site to 200%
    - [X] Check for keyboard traps
- [X] Design & Code
    - [X] Add updates to Storybook and check them
    - [X] Check that it looks like the design(s)
    - ~~[ ] Check that it is working in the local website nuxt dev server~~
    - ~~[ ] Review the Chromatic _(if the PR is large and requires it)_~~

### UX Review
- ~~[ ] UX has reviewed and approved~~ (nothing visual to approve)

### Dev Review
  - [ ] Review Chromatic
  - [x] Review the Storybook preview
  - [x] Review the code


[LADI-5307]: https://uclalibrary.atlassian.net/browse/LADI-5307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ