### PR TITLE
feat: LADI-5240-3_add-external-article-entry-type

### DIFF
--- a/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
@@ -134,7 +134,6 @@ const parsedItems = computed(() => {
         && (
           obj.contentType === 'exhibition'
           || obj.contentType === 'workshopOrEventSeries'
-          || obj.contentType === 'endowment'
         )
       ) {
         return {
@@ -176,6 +175,13 @@ const parsedItems = computed(() => {
             undefined
           ),
           to: stripMeapFromURI(obj.to),
+          locations: _get(
+            obj,
+            'associatedLocations',
+            undefined
+          ),
+          startDate: _get(obj, 'startDate', ''),
+          endDate: _get(obj, 'endDate', ''),
         }
       }
     })

--- a/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
+++ b/packages/vue-component-library/src/lib-components/Flexible/Highlight.vue
@@ -134,6 +134,7 @@ const parsedItems = computed(() => {
         && (
           obj.contentType === 'exhibition'
           || obj.contentType === 'workshopOrEventSeries'
+          || obj.contentType === 'endowment'
         )
       ) {
         return {

--- a/packages/vue-component-library/src/stories/Flexible_Highlight.stories.js
+++ b/packages/vue-component-library/src/stories/Flexible_Highlight.stories.js
@@ -1,4 +1,4 @@
-import { mockExternalContent, mockInternalContentArticleAndExternalArticle, mockInternalContentEndowmentAndCollectionAndGeneralContentPage, mockInternalContentEventAndExhibition, mockInternalContentWorshopSeriesAndEventSeries } from './mock/Flexible_Highlight'
+import { mockExternalContent, mockInternalContentArticleAndExternalArticle, mockInternalContentEndowmentAndCollectionAndGeneralContentPage, mockInternalContentEventAndExhibition, mockInternalContentWorkshopSeriesAndEventSeries } from './mock/Flexible_Highlight'
 import FlexibleHighlight from '@/lib-components/Flexible/Highlight'
 
 export default {
@@ -22,11 +22,11 @@ export function Default() {
   }
 }
 
-export function InternalContentWorshopSeriesAndEventSeries() {
+export function InternalContentWorkshopSeriesAndEventSeries() {
   return {
     data() {
       return {
-        block: mockInternalContentWorshopSeriesAndEventSeries,
+        block: mockInternalContentWorkshopSeriesAndEventSeries,
       }
     },
     components: { FlexibleHighlight },

--- a/packages/vue-component-library/src/stories/mock/Flexible_Highlight.js
+++ b/packages/vue-component-library/src/stories/mock/Flexible_Highlight.js
@@ -86,10 +86,10 @@ export const mockInternalContentEventAndExhibition = {
   ]
 }
 
-export const mockInternalContentWorshopSeriesAndEventSeries = {
+export const mockInternalContentWorkshopSeriesAndEventSeries = {
   id: '4988975',
   typeHandle: 'highlight',
-  sectionTitle: 'Highlight with Internal Content - Worshop Series & Event Series',
+  sectionTitle: 'Highlight with Internal Content - Workshop Series & Event Series',
   sectionSummary: null,
   highlight: [
     {
@@ -339,7 +339,7 @@ export const mockInternalContentEndowmentAndCollectionAndGeneralContentPage = {
           id: '796386',
           contentType: 'collection',
           to: 'collections/explore/spools',
-          title: 'Spools are so interesting',
+          title: 'Spool Collections are so interesting',
           text: '<p>A cylindrical device on which film, magnetic tape, thread, or other flexible materials can be wound; a reel.</p>',
           articleByline2: '2023-02-03T01:08:00-08:00',
           heroImage: [
@@ -372,7 +372,7 @@ export const mockInternalContentEndowmentAndCollectionAndGeneralContentPage = {
           id: '6333',
           contentType: 'generalContentPage',
           to: 'get-help',
-          title: 'Get Help',
+          title: 'Get Help - General Content Page',
           text: null,
           articleByline2: '2022-03-01T09:56:00-08:00',
           heroImage: []


### PR DESCRIPTION
#### Connected to [LADI-5240](https://jira.library.ucla.edu/browse/LADI-5240)

#### Deployed on https://deploy-preview-968--ucla-library-storybook.netlify.app/?path=/story/flexible-highlight--internal-content-endowment-and-collection-and-general-content-page

---

### Notes

Endowment location element was missing in the Flex/Highlight component.

**Before**
<img width="398" height="522" alt="Screenshot 2026-07-31 at 4 13 41 PM" src="https://github.com/user-attachments/assets/52d395f8-5630-410d-8d77-dc9b1491057d" />

**After**
<img width="406" height="528" alt="Screenshot 2026-07-29 at 9 50 10 AM" src="https://github.com/user-attachments/assets/81be7d47-6be5-4ba7-abdc-ecbf143cd8cf" />

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - [x] Review PR in desktop view, tablet view, mobile view
- [x] A11Y
    - [x] Zoom the site to 200%
    - [x] Check for keyboard traps
- [x] Design & Code
    - [x] Add updates to Storybook and check them
    - [x] Check that it looks like the design(s)
    - [x] Check that it is working in the local website nuxt dev server

### UX Review
- [ ] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the Storybook preview
  - [ ] Review the code


[LADI-5240]: https://uclalibrary.atlassian.net/browse/LADI-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ