### PR TITLE
fix: LADI-5320 force header height

### DIFF
--- a/packages/vue-component-library/src/styles/ftva/_header-sticky.scss
+++ b/packages/vue-component-library/src/styles/ftva/_header-sticky.scss
@@ -2,6 +2,7 @@
 .ftva.header-sticky {
     background-color: ftvatokens.$navy-blue;
     border-bottom: 1px solid var(--ftva-medium-blue);
+    height: 64px;
 
     .primary {
         width: 100%;

--- a/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
+++ b/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
@@ -45,7 +45,7 @@
         .slot-container {
             display: block;
             position: absolute;
-            // margin-top: 64px; // offset height of the header
+            margin-top: 64px; // offset height of the header
             width: 100%;
             background-color: ftvatokens.$navy-blue;
             transform: scaleY(0);
@@ -204,7 +204,7 @@
 
             .slot-container {
                 transition-duration: 0s; // no transition on mobile
-
+                margin-top: 0px; // header height does not need to be offset on mobile
                 :deep(.nav-search) {
                     width: unset;
                 }

--- a/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
+++ b/packages/vue-component-library/src/styles/ftva/_nav-primary.scss
@@ -45,7 +45,7 @@
         .slot-container {
             display: block;
             position: absolute;
-            margin-top: 64px; // offset height of the header
+            // margin-top: 64px; // offset height of the header
             width: 100%;
             background-color: ftvatokens.$navy-blue;
             transform: scaleY(0);


### PR DESCRIPTION
#### Connected to [LADI-5320](https://jira.library.ucla.edu/browse/LADI-5320)

#### Deployed on https://deploy-preview-969--ucla-library-storybook.netlify.app/

---

### Notes
I accidentally introduced a regression when I worked on this PR to prevent tab-targetting issues: https://github.com/UCLALibrary/ucla-library-website-components/pull/955

You can see the content behind the header is further down before vs after, and thats because there was a hidden element in the header pushing that content down. Once I stopped the hidden element from rendering (and being tabbed to),  we lost this extra space we were depending on.

 
(before)
https://deploy-preview-954--ucla-library-storybook.netlify.app/?path=/story/global-header-sticky--ftva-sticky
(after)
https://deploy-preview-955--ucla-library-storybook.netlify.app/?path=/story/global-header-sticky--ftva-sticky

and this PR, where its restored:
https://deploy-preview-969--ucla-library-storybook.netlify.app/?path=/story/global-header-sticky--ftva-sticky

I had actually noticed this with the slot content and added extra 64px of top-margin there, but I needed to go a level up and add it to the header itself as well. 

---

## Checklist

### Author
- [X] Browsers
    - [X] Review PR in Chrome, Firefox, Safari, Edge
    - [X] Review PR in desktop view, tablet view, mobile view
- [X] A11Y
    - [X] Zoom the site to 200%
    - [X] Check for keyboard traps
- [X] Design & Code
    - [X] Add updates to Storybook and check them
    - [X] Check that it looks like the design(s)
    - [X] Check that it is working in the local website nuxt dev server
    - ~~[ ] Review the Chromatic _(if the PR is large and requires it)_~~

### UX Review
- [X] UX has reviewed and approved

### Dev Review
  - [x] Review Chromatic
  - [x] Review the Storybook preview
  - [x] Review the code


[LADI-5320]: https://uclalibrary.atlassian.net/browse/LADI-5320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ