### PR TITLE
feat: LADI-5204 No visible keyboard focus indicator on DateFilter button

### DIFF
--- a/packages/vue-component-library/src/lib-components/DateFilter.vue
+++ b/packages/vue-component-library/src/lib-components/DateFilter.vue
@@ -455,7 +455,7 @@ onMounted(() => {
 
   button:focus,
   button:focus-visible {
-    outline: 1px solid ftvatokens.$accent-blue;
+    outline: 2px solid ftvatokens.$accent-blue;
   }
 
   .button-text {
@@ -496,7 +496,7 @@ onMounted(() => {
       &:focus,
       &:focus-visible {
         border-color: #ddd;
-        outline: 1px solid ftvatokens.$accent-blue;
+        outline: 2px solid ftvatokens.$accent-blue;
         outline-offset: -2px;
       }
 
@@ -839,7 +839,7 @@ onMounted(() => {
 
       &:focus,
       &:focus-visible {
-        outline: 1px solid ftvatokens.$accent-blue;
+        outline: 2px solid ftvatokens.$accent-blue;
         outline-offset: -2px;
       }
 

--- a/packages/vue-component-library/src/lib-components/DateFilter.vue
+++ b/packages/vue-component-library/src/lib-components/DateFilter.vue
@@ -455,7 +455,7 @@ onMounted(() => {
 
   button:focus,
   button:focus-visible {
-    outline: 2px solid ftvatokens.$accent-blue;
+    outline: 1px solid ftvatokens.$accent-blue;
   }
 
   .button-text {
@@ -490,16 +490,13 @@ onMounted(() => {
 
       &:hover {
         border-color: #ddd;
+        background-color: #f1f1f1;
       }
 
       &:focus,
       &:focus-visible {
         border-color: #ddd;
         outline: 2px solid ftvatokens.$accent-blue;
-      }
-
-      &:hover {
-        background-color: #f1f1f1;
       }
 
       @media #{$small} {

--- a/packages/vue-component-library/src/lib-components/DateFilter.vue
+++ b/packages/vue-component-library/src/lib-components/DateFilter.vue
@@ -496,7 +496,7 @@ onMounted(() => {
       &:focus,
       &:focus-visible {
         border-color: #ddd;
-        outline: 2px solid ftvatokens.$accent-blue;
+        outline: 1px solid ftvatokens.$accent-blue;
         outline-offset: -2px;
       }
 
@@ -836,7 +836,12 @@ onMounted(() => {
     .mobile-button {
       width: 166px;
       padding: 6px;
-      // border: none;
+
+      &:focus,
+      &:focus-visible {
+        outline: 1px solid ftvatokens.$accent-blue;
+        outline-offset: -2px;
+      }
 
       &:active {
         color: white;

--- a/packages/vue-component-library/src/lib-components/DateFilter.vue
+++ b/packages/vue-component-library/src/lib-components/DateFilter.vue
@@ -456,7 +456,6 @@ onMounted(() => {
   button:focus,
   button:focus-visible {
     outline: 2px solid ftvatokens.$accent-blue;
-    outline-offset: 2px;
   }
 
   .button-text {
@@ -697,8 +696,7 @@ onMounted(() => {
           height: 31px;
           transition: background-color 0.3s ease;
 
-          &:hover,
-          &:focus {
+          &:hover {
             background-color: ftvatokens.$grey-blue;
           }
         }
@@ -787,8 +785,7 @@ onMounted(() => {
           display: none;
         }
 
-        &:hover,
-        &:focus {
+        &:hover {
           background-color: ftvatokens.$navy-blue;
         }
       }
@@ -801,8 +798,7 @@ onMounted(() => {
           stroke: ftvatokens.$accent-blue;
         }
 
-        &:hover,
-        &:focus {
+        &:hover {
           background-color: ftvatokens.$navy-blue;
           color: var(--color-white);
 

--- a/packages/vue-component-library/src/lib-components/DateFilter.vue
+++ b/packages/vue-component-library/src/lib-components/DateFilter.vue
@@ -837,12 +837,6 @@ onMounted(() => {
       width: 166px;
       padding: 6px;
 
-      // &:focus,
-      // &:focus-visible {
-      //   outline: 2px solid ftvatokens.$accent-blue;
-      //   outline-offset: -2px;
-      // }
-
       &:active {
         color: white;
         background-color: ftvatokens.$accent-blue;

--- a/packages/vue-component-library/src/lib-components/DateFilter.vue
+++ b/packages/vue-component-library/src/lib-components/DateFilter.vue
@@ -837,11 +837,11 @@ onMounted(() => {
       width: 166px;
       padding: 6px;
 
-      &:focus,
-      &:focus-visible {
-        outline: 2px solid ftvatokens.$accent-blue;
-        outline-offset: -2px;
-      }
+      // &:focus,
+      // &:focus-visible {
+      //   outline: 2px solid ftvatokens.$accent-blue;
+      //   outline-offset: -2px;
+      // }
 
       &:active {
         color: white;

--- a/packages/vue-component-library/src/lib-components/DateFilter.vue
+++ b/packages/vue-component-library/src/lib-components/DateFilter.vue
@@ -489,9 +489,14 @@ onMounted(() => {
       color: ftvatokens.$medium-grey;
       border-radius: 8px;
 
-      &:hover,
-      &:focus {
+      &:hover {
         border-color: #ddd;
+      }
+
+      &:focus,
+      &:focus-visible {
+        border-color: #ddd;
+        outline: 2px solid ftvatokens.$accent-blue;
       }
 
       &:hover {

--- a/packages/vue-component-library/src/lib-components/DateFilter.vue
+++ b/packages/vue-component-library/src/lib-components/DateFilter.vue
@@ -497,6 +497,7 @@ onMounted(() => {
       &:focus-visible {
         border-color: #ddd;
         outline: 2px solid ftvatokens.$accent-blue;
+        outline-offset: -2px;
       }
 
       @media #{$small} {

--- a/packages/vue-component-library/src/lib-components/DateFilter.vue
+++ b/packages/vue-component-library/src/lib-components/DateFilter.vue
@@ -455,7 +455,8 @@ onMounted(() => {
 
   button:focus,
   button:focus-visible {
-    outline: 1px hidden ftvatokens.$accent-blue;
+    outline: 2px solid ftvatokens.$accent-blue;
+    outline-offset: 2px;
   }
 
   .button-text {
@@ -691,7 +692,8 @@ onMounted(() => {
           height: 31px;
           transition: background-color 0.3s ease;
 
-          &:hover {
+          &:hover,
+          &:focus {
             background-color: ftvatokens.$grey-blue;
           }
         }
@@ -780,7 +782,8 @@ onMounted(() => {
           display: none;
         }
 
-        &:hover {
+        &:hover,
+        &:focus {
           background-color: ftvatokens.$navy-blue;
         }
       }
@@ -793,7 +796,8 @@ onMounted(() => {
           stroke: ftvatokens.$accent-blue;
         }
 
-        &:hover {
+        &:hover,
+        &:focus {
           background-color: ftvatokens.$navy-blue;
           color: var(--color-white);
 


### PR DESCRIPTION
#### Connected to [LADI-5204](https://uclalibrary.atlassian.net/browse/LADI-5204))

#### Deployed on https://deploy-preview-971--ucla-library-storybook.netlify.app/?path=/story/datefilter--default

---

Here I have it linked to the FTVA site:
<img width="1213" height="613" alt="Screenshot 2026-08-07 at 12 06 28 AM" src="https://github.com/user-attachments/assets/5dfe684e-22bf-451a-b6c4-5e265e9f0151" />

---

## Checklist

### Author
- [x] Browsers
    - [x] Review PR in Chrome, Firefox, Safari, Edge
    - [x] Review PR in desktop view, tablet view, mobile view
- [x] A11Y
    - [x] Zoom the site to 200%
    - [x] Check for keyboard traps
- [x] Design & Code
    - [x] Add updates to Storybook and check them
    - [x] Check that it looks like the design(s)
    - [x] Check that it is working in the local website nuxt dev server
    - [ ] ~~Review the Chromatic _(if the PR is large and requires it)_~~

### UX Review
- [ ] UX has reviewed and approved

### Dev Review
  - [ ] Review Chromatic
  - [ ] Review the Storybook preview
  - [ ] Review the code


[LADI-5204]: https://uclalibrary.atlassian.net/browse/LADI-5204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ